### PR TITLE
Fix audio toggle showing for posts whose embedded podcast player can't load

### DIFF
--- a/packages/lesswrong/components/posts/PostsPage/PostsPodcastPlayer.tsx
+++ b/packages/lesswrong/components/posts/PostsPage/PostsPodcastPlayer.tsx
@@ -34,10 +34,13 @@ const PostsPodcastPlayer = ({podcastEpisode, postId, hideIconList = false}: {
   // Embed a reference to the generated-per-episode buzzsprout script, which is
   // responsible for hydrating the player div (with the id
   // `buzzsprout-player-${externalEpisodeId}`).
+  // Note: some legacy episodeLink rows in the database contain HTML-encoded
+  // "&amp;" instead of "&", which Buzzsprout's player endpoint 404s on. Decode
+  // defensively so that the player still works for those rows.
   useEffect(() => {
     const newScript = document.createElement('script');
     newScript.async=true;
-    newScript.src=podcastEpisode.episodeLink;
+    newScript.src=podcastEpisode.episodeLink.replace(/&amp;/g, '&');
     document.head.appendChild(newScript);
     
     return () => {

--- a/packages/lesswrong/server/manualMigrations/resources/curatedPostToBuzzsproutMappings.json
+++ b/packages/lesswrong/server/manualMigrations/resources/curatedPostToBuzzsproutMappings.json
@@ -2,97 +2,97 @@
   "pL4WhsoPJwauRYkeK": {
     "serverTitle": "Moses and the Class Struggle",
     "postId": "pL4WhsoPJwauRYkeK",
-    "episodeLink": "https://www.buzzsprout.com//2037297/11168057-moses-and-the-class-struggle-by-lsusr.js?container_id=buzzsprout-player-11168057&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2037297/11168057-moses-and-the-class-struggle-by-lsusr.js?container_id=buzzsprout-player-11168057&player=small",
     "externalEpisodeId": 11168057
   },
   "T6kzsMDJyKwxLGe3r": {
     "serverTitle": "Benign Boundary Violations",
     "postId": "T6kzsMDJyKwxLGe3r",
-    "episodeLink": "https://www.buzzsprout.com//2037297/11168058-benign-boundary-violations-by-duncan-sabien.js?container_id=buzzsprout-player-11168058&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2037297/11168058-benign-boundary-violations-by-duncan-sabien.js?container_id=buzzsprout-player-11168058&player=small",
     "externalEpisodeId": 11168058
   },
   "keiYkaeoLHoKK4LYA": {
     "serverTitle": "Six Dimensions of Operational Adequacy in AGI Projects",
     "postId": "keiYkaeoLHoKK4LYA",
-    "episodeLink": "https://www.buzzsprout.com//2037297/11168056-six-dimensions-of-operational-adequacy-in-agi-projects-by-eliezer-yudkowsky.js?container_id=buzzsprout-player-11168056&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2037297/11168056-six-dimensions-of-operational-adequacy-in-agi-projects-by-eliezer-yudkowsky.js?container_id=buzzsprout-player-11168056&player=small",
     "externalEpisodeId": 11168056
   },
   "uMQ3cqWDPHhjtiesc": {
     "serverTitle": "AGI Ruin: A List of Lethalities",
     "postId": "uMQ3cqWDPHhjtiesc",
-    "episodeLink": "https://www.buzzsprout.com//2037297/11168059-agi-ruin-a-list-of-lethalities-by-eliezer-yudkowsky.js?container_id=buzzsprout-player-11168059&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2037297/11168059-agi-ruin-a-list-of-lethalities-by-eliezer-yudkowsky.js?container_id=buzzsprout-player-11168059&player=small",
     "externalEpisodeId": 11168059
   },
   "7iAABhWpcGeP5e6SB": {
     "serverTitle": "It’s Probably Not Lithium",
     "postId": "7iAABhWpcGeP5e6SB",
-    "episodeLink": "https://www.buzzsprout.com//2037297/11168052-it-s-probably-not-lithium-by-natalia-coelho-mendonca.js?container_id=buzzsprout-player-11168052&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2037297/11168052-it-s-probably-not-lithium-by-natalia-coelho-mendonca.js?container_id=buzzsprout-player-11168052&player=small",
     "externalEpisodeId": 11168052
   },
   "28zsuPaJpKAGSX4zq": {
     "serverTitle": "Humans are very reliable agents",
     "postId": "28zsuPaJpKAGSX4zq",
-    "episodeLink": "https://www.buzzsprout.com//2037297/11168050-humans-are-very-reliable-agents-by-alyssa-vance.js?container_id=buzzsprout-player-11168050&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2037297/11168050-humans-are-very-reliable-agents-by-alyssa-vance.js?container_id=buzzsprout-player-11168050&player=small",
     "externalEpisodeId": 11168050
   },
   "CoZhXrhpQxpy9xw9y": {
     "serverTitle": "Where I agree and disagree with Eliezer",
     "postId": "CoZhXrhpQxpy9xw9y",
-    "episodeLink": "https://www.buzzsprout.com//2037297/11168055-where-i-agree-and-disagree-with-eliezer-by-paul-christiano.js?container_id=buzzsprout-player-11168055&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2037297/11168055-where-i-agree-and-disagree-with-eliezer-by-paul-christiano.js?container_id=buzzsprout-player-11168055&player=small",
     "externalEpisodeId": 11168055
   },
   "Ke2ogqSEhL2KCJCNx": {
     "serverTitle": "Security Mindset: Lessons from 20+ years of Software Security Failures Relevant to AGI Alignment",
     "postId": "Ke2ogqSEhL2KCJCNx",
-    "episodeLink": "https://www.buzzsprout.com//2037297/11168054-security-mindset-lessons-from-20-years-of-software-security-failures-relevant-to-agi-alignment-by-elspood.js?container_id=buzzsprout-player-11168054&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2037297/11168054-security-mindset-lessons-from-20-years-of-software-security-failures-relevant-to-agi-alignment-by-elspood.js?container_id=buzzsprout-player-11168054&player=small",
     "externalEpisodeId": 11168054
   },
   "bhLxWTkRc8GXunFcB": {
     "serverTitle": "What Are You Tracking In Your Head?",
     "postId": "bhLxWTkRc8GXunFcB",
-    "episodeLink": "https://www.buzzsprout.com//2037297/11168053-what-are-you-tracking-in-your-head-by-john-wentworth.js?container_id=buzzsprout-player-11168053&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2037297/11168053-what-are-you-tracking-in-your-head-by-john-wentworth.js?container_id=buzzsprout-player-11168053&player=small",
     "externalEpisodeId": 11168053
   },
   "2GxhAyn9aHqukap2S": {
     "serverTitle": "Looking back on my alignment PhD",
     "postId": "2GxhAyn9aHqukap2S",
-    "episodeLink": "https://www.buzzsprout.com//2037297/11168051-looking-back-on-my-alignment-phd-by-turntrout.js?container_id=buzzsprout-player-11168051&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2037297/11168051-looking-back-on-my-alignment-phd-by-turntrout.js?container_id=buzzsprout-player-11168051&player=small",
     "externalEpisodeId": 11168051
   },
   "3pinFH3jerMzAvmza": {
     "serverTitle": "On how various plans miss the hard bits of the alignment challenge",
     "postId": "3pinFH3jerMzAvmza",
-    "episodeLink": "https://www.buzzsprout.com//2037297/11168049-on-how-various-plans-miss-the-hard-bits-of-the-alignment-challenge-by-nate-soares.js?container_id=buzzsprout-player-11168049&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2037297/11168049-on-how-various-plans-miss-the-hard-bits-of-the-alignment-challenge-by-nate-soares.js?container_id=buzzsprout-player-11168049&player=small",
     "externalEpisodeId": 11168049
   },
   "MdZyLnLHuaHrCskjy": {
     "serverTitle": "ITT-passing and civility are good; \"charity\" is bad; steelmanning is niche",
     "postId": "MdZyLnLHuaHrCskjy",
-    "episodeLink": "https://www.buzzsprout.com//2037297/11168047-itt-passing-and-civility-are-good-charity-is-bad-steelmanning-is-niche-by-rob-bensinger.js?container_id=buzzsprout-player-11168047&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2037297/11168047-itt-passing-and-civility-are-good-charity-is-bad-steelmanning-is-niche-by-rob-bensinger.js?container_id=buzzsprout-player-11168047&player=small",
     "externalEpisodeId": 11168047
   },
   "mmHctwkKjpvaQdC3c": {
     "serverTitle": "What should you change in response to an \"emergency\"? And AI risk",
     "postId": "mmHctwkKjpvaQdC3c",
-    "episodeLink": "https://www.buzzsprout.com//2037297/11168048-what-should-you-change-in-response-to-an-emergency-and-ai-risk-by-anna-salamon.js?container_id=buzzsprout-player-11168048&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2037297/11168048-what-should-you-change-in-response-to-an-emergency-and-ai-risk-by-anna-salamon.js?container_id=buzzsprout-player-11168048&player=small",
     "externalEpisodeId": 11168048
   },
   "CjFZeDD6iCnNubDoS": {
     "serverTitle": "Humans provide an untapped wealth of evidence about alignment",
     "postId": "CjFZeDD6iCnNubDoS",
-    "episodeLink": "https://www.buzzsprout.com//2037297/11168035-humans-provide-an-untapped-wealth-of-evidence-about-alignment-by-turntrout-quintin-pope.js?container_id=buzzsprout-player-11168035&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2037297/11168035-humans-provide-an-untapped-wealth-of-evidence-about-alignment-by-turntrout-quintin-pope.js?container_id=buzzsprout-player-11168035&player=small",
     "externalEpisodeId": 11168035
   },
   "DdDt5NXkfuxAnAvGJ": {
     "serverTitle": "Changing the world through slack & hobbies",
     "postId": "DdDt5NXkfuxAnAvGJ",
-    "episodeLink": "https://www.buzzsprout.com//2037297/11168036-changing-the-world-through-slack-hobbies-by-steven-byrnes.js?container_id=buzzsprout-player-11168036&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2037297/11168036-changing-the-world-through-slack-hobbies-by-steven-byrnes.js?container_id=buzzsprout-player-11168036&player=small",
     "externalEpisodeId": 11168036
   },
   "8oMF8Lv5jiGaQSFvo": {
     "serverTitle": "«Boundaries», Part 1: a key missing concept from utility theory",
     "postId": "8oMF8Lv5jiGaQSFvo",
-    "episodeLink": "https://www.buzzsprout.com//2037297/11168046-boundaries-part-1-a-key-missing-concept-from-utility-theory-by-andrew-critch.js?container_id=buzzsprout-player-11168046&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2037297/11168046-boundaries-part-1-a-key-missing-concept-from-utility-theory-by-andrew-critch.js?container_id=buzzsprout-player-11168046&player=small",
     "externalEpisodeId": 11168046
   }
 }

--- a/packages/lesswrong/server/manualMigrations/resources/razPostToBuzzsproutMappings.json
+++ b/packages/lesswrong/server/manualMigrations/resources/razPostToBuzzsproutMappings.json
@@ -2,2005 +2,2005 @@
   "ptxnyfLWqRZ98wnYi": {
     "serverTitle": "Biases: An Introduction",
     "postId": "ptxnyfLWqRZ98wnYi",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163442-biases-an-introduction.js?container_id=buzzsprout-player-11163442&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163442-biases-an-introduction.js?container_id=buzzsprout-player-11163442&player=small",
     "externalEpisodeId": 11163442
   },
   "2ftJ38y9SRBCBsCzy": {
     "serverTitle": "Scope Insensitivity",
     "postId": "2ftJ38y9SRBCBsCzy",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163152-scope-insensitivity.js?container_id=buzzsprout-player-11163152&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163152-scope-insensitivity.js?container_id=buzzsprout-player-11163152&player=small",
     "externalEpisodeId": 11163152
   },
   "R8cpqD3NA4rZxRdQ4": {
     "serverTitle": "Availability",
     "postId": "R8cpqD3NA4rZxRdQ4",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163437-availability.js?container_id=buzzsprout-player-11163437&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163437-availability.js?container_id=buzzsprout-player-11163437&player=small",
     "externalEpisodeId": 11163437
   },
   "jnZbHi873v9vcpGpZ": {
     "serverTitle": "What's a Bias?",
     "postId": "jnZbHi873v9vcpGpZ",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163438-what-s-a-bias-again.js?container_id=buzzsprout-player-11163438&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163438-what-s-a-bias-again.js?container_id=buzzsprout-player-11163438&player=small",
     "externalEpisodeId": 11163438
   },
   "Yq6aA4M3JKWaQepPJ": {
     "serverTitle": "Burdensome Details",
     "postId": "Yq6aA4M3JKWaQepPJ",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163436-burdensome-details.js?container_id=buzzsprout-player-11163436&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163436-burdensome-details.js?container_id=buzzsprout-player-11163436&player=small",
     "externalEpisodeId": 11163436
   },
   "RcZCwxFiZzE6X7nsv": {
     "serverTitle": "What Do We Mean By \"Rationality\"?",
     "postId": "RcZCwxFiZzE6X7nsv",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163441-what-do-we-mean-by-rationality.js?container_id=buzzsprout-player-11163441&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163441-what-do-we-mean-by-rationality.js?container_id=buzzsprout-player-11163441&player=small",
     "externalEpisodeId": 11163441
   },
   "CPm5LTwHrvBJCa9h5": {
     "serverTitle": "Planning Fallacy",
     "postId": "CPm5LTwHrvBJCa9h5",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163435-planning-fallacy.js?container_id=buzzsprout-player-11163435&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163435-planning-fallacy.js?container_id=buzzsprout-player-11163435&player=small",
     "externalEpisodeId": 11163435
   },
   "YshRbqZHYFoEMqFAu": {
     "serverTitle": "Why Truth?",
     "postId": "YshRbqZHYFoEMqFAu",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163439-why-truth-and.js?container_id=buzzsprout-player-11163439&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163439-why-truth-and.js?container_id=buzzsprout-player-11163439&player=small",
     "externalEpisodeId": 11163439
   },
   "SqF8cHjJv43mvJJzx": {
     "serverTitle": "Feeling Rational",
     "postId": "SqF8cHjJv43mvJJzx",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163440-feeling-rational.js?container_id=buzzsprout-player-11163440&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163440-feeling-rational.js?container_id=buzzsprout-player-11163440&player=small",
     "externalEpisodeId": 11163440
   },
   "46qnWRSR7L2eyNbMA": {
     "serverTitle": "The Lens That Sees Its Flaws",
     "postId": "46qnWRSR7L2eyNbMA",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163432-the-lens-that-sees-its-flaws.js?container_id=buzzsprout-player-11163432&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163432-the-lens-that-sees-its-flaws.js?container_id=buzzsprout-player-11163432&player=small",
     "externalEpisodeId": 11163432
   },
   "a7n8GdKiAZRX86T5A": {
     "serverTitle": "Making Beliefs Pay Rent (in Anticipated Experiences)",
     "postId": "a7n8GdKiAZRX86T5A",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163431-making-beliefs-pay-rent-in-anticipated-experiences.js?container_id=buzzsprout-player-11163431&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163431-making-beliefs-pay-rent-in-anticipated-experiences.js?container_id=buzzsprout-player-11163431&player=small",
     "externalEpisodeId": 11163431
   },
   "6hfGNLf4Hg5DXqJCF": {
     "serverTitle": "A Fable of Science and Politics",
     "postId": "6hfGNLf4Hg5DXqJCF",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163430-a-fable-of-science-and-politics.js?container_id=buzzsprout-player-11163430&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163430-a-fable-of-science-and-politics.js?container_id=buzzsprout-player-11163430&player=small",
     "externalEpisodeId": 11163430
   },
   "CqyJzDZWvGhhFJ7dY": {
     "serverTitle": "Belief in Belief",
     "postId": "CqyJzDZWvGhhFJ7dY",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163429-belief-in-belief.js?container_id=buzzsprout-player-11163429&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163429-belief-in-belief.js?container_id=buzzsprout-player-11163429&player=small",
     "externalEpisodeId": 11163429
   },
   "fAuWLS7RKWD2npBFR": {
     "serverTitle": "Religion's Claim to be Non-Disprovable",
     "postId": "fAuWLS7RKWD2npBFR",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163426-religion-s-claim-to-be-non-disprovable.js?container_id=buzzsprout-player-11163426&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163426-religion-s-claim-to-be-non-disprovable.js?container_id=buzzsprout-player-11163426&player=small",
     "externalEpisodeId": 11163426
   },
   "RmCjazjupRGcHSm5N": {
     "serverTitle": "Professing and Cheering",
     "postId": "RmCjazjupRGcHSm5N",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163425-professing-and-cheering.js?container_id=buzzsprout-player-11163425&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163425-professing-and-cheering.js?container_id=buzzsprout-player-11163425&player=small",
     "externalEpisodeId": 11163425
   },
   "nYkMLFpx77Rz3uo9c": {
     "serverTitle": "Belief as Attire",
     "postId": "nYkMLFpx77Rz3uo9c",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163424-belief-as-attire.js?container_id=buzzsprout-player-11163424&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163424-belief-as-attire.js?container_id=buzzsprout-player-11163424&player=small",
     "externalEpisodeId": 11163424
   },
   "jeyvzALDbjdjjv5RW": {
     "serverTitle": "Pretending to be Wise",
     "postId": "jeyvzALDbjdjjv5RW",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163427-pretending-to-be-wise.js?container_id=buzzsprout-player-11163427&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163427-pretending-to-be-wise.js?container_id=buzzsprout-player-11163427&player=small",
     "externalEpisodeId": 11163427
   },
   "dLbkrPu5STNCBLRjr": {
     "serverTitle": "Applause Lights",
     "postId": "dLbkrPu5STNCBLRjr",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163423-applause-lights.js?container_id=buzzsprout-player-11163423&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163423-applause-lights.js?container_id=buzzsprout-player-11163423&player=small",
     "externalEpisodeId": 11163423
   },
   "GJ4ZQm7crTzTM6xDW": {
     "serverTitle": "Focus Your Uncertainty",
     "postId": "GJ4ZQm7crTzTM6xDW",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163422-focus-your-uncertainty.js?container_id=buzzsprout-player-11163422&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163422-focus-your-uncertainty.js?container_id=buzzsprout-player-11163422&player=small",
     "externalEpisodeId": 11163422
   },
   "6s3xABaXKPdFwA3FS": {
     "serverTitle": "What is Evidence?",
     "postId": "6s3xABaXKPdFwA3FS",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163421-what-is-evidence.js?container_id=buzzsprout-player-11163421&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163421-what-is-evidence.js?container_id=buzzsprout-player-11163421&player=small",
     "externalEpisodeId": 11163421
   },
   "fhojYBGGiYAFcryHZ": {
     "serverTitle": "Scientific Evidence, Legal Evidence, Rational Evidence",
     "postId": "fhojYBGGiYAFcryHZ",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163420-scientific-evidence-legal-evidence-rational-evidence.js?container_id=buzzsprout-player-11163420&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163420-scientific-evidence-legal-evidence-rational-evidence.js?container_id=buzzsprout-player-11163420&player=small",
     "externalEpisodeId": 11163420
   },
   "nj8JKFoLSMEmD3RGp": {
     "serverTitle": "How Much Evidence Does It Take?",
     "postId": "nj8JKFoLSMEmD3RGp",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163419-how-much-evidence-does-it-take.js?container_id=buzzsprout-player-11163419&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163419-how-much-evidence-does-it-take.js?container_id=buzzsprout-player-11163419&player=small",
     "externalEpisodeId": 11163419
   },
   "MwQRucYo6BZZwjKE7": {
     "serverTitle": "Einstein's Arrogance",
     "postId": "MwQRucYo6BZZwjKE7",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163418-einstein-s-arrogance.js?container_id=buzzsprout-player-11163418&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163418-einstein-s-arrogance.js?container_id=buzzsprout-player-11163418&player=small",
     "externalEpisodeId": 11163418
   },
   "f4txACqDWithRi7hs": {
     "serverTitle": "Occam's Razor",
     "postId": "f4txACqDWithRi7hs",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163417-occam-s-razor.js?container_id=buzzsprout-player-11163417&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163417-occam-s-razor.js?container_id=buzzsprout-player-11163417&player=small",
     "externalEpisodeId": 11163417
   },
   "5JDkW4MYXit2CquLs": {
     "serverTitle": "Your Strength as a Rationalist",
     "postId": "5JDkW4MYXit2CquLs",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163416-your-strength-as-a-rationalist.js?container_id=buzzsprout-player-11163416&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163416-your-strength-as-a-rationalist.js?container_id=buzzsprout-player-11163416&player=small",
     "externalEpisodeId": 11163416
   },
   "mnS2WYLCGJP2kQkRn": {
     "serverTitle": "Absence of Evidence Is Evidence of Absence",
     "postId": "mnS2WYLCGJP2kQkRn",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163415-absence-of-evidence-is-evidence-of-absence.js?container_id=buzzsprout-player-11163415&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163415-absence-of-evidence-is-evidence-of-absence.js?container_id=buzzsprout-player-11163415&player=small",
     "externalEpisodeId": 11163415
   },
   "jiBFC7DcCrZjGmZnJ": {
     "serverTitle": "Conservation of Expected Evidence",
     "postId": "jiBFC7DcCrZjGmZnJ",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163414-conservation-of-expected-evidence.js?container_id=buzzsprout-player-11163414&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163414-conservation-of-expected-evidence.js?container_id=buzzsprout-player-11163414&player=small",
     "externalEpisodeId": 11163414
   },
   "WnheMGAka4fL99eae": {
     "serverTitle": "Hindsight Devalues Science",
     "postId": "WnheMGAka4fL99eae",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163413-hindsight-devalues-science.js?container_id=buzzsprout-player-11163413&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163413-hindsight-devalues-science.js?container_id=buzzsprout-player-11163413&player=small",
     "externalEpisodeId": 11163413
   },
   "sSqoEw9eRP2kPKLCz": {
     "serverTitle": "Illusion of Transparency:  Why No One Understands You",
     "postId": "sSqoEw9eRP2kPKLCz",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163434-illusion-of-transparency-why-no-one-understands-you.js?container_id=buzzsprout-player-11163434&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163434-illusion-of-transparency-why-no-one-understands-you.js?container_id=buzzsprout-player-11163434&player=small",
     "externalEpisodeId": 11163434
   },
   "HLqWn5LASfhhArZ7w": {
     "serverTitle": "Expecting Short Inferential Distances",
     "postId": "HLqWn5LASfhhArZ7w",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163433-expecting-short-inferential-distances.js?container_id=buzzsprout-player-11163433&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163433-expecting-short-inferential-distances.js?container_id=buzzsprout-player-11163433&player=small",
     "externalEpisodeId": 11163433
   },
   "fysgqk4CjAwhBgNYT": {
     "serverTitle": "Fake Explanations",
     "postId": "fysgqk4CjAwhBgNYT",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163412-fake-explanations.js?container_id=buzzsprout-player-11163412&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163412-fake-explanations.js?container_id=buzzsprout-player-11163412&player=small",
     "externalEpisodeId": 11163412
   },
   "NMoLJuDJEms7Ku9XS": {
     "serverTitle": "Guessing the Teacher's Password",
     "postId": "NMoLJuDJEms7Ku9XS",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163411-guessing-the-teacher-s-password.js?container_id=buzzsprout-player-11163411&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163411-guessing-the-teacher-s-password.js?container_id=buzzsprout-player-11163411&player=small",
     "externalEpisodeId": 11163411
   },
   "4Bwr6s9dofvqPWakn": {
     "serverTitle": "Science as Attire",
     "postId": "4Bwr6s9dofvqPWakn",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163410-science-as-attire.js?container_id=buzzsprout-player-11163410&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163410-science-as-attire.js?container_id=buzzsprout-player-11163410&player=small",
     "externalEpisodeId": 11163410
   },
   "RgkqLqkg8vLhsYpfh": {
     "serverTitle": "Fake Causality",
     "postId": "RgkqLqkg8vLhsYpfh",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163409-fake-causality.js?container_id=buzzsprout-player-11163409&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163409-fake-causality.js?container_id=buzzsprout-player-11163409&player=small",
     "externalEpisodeId": 11163409
   },
   "FWMfQKG3RpZx6irjm": {
     "serverTitle": "Semantic Stopsigns",
     "postId": "FWMfQKG3RpZx6irjm",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163408-semantic-stopsigns.js?container_id=buzzsprout-player-11163408&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163408-semantic-stopsigns.js?container_id=buzzsprout-player-11163408&player=small",
     "externalEpisodeId": 11163408
   },
   "6i3zToomS86oj9bS6": {
     "serverTitle": "Mysterious Answers to Mysterious Questions",
     "postId": "6i3zToomS86oj9bS6",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163407-mysterious-answers-to-mysterious-questions.js?container_id=buzzsprout-player-11163407&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163407-mysterious-answers-to-mysterious-questions.js?container_id=buzzsprout-player-11163407&player=small",
     "externalEpisodeId": 11163407
   },
   "8QzZKw9WHRxjR4948": {
     "serverTitle": "The Futility of Emergence",
     "postId": "8QzZKw9WHRxjR4948",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163406-the-futility-of-emergence.js?container_id=buzzsprout-player-11163406&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163406-the-futility-of-emergence.js?container_id=buzzsprout-player-11163406&player=small",
     "externalEpisodeId": 11163406
   },
   "kpRSCH7ALLcb6ucWM": {
     "serverTitle": "Say Not \"Complexity\"",
     "postId": "kpRSCH7ALLcb6ucWM",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163405-say-not-complexity.js?container_id=buzzsprout-player-11163405&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163405-say-not-complexity.js?container_id=buzzsprout-player-11163405&player=small",
     "externalEpisodeId": 11163405
   },
   "rmAbiEKQDpDnZzcRf": {
     "serverTitle": "Positive Bias: Look Into the Dark",
     "postId": "rmAbiEKQDpDnZzcRf",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163404-positive-bias-look-into-the-dark.js?container_id=buzzsprout-player-11163404&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163404-positive-bias-look-into-the-dark.js?container_id=buzzsprout-player-11163404&player=small",
     "externalEpisodeId": 11163404
   },
   "msJA6B9ZjiiZxT6EZ": {
     "serverTitle": "Lawful Uncertainty",
     "postId": "msJA6B9ZjiiZxT6EZ",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163403-lawful-uncertainty.js?container_id=buzzsprout-player-11163403&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163403-lawful-uncertainty.js?container_id=buzzsprout-player-11163403&player=small",
     "externalEpisodeId": 11163403
   },
   "DwtYPRuCxpXTrzG9m": {
     "serverTitle": "My Wild and Reckless Youth",
     "postId": "DwtYPRuCxpXTrzG9m",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163402-my-wild-and-reckless-youth.js?container_id=buzzsprout-player-11163402&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163402-my-wild-and-reckless-youth.js?container_id=buzzsprout-player-11163402&player=small",
     "externalEpisodeId": 11163402
   },
   "97Y7Jwrzxyfzz3Ad2": {
     "serverTitle": "Failing to Learn from History",
     "postId": "97Y7Jwrzxyfzz3Ad2",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163401-failing-to-learn-from-history.js?container_id=buzzsprout-player-11163401&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163401-failing-to-learn-from-history.js?container_id=buzzsprout-player-11163401&player=small",
     "externalEpisodeId": 11163401
   },
   "TLKPj4GDXetZuPDH5": {
     "serverTitle": "Making History Available",
     "postId": "TLKPj4GDXetZuPDH5",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163400-making-history-available.js?container_id=buzzsprout-player-11163400&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163400-making-history-available.js?container_id=buzzsprout-player-11163400&player=small",
     "externalEpisodeId": 11163400
   },
   "yxvi9RitzZDpqn6Yh": {
     "serverTitle": "Explain/Worship/Ignore?",
     "postId": "yxvi9RitzZDpqn6Yh",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163399-explain-worship-ignore.js?container_id=buzzsprout-player-11163399&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163399-explain-worship-ignore.js?container_id=buzzsprout-player-11163399&player=small",
     "externalEpisodeId": 11163399
   },
   "L22jhyY9ocXQNLqyE": {
     "serverTitle": "\"Science\" as Curiosity-Stopper",
     "postId": "L22jhyY9ocXQNLqyE",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163398-science-as-curiosity-stopper.js?container_id=buzzsprout-player-11163398&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163398-science-as-curiosity-stopper.js?container_id=buzzsprout-player-11163398&player=small",
     "externalEpisodeId": 11163398
   },
   "fg9fXrHpeaDD6pEPL": {
     "serverTitle": "Truly Part Of You",
     "postId": "fg9fXrHpeaDD6pEPL",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163397-truly-part-of-you.js?container_id=buzzsprout-player-11163397&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163397-truly-part-of-you.js?container_id=buzzsprout-player-11163397&player=small",
     "externalEpisodeId": 11163397
   },
   "X3HpE8tMXz4m4w6Rz": {
     "serverTitle": "The Simple Truth",
     "postId": "X3HpE8tMXz4m4w6Rz",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163396-interlude-the-simple-truth.js?container_id=buzzsprout-player-11163396&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163396-interlude-the-simple-truth.js?container_id=buzzsprout-player-11163396&player=small",
     "externalEpisodeId": 11163396
   },
   "KfEyHB6WXFW6q2D5S": {
     "serverTitle": "Ends: An Introduction",
     "postId": "KfEyHB6WXFW6q2D5S",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163177-ends-an-introduction.js?container_id=buzzsprout-player-11163177&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163177-ends-an-introduction.js?container_id=buzzsprout-player-11163177&player=small",
     "externalEpisodeId": 11163177
   },
   "synsRtBKDeAFuo7e3": {
     "serverTitle": "Not for the Sake of Happiness (Alone)",
     "postId": "synsRtBKDeAFuo7e3",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163176-not-for-the-sake-of-happiness-alone.js?container_id=buzzsprout-player-11163176&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163176-not-for-the-sake-of-happiness-alone.js?container_id=buzzsprout-player-11163176&player=small",
     "externalEpisodeId": 11163176
   },
   "Masoq4NdmmGSiq2xw": {
     "serverTitle": "Fake Selfishness",
     "postId": "Masoq4NdmmGSiq2xw",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163175-fake-selfishness.js?container_id=buzzsprout-player-11163175&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163175-fake-selfishness.js?container_id=buzzsprout-player-11163175&player=small",
     "externalEpisodeId": 11163175
   },
   "fATPBv4pnHC33EmJ2": {
     "serverTitle": "Fake Morality",
     "postId": "fATPBv4pnHC33EmJ2",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163174-fake-morality.js?container_id=buzzsprout-player-11163174&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163174-fake-morality.js?container_id=buzzsprout-player-11163174&player=small",
     "externalEpisodeId": 11163174
   },
   "NnohDYHNnKDtbiMyp": {
     "serverTitle": "Fake Utility Functions",
     "postId": "NnohDYHNnKDtbiMyp",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163173-fake-utility-functions.js?container_id=buzzsprout-player-11163173&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163173-fake-utility-functions.js?container_id=buzzsprout-player-11163173&player=small",
     "externalEpisodeId": 11163173
   },
   "zY4pic7cwQpa9dnyk": {
     "serverTitle": "Detached Lever Fallacy",
     "postId": "zY4pic7cwQpa9dnyk",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163172-detached-lever-fallacy.js?container_id=buzzsprout-player-11163172&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163172-detached-lever-fallacy.js?container_id=buzzsprout-player-11163172&player=small",
     "externalEpisodeId": 11163172
   },
   "p7ftQ6acRkgo6hqHb": {
     "serverTitle": "Dreams of AI Design",
     "postId": "p7ftQ6acRkgo6hqHb",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163171-dreams-of-ai-design.js?container_id=buzzsprout-player-11163171&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163171-dreams-of-ai-design.js?container_id=buzzsprout-player-11163171&player=small",
     "externalEpisodeId": 11163171
   },
   "tnWRXkcDi5Tw9rzXw": {
     "serverTitle": "The Design Space of Minds-In-General",
     "postId": "tnWRXkcDi5Tw9rzXw",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163170-the-design-space-of-minds-in-general.js?container_id=buzzsprout-player-11163170&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163170-the-design-space-of-minds-in-general.js?container_id=buzzsprout-player-11163170&player=small",
     "externalEpisodeId": 11163170
   },
   "C8nEXTcjZb9oauTCW": {
     "serverTitle": "Where Recursive Justification Hits Bottom",
     "postId": "C8nEXTcjZb9oauTCW",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163169-where-recursive-justification-hits-bottom.js?container_id=buzzsprout-player-11163169&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163169-where-recursive-justification-hits-bottom.js?container_id=buzzsprout-player-11163169&player=small",
     "externalEpisodeId": 11163169
   },
   "TynBiYt6zg42StRbb": {
     "serverTitle": "My Kind of Reflection",
     "postId": "TynBiYt6zg42StRbb",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163168-my-kind-of-reflection.js?container_id=buzzsprout-player-11163168&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163168-my-kind-of-reflection.js?container_id=buzzsprout-player-11163168&player=small",
     "externalEpisodeId": 11163168
   },
   "PtoQdG7E8MxYJrigu": {
     "serverTitle": "No Universally Compelling Arguments",
     "postId": "PtoQdG7E8MxYJrigu",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163167-no-universally-compelling-arguments.js?container_id=buzzsprout-player-11163167&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163167-no-universally-compelling-arguments.js?container_id=buzzsprout-player-11163167&player=small",
     "externalEpisodeId": 11163167
   },
   "CuSTqHgeK4CMpWYTe": {
     "serverTitle": "Created Already In Motion",
     "postId": "CuSTqHgeK4CMpWYTe",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163166-created-already-in-motion.js?container_id=buzzsprout-player-11163166&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163166-created-already-in-motion.js?container_id=buzzsprout-player-11163166&player=small",
     "externalEpisodeId": 11163166
   },
   "mMBTPTjRbsrqbSkZE": {
     "serverTitle": "Sorting Pebbles Into Correct Heaps",
     "postId": "mMBTPTjRbsrqbSkZE",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163165-sorting-pebbles-into-correct-heaps.js?container_id=buzzsprout-player-11163165&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163165-sorting-pebbles-into-correct-heaps.js?container_id=buzzsprout-player-11163165&player=small",
     "externalEpisodeId": 11163165
   },
   "eDpPnT7wdBwWPGvo5": {
     "serverTitle": "2-Place and 1-Place Words",
     "postId": "eDpPnT7wdBwWPGvo5",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163164-2-place-and-1-place-words.js?container_id=buzzsprout-player-11163164&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163164-2-place-and-1-place-words.js?container_id=buzzsprout-player-11163164&player=small",
     "externalEpisodeId": 11163164
   },
   "iGH7FSrdoCXa5AHGs": {
     "serverTitle": "What Would You Do Without Morality?",
     "postId": "iGH7FSrdoCXa5AHGs",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163163-what-would-you-do-without-morality.js?container_id=buzzsprout-player-11163163&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163163-what-would-you-do-without-morality.js?container_id=buzzsprout-player-11163163&player=small",
     "externalEpisodeId": 11163163
   },
   "LhP2zGBWR5AdssrdJ": {
     "serverTitle": "Changing Your Metaethics",
     "postId": "LhP2zGBWR5AdssrdJ",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163162-changing-your-metaethics.js?container_id=buzzsprout-player-11163162&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163162-changing-your-metaethics.js?container_id=buzzsprout-player-11163162&player=small",
     "externalEpisodeId": 11163162
   },
   "vy9nnPdwTjSmt5qdb": {
     "serverTitle": "Could Anything Be Right?",
     "postId": "vy9nnPdwTjSmt5qdb",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163161-could-anything-be-right.js?container_id=buzzsprout-player-11163161&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163161-could-anything-be-right.js?container_id=buzzsprout-player-11163161&player=small",
     "externalEpisodeId": 11163161
   },
   "FnJPa8E9ZG5xiLLp5": {
     "serverTitle": "Morality as Fixed Computation",
     "postId": "FnJPa8E9ZG5xiLLp5",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163160-morality-as-fixed-computation.js?container_id=buzzsprout-player-11163160&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163160-morality-as-fixed-computation.js?container_id=buzzsprout-player-11163160&player=small",
     "externalEpisodeId": 11163160
   },
   "PoDAyQMWEXBBBEJ5P": {
     "serverTitle": "Magical Categories",
     "postId": "PoDAyQMWEXBBBEJ5P",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163159-magical-categories.js?container_id=buzzsprout-player-11163159&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163159-magical-categories.js?container_id=buzzsprout-player-11163159&player=small",
     "externalEpisodeId": 11163159
   },
   "HFyWNBnDNEDsDNLrZ": {
     "serverTitle": "The True Prisoner's Dilemma",
     "postId": "HFyWNBnDNEDsDNLrZ",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163158-the-true-prisoner-s-dilemma.js?container_id=buzzsprout-player-11163158&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163158-the-true-prisoner-s-dilemma.js?container_id=buzzsprout-player-11163158&player=small",
     "externalEpisodeId": 11163158
   },
   "NLMo5FZWFFq652MNe": {
     "serverTitle": "Sympathetic Minds",
     "postId": "NLMo5FZWFFq652MNe",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163157-sympathetic-minds.js?container_id=buzzsprout-player-11163157&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163157-sympathetic-minds.js?container_id=buzzsprout-player-11163157&player=small",
     "externalEpisodeId": 11163157
   },
   "29vqqmGNxNRGzffEj": {
     "serverTitle": "High Challenge",
     "postId": "29vqqmGNxNRGzffEj",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163156-high-challenge.js?container_id=buzzsprout-player-11163156&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163156-high-challenge.js?container_id=buzzsprout-player-11163156&player=small",
     "externalEpisodeId": 11163156
   },
   "6qS9q5zHafFXsB6hf": {
     "serverTitle": "Serious Stories",
     "postId": "6qS9q5zHafFXsB6hf",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163155-serious-stories.js?container_id=buzzsprout-player-11163155&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163155-serious-stories.js?container_id=buzzsprout-player-11163155&player=small",
     "externalEpisodeId": 11163155
   },
   "GNnHHmm8EzePmKzPk": {
     "serverTitle": "Value is Fragile",
     "postId": "GNnHHmm8EzePmKzPk",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163154-value-is-fragile.js?container_id=buzzsprout-player-11163154&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163154-value-is-fragile.js?container_id=buzzsprout-player-11163154&player=small",
     "externalEpisodeId": 11163154
   },
   "pGvyqAQw6yqTjpKf4": {
     "serverTitle": "The Gift We Give To Tomorrow",
     "postId": "pGvyqAQw6yqTjpKf4",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163153-the-gift-we-give-to-tomorrow.js?container_id=buzzsprout-player-11163153&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163153-the-gift-we-give-to-tomorrow.js?container_id=buzzsprout-player-11163153&player=small",
     "externalEpisodeId": 11163153
   },
   "xiHy3kFni8nsxfdcP": {
     "serverTitle": "One Life Against the World",
     "postId": "xiHy3kFni8nsxfdcP",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163151-one-life-against-the-world.js?container_id=buzzsprout-player-11163151&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163151-one-life-against-the-world.js?container_id=buzzsprout-player-11163151&player=small",
     "externalEpisodeId": 11163151
   },
   "zJZvoiwydJ5zvzTHK": {
     "serverTitle": "The Allais Paradox",
     "postId": "zJZvoiwydJ5zvzTHK",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163150-the-allais-paradox.js?container_id=buzzsprout-player-11163150&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163150-the-allais-paradox.js?container_id=buzzsprout-player-11163150&player=small",
     "externalEpisodeId": 11163150
   },
   "zNcLnqHF5rvrTsQJx": {
     "serverTitle": "Zut Allais!",
     "postId": "zNcLnqHF5rvrTsQJx",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163149-zut-allais.js?container_id=buzzsprout-player-11163149&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163149-zut-allais.js?container_id=buzzsprout-player-11163149&player=small",
     "externalEpisodeId": 11163149
   },
   "Nx2WxEuPSvNBGuYpo": {
     "serverTitle": "Feeling Moral",
     "postId": "Nx2WxEuPSvNBGuYpo",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163148-feeling-moral.js?container_id=buzzsprout-player-11163148&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163148-feeling-moral.js?container_id=buzzsprout-player-11163148&player=small",
     "externalEpisodeId": 11163148
   },
   "r5MSQ83gtbjWRBDWJ": {
     "serverTitle": "The \"Intuitions\" Behind \"Utilitarianism\"",
     "postId": "r5MSQ83gtbjWRBDWJ",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163147-the-intuitions-behind-utilitarianism.js?container_id=buzzsprout-player-11163147&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163147-the-intuitions-behind-utilitarianism.js?container_id=buzzsprout-player-11163147&player=small",
     "externalEpisodeId": 11163147
   },
   "K9ZaZXDnL3SEmYZqB": {
     "serverTitle": "Ends Don't Justify Means (Among Humans)",
     "postId": "K9ZaZXDnL3SEmYZqB",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163146-ends-don-t-justify-means-among-humans.js?container_id=buzzsprout-player-11163146&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163146-ends-don-t-justify-means-among-humans.js?container_id=buzzsprout-player-11163146&player=small",
     "externalEpisodeId": 11163146
   },
   "dWTEtgBfFaz6vjwQf": {
     "serverTitle": "Ethical Injunctions",
     "postId": "dWTEtgBfFaz6vjwQf",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163145-ethical-injunctions.js?container_id=buzzsprout-player-11163145&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163145-ethical-injunctions.js?container_id=buzzsprout-player-11163145&player=small",
     "externalEpisodeId": 11163145
   },
   "SGR4GxFK7KmW7ckCB": {
     "serverTitle": "Something to Protect",
     "postId": "SGR4GxFK7KmW7ckCB",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163144-something-to-protect.js?container_id=buzzsprout-player-11163144&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163144-something-to-protect.js?container_id=buzzsprout-player-11163144&player=small",
     "externalEpisodeId": 11163144
   },
   "AJ9dX59QXokZb35fk": {
     "serverTitle": "When (Not) To Use Probabilities",
     "postId": "AJ9dX59QXokZb35fk",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163143-when-not-to-use-probabilities.js?container_id=buzzsprout-player-11163143&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163143-when-not-to-use-probabilities.js?container_id=buzzsprout-player-11163143&player=small",
     "externalEpisodeId": 11163143
   },
   "6ddcsdA2c2XpNpE5x": {
     "serverTitle": "Newcomb's Problem and Regret of Rationality",
     "postId": "6ddcsdA2c2XpNpE5x",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163142-newcomb-s-problem-and-regret-of-rationality.js?container_id=buzzsprout-player-11163142&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163142-newcomb-s-problem-and-regret-of-rationality.js?container_id=buzzsprout-player-11163142&player=small",
     "externalEpisodeId": 11163142
   },
   "7ZqGiPHTpiDMwqMN2": {
     "serverTitle": "Twelve Virtues of Rationality",
     "postId": "7ZqGiPHTpiDMwqMN2",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163141-the-twelve-virtues-of-rationality.js?container_id=buzzsprout-player-11163141&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163141-the-twelve-virtues-of-rationality.js?container_id=buzzsprout-player-11163141&player=small",
     "externalEpisodeId": 11163141
   },
   "ujoJSat3ypzp3tmpj": {
     "serverTitle": "The World: An Introduction",
     "postId": "ujoJSat3ypzp3tmpj",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163255-the-world-an-introduction.js?container_id=buzzsprout-player-11163255&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163255-the-world-an-introduction.js?container_id=buzzsprout-player-11163255&player=small",
     "externalEpisodeId": 11163255
   },
   "LaM5aTcXvXzwQSC2Q": {
     "serverTitle": "Universal Fire",
     "postId": "LaM5aTcXvXzwQSC2Q",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163254-universal-fire.js?container_id=buzzsprout-player-11163254&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163254-universal-fire.js?container_id=buzzsprout-player-11163254&player=small",
     "externalEpisodeId": 11163254
   },
   "7iTwGquBFZKttpEdE": {
     "serverTitle": "Universal Law",
     "postId": "7iTwGquBFZKttpEdE",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163253-universal-law.js?container_id=buzzsprout-player-11163253&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163253-universal-law.js?container_id=buzzsprout-player-11163253&player=small",
     "externalEpisodeId": 11163253
   },
   "oKiy7YwGToaYXdvnj": {
     "serverTitle": "Is Reality Ugly?",
     "postId": "oKiy7YwGToaYXdvnj",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163252-is-reality-ugly.js?container_id=buzzsprout-player-11163252&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163252-is-reality-ugly.js?container_id=buzzsprout-player-11163252&player=small",
     "externalEpisodeId": 11163252
   },
   "bkSkRwo9SRYxJMiSY": {
     "serverTitle": "Beautiful Probability",
     "postId": "bkSkRwo9SRYxJMiSY",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163251-beautiful-probability.js?container_id=buzzsprout-player-11163251&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163251-beautiful-probability.js?container_id=buzzsprout-player-11163251&player=small",
     "externalEpisodeId": 11163251
   },
   "N2pENnTPB75sfc9kb": {
     "serverTitle": "Outside the Laboratory",
     "postId": "N2pENnTPB75sfc9kb",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163250-outside-the-laboratory.js?container_id=buzzsprout-player-11163250&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163250-outside-the-laboratory.js?container_id=buzzsprout-player-11163250&player=small",
     "externalEpisodeId": 11163250
   },
   "QkX2bAkwG2EpGvNug": {
     "serverTitle": "The Second Law of Thermodynamics, and Engines of Cognition",
     "postId": "QkX2bAkwG2EpGvNug",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163249-the-second-law-of-thermodynamics.js?container_id=buzzsprout-player-11163249&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163249-the-second-law-of-thermodynamics.js?container_id=buzzsprout-player-11163249&player=small",
     "externalEpisodeId": 11163249
   },
   "zFuCxbY9E2E8HTbfZ": {
     "serverTitle": "Perpetual Motion Beliefs",
     "postId": "zFuCxbY9E2E8HTbfZ",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163248-perpetual-motion-beliefs.js?container_id=buzzsprout-player-11163248&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163248-perpetual-motion-beliefs.js?container_id=buzzsprout-player-11163248&player=small",
     "externalEpisodeId": 11163248
   },
   "QrhAeKBkm2WsdRYao": {
     "serverTitle": "Searching for Bayes-Structure",
     "postId": "QrhAeKBkm2WsdRYao",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163247-searching-for-bayes-structure.js?container_id=buzzsprout-player-11163247&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163247-searching-for-bayes-structure.js?container_id=buzzsprout-player-11163247&player=small",
     "externalEpisodeId": 11163247
   },
   "Mc6QcrsbH5NRXbCRX": {
     "serverTitle": "Dissolving the Question",
     "postId": "Mc6QcrsbH5NRXbCRX",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163246-dissolving-the-question.js?container_id=buzzsprout-player-11163246&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163246-dissolving-the-question.js?container_id=buzzsprout-player-11163246&player=small",
     "externalEpisodeId": 11163246
   },
   "XzrqkhfwtiSDgKoAF": {
     "serverTitle": "Wrong Questions",
     "postId": "XzrqkhfwtiSDgKoAF",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163245-wrong-questions.js?container_id=buzzsprout-player-11163245&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163245-wrong-questions.js?container_id=buzzsprout-player-11163245&player=small",
     "externalEpisodeId": 11163245
   },
   "rQEwySCcLtdKHkrHp": {
     "serverTitle": "Righting a Wrong Question",
     "postId": "rQEwySCcLtdKHkrHp",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163244-righting-a-wrong-question.js?container_id=buzzsprout-player-11163244&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163244-righting-a-wrong-question.js?container_id=buzzsprout-player-11163244&player=small",
     "externalEpisodeId": 11163244
   },
   "ZTRiSNmeGQK8AkdN2": {
     "serverTitle": "Mind Projection Fallacy",
     "postId": "ZTRiSNmeGQK8AkdN2",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163243-mind-projection-fallacy.js?container_id=buzzsprout-player-11163243&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163243-mind-projection-fallacy.js?container_id=buzzsprout-player-11163243&player=small",
     "externalEpisodeId": 11163243
   },
   "f6ZLxEWaankRZ2Crv": {
     "serverTitle": "Probability is in the Mind",
     "postId": "f6ZLxEWaankRZ2Crv",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163242-probability-is-in-the-mind.js?container_id=buzzsprout-player-11163242&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163242-probability-is-in-the-mind.js?container_id=buzzsprout-player-11163242&player=small",
     "externalEpisodeId": 11163242
   },
   "np3tP49caG4uFLRbS": {
     "serverTitle": "The Quotation is not the Referent",
     "postId": "np3tP49caG4uFLRbS",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163241-the-quotation-is-not-the-referent.js?container_id=buzzsprout-player-11163241&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163241-the-quotation-is-not-the-referent.js?container_id=buzzsprout-player-11163241&player=small",
     "externalEpisodeId": 11163241
   },
   "BwtBhqvTPGG2n2GuJ": {
     "serverTitle": "Qualitatively Confused",
     "postId": "BwtBhqvTPGG2n2GuJ",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163240-qualitatively-confused.js?container_id=buzzsprout-player-11163240&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163240-qualitatively-confused.js?container_id=buzzsprout-player-11163240&player=small",
     "externalEpisodeId": 11163240
   },
   "tWLFWAndSZSYN6rPB": {
     "serverTitle": "Think Like Reality",
     "postId": "tWLFWAndSZSYN6rPB",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163239-think-like-reality.js?container_id=buzzsprout-player-11163239&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163239-think-like-reality.js?container_id=buzzsprout-player-11163239&player=small",
     "externalEpisodeId": 11163239
   },
   "NyFtHycJvkyNjXNsP": {
     "serverTitle": "Chaotic Inversion",
     "postId": "NyFtHycJvkyNjXNsP",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163238-chaotic-inversion.js?container_id=buzzsprout-player-11163238&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163238-chaotic-inversion.js?container_id=buzzsprout-player-11163238&player=small",
     "externalEpisodeId": 11163238
   },
   "tPqQdLCuxanjhoaNs": {
     "serverTitle": "Reductionism",
     "postId": "tPqQdLCuxanjhoaNs",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163235-fake-reductionism.js?container_id=buzzsprout-player-11163235&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163235-fake-reductionism.js?container_id=buzzsprout-player-11163235&player=small",
     "externalEpisodeId": 11163235
   },
   "cphoF8naigLhRf3tu": {
     "serverTitle": "Explaining vs. Explaining Away",
     "postId": "cphoF8naigLhRf3tu",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163236-explaining-vs-explaining-away.js?container_id=buzzsprout-player-11163236&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163236-explaining-vs-explaining-away.js?container_id=buzzsprout-player-11163236&player=small",
     "externalEpisodeId": 11163236
   },
   "mTf8MkpAigm3HP6x2": {
     "serverTitle": "Fake Reductionism",
     "postId": "mTf8MkpAigm3HP6x2",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163235-fake-reductionism.js?container_id=buzzsprout-player-11163235&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163235-fake-reductionism.js?container_id=buzzsprout-player-11163235&player=small",
     "externalEpisodeId": 11163235
   },
   "kQzs8MFbBxdYhe3hK": {
     "serverTitle": "Savanna Poets",
     "postId": "kQzs8MFbBxdYhe3hK",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163234-savanna-poets.js?container_id=buzzsprout-player-11163234&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163234-savanna-poets.js?container_id=buzzsprout-player-11163234&player=small",
     "externalEpisodeId": 11163234
   },
   "x4dG4GhpZH2hgz59x": {
     "serverTitle": "Joy in the Merely Real",
     "postId": "x4dG4GhpZH2hgz59x",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163233-joy-in-the-merely-real.js?container_id=buzzsprout-player-11163233&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163233-joy-in-the-merely-real.js?container_id=buzzsprout-player-11163233&player=small",
     "externalEpisodeId": 11163233
   },
   "KfMNFB3G7XNviHBPN": {
     "serverTitle": "Joy in Discovery",
     "postId": "KfMNFB3G7XNviHBPN",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163232-joy-in-discovery.js?container_id=buzzsprout-player-11163232&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163232-joy-in-discovery.js?container_id=buzzsprout-player-11163232&player=small",
     "externalEpisodeId": 11163232
   },
   "WjpA4PCjt5EkTGbLF": {
     "serverTitle": "Bind Yourself to Reality",
     "postId": "WjpA4PCjt5EkTGbLF",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163231-bind-yourself-to-reality.js?container_id=buzzsprout-player-11163231&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163231-bind-yourself-to-reality.js?container_id=buzzsprout-player-11163231&player=small",
     "externalEpisodeId": 11163231
   },
   "iiWiHgtQekWNnmE6Q": {
     "serverTitle": "If You Demand Magic, Magic Won't Help",
     "postId": "iiWiHgtQekWNnmE6Q",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163230-if-you-demand-magic-magic-won-t-help.js?container_id=buzzsprout-player-11163230&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163230-if-you-demand-magic-magic-won-t-help.js?container_id=buzzsprout-player-11163230&player=small",
     "externalEpisodeId": 11163230
   },
   "SXK87NgEPszhWkvQm": {
     "serverTitle": "Mundane Magic",
     "postId": "SXK87NgEPszhWkvQm",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163229-mundane-magic.js?container_id=buzzsprout-player-11163229&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163229-mundane-magic.js?container_id=buzzsprout-player-11163229&player=small",
     "externalEpisodeId": 11163229
   },
   "ndGYn7ZFiZyernp9f": {
     "serverTitle": "The Beauty of Settled Science",
     "postId": "ndGYn7ZFiZyernp9f",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163228-the-beauty-of-settled-science.js?container_id=buzzsprout-player-11163228&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163228-the-beauty-of-settled-science.js?container_id=buzzsprout-player-11163228&player=small",
     "externalEpisodeId": 11163228
   },
   "hYqDp4qAucZM33qSh": {
     "serverTitle": "Amazing Breakthrough Day: April 1st",
     "postId": "hYqDp4qAucZM33qSh",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163227-amazing-breakthrough-day-april-1st.js?container_id=buzzsprout-player-11163227&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163227-amazing-breakthrough-day-april-1st.js?container_id=buzzsprout-player-11163227&player=small",
     "externalEpisodeId": 11163227
   },
   "PMr6f7ZocEWFtCYXj": {
     "serverTitle": "Is Humanism A Religion-Substitute?",
     "postId": "PMr6f7ZocEWFtCYXj",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163226-is-humanism-a-religion-substitute.js?container_id=buzzsprout-player-11163226&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163226-is-humanism-a-religion-substitute.js?container_id=buzzsprout-player-11163226&player=small",
     "externalEpisodeId": 11163226
   },
   "MCYp8g9EMAiTCTawk": {
     "serverTitle": "Scarcity",
     "postId": "MCYp8g9EMAiTCTawk",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163225-scarcity.js?container_id=buzzsprout-player-11163225&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163225-scarcity.js?container_id=buzzsprout-player-11163225&player=small",
     "externalEpisodeId": 11163225
   },
   "Fwt4sDDacko8Sh5iR": {
     "serverTitle": "The Sacred Mundane",
     "postId": "Fwt4sDDacko8Sh5iR",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163224-the-sacred-mundane.js?container_id=buzzsprout-player-11163224&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163224-the-sacred-mundane.js?container_id=buzzsprout-player-11163224&player=small",
     "externalEpisodeId": 11163224
   },
   "3diLhMELXxM8rFHJj": {
     "serverTitle": "To Spread Science, Keep It Secret",
     "postId": "3diLhMELXxM8rFHJj",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163223-to-spread-science-keep-it-secret.js?container_id=buzzsprout-player-11163223&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163223-to-spread-science-keep-it-secret.js?container_id=buzzsprout-player-11163223&player=small",
     "externalEpisodeId": 11163223
   },
   "fnEWQAYxcRnaYBqaZ": {
     "serverTitle": "Initiation Ceremony",
     "postId": "fnEWQAYxcRnaYBqaZ",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163222-initiation-ceremony.js?container_id=buzzsprout-player-11163222&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163222-initiation-ceremony.js?container_id=buzzsprout-player-11163222&player=small",
     "externalEpisodeId": 11163222
   },
   "KmghfjH6RgXvoKruJ": {
     "serverTitle": "Hand vs. Fingers",
     "postId": "KmghfjH6RgXvoKruJ",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163221-hand-vs-fingers.js?container_id=buzzsprout-player-11163221&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163221-hand-vs-fingers.js?container_id=buzzsprout-player-11163221&player=small",
     "externalEpisodeId": 11163221
   },
   "ddwk9veF8efn3Nzbu": {
     "serverTitle": "Angry Atoms",
     "postId": "ddwk9veF8efn3Nzbu",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163220-angry-atoms.js?container_id=buzzsprout-player-11163220&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163220-angry-atoms.js?container_id=buzzsprout-player-11163220&player=small",
     "externalEpisodeId": 11163220
   },
   "ne6Ra62FB9ACHGSuh": {
     "serverTitle": "Heat vs. Motion",
     "postId": "ne6Ra62FB9ACHGSuh",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163219-heat-vs-motion.js?container_id=buzzsprout-player-11163219&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163219-heat-vs-motion.js?container_id=buzzsprout-player-11163219&player=small",
     "externalEpisodeId": 11163219
   },
   "nzzNFcrSk7akQ9bwD": {
     "serverTitle": "Brain Breakthrough! It's Made of Neurons!",
     "postId": "nzzNFcrSk7akQ9bwD",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163218-brain-breakthrough-it-s-made-of-neurons.js?container_id=buzzsprout-player-11163218&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163218-brain-breakthrough-it-s-made-of-neurons.js?container_id=buzzsprout-player-11163218&player=small",
     "externalEpisodeId": 11163218
   },
   "f4RJtHBPvDRJcCTva": {
     "serverTitle": "When Anthropomorphism Became Stupid",
     "postId": "f4RJtHBPvDRJcCTva",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163217-when-anthropomorphism-became-stupid.js?container_id=buzzsprout-player-11163217&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163217-when-anthropomorphism-became-stupid.js?container_id=buzzsprout-player-11163217&player=small",
     "externalEpisodeId": 11163217
   },
   "qmqLxvtsPzZ2s6mpY": {
     "serverTitle": "A Priori",
     "postId": "qmqLxvtsPzZ2s6mpY",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163216-a-priori.js?container_id=buzzsprout-player-11163216&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163216-a-priori.js?container_id=buzzsprout-player-11163216&player=small",
     "externalEpisodeId": 11163216
   },
   "gRa5cWWBsZqdFvmqu": {
     "serverTitle": "Reductive Reference",
     "postId": "gRa5cWWBsZqdFvmqu",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163215-reductive-references.js?container_id=buzzsprout-player-11163215&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163215-reductive-references.js?container_id=buzzsprout-player-11163215&player=small",
     "externalEpisodeId": 11163215
   },
   "fdEWWr8St59bXLbQr": {
     "serverTitle": "Zombies! Zombies?",
     "postId": "fdEWWr8St59bXLbQr",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163214-zombies-zombies.js?container_id=buzzsprout-player-11163214&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163214-zombies-zombies.js?container_id=buzzsprout-player-11163214&player=small",
     "externalEpisodeId": 11163214
   },
   "4moMTeCy9EqYxAher": {
     "serverTitle": "Zombie Responses",
     "postId": "4moMTeCy9EqYxAher",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163213-zombie-responses.js?container_id=buzzsprout-player-11163213&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163213-zombie-responses.js?container_id=buzzsprout-player-11163213&player=small",
     "externalEpisodeId": 11163213
   },
   "kYAuNJX2ecH2uFqZ9": {
     "serverTitle": "The Generalized Anti-Zombie Principle",
     "postId": "kYAuNJX2ecH2uFqZ9",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163212-the-generalized-anti-zombie-principle.js?container_id=buzzsprout-player-11163212&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163212-the-generalized-anti-zombie-principle.js?container_id=buzzsprout-player-11163212&player=small",
     "externalEpisodeId": 11163212
   },
   "k6EPphHiBH4WWYFCj": {
     "serverTitle": "GAZP vs. GLUT",
     "postId": "k6EPphHiBH4WWYFCj",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163211-gazp-vs-glut.js?container_id=buzzsprout-player-11163211&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163211-gazp-vs-glut.js?container_id=buzzsprout-player-11163211&player=small",
     "externalEpisodeId": 11163211
   },
   "3XMwPNMSbaPm2suGz": {
     "serverTitle": "Belief in the Implied Invisible",
     "postId": "3XMwPNMSbaPm2suGz",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163210-belief-in-the-implied-invisible.js?container_id=buzzsprout-player-11163210&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163210-belief-in-the-implied-invisible.js?container_id=buzzsprout-player-11163210&player=small",
     "externalEpisodeId": 11163210
   },
   "fsDz6HieZJBu54Yes": {
     "serverTitle": "Zombies: The Movie",
     "postId": "fsDz6HieZJBu54Yes",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163209-zombies-the-movie.js?container_id=buzzsprout-player-11163209&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163209-zombies-the-movie.js?container_id=buzzsprout-player-11163209&player=small",
     "externalEpisodeId": 11163209
   },
   "u6JzcFtPGiznFgDxP": {
     "serverTitle": "Excluding the Supernatural",
     "postId": "u6JzcFtPGiznFgDxP",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163208-excluding-the-supernatural.js?container_id=buzzsprout-player-11163208&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163208-excluding-the-supernatural.js?container_id=buzzsprout-player-11163208&player=small",
     "externalEpisodeId": 11163208
   },
   "7Au7kvRAPREm3ADcK": {
     "serverTitle": "Psychic Powers",
     "postId": "7Au7kvRAPREm3ADcK",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163207-psychic-powers.js?container_id=buzzsprout-player-11163207&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163207-psychic-powers.js?container_id=buzzsprout-player-11163207&player=small",
     "externalEpisodeId": 11163207
   },
   "7FSwbFpDsca7uXpQ2": {
     "serverTitle": "Quantum Explanations",
     "postId": "7FSwbFpDsca7uXpQ2",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163206-quantum-explanations.js?container_id=buzzsprout-player-11163206&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163206-quantum-explanations.js?container_id=buzzsprout-player-11163206&player=small",
     "externalEpisodeId": 11163206
   },
   "5vZD32EynD9n94dhr": {
     "serverTitle": "Configurations and Amplitude",
     "postId": "5vZD32EynD9n94dhr",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163205-configurations-and-amplitude.js?container_id=buzzsprout-player-11163205&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163205-configurations-and-amplitude.js?container_id=buzzsprout-player-11163205&player=small",
     "externalEpisodeId": 11163205
   },
   "ybusFwDqiZgQa6NCq": {
     "serverTitle": "Joint Configurations",
     "postId": "ybusFwDqiZgQa6NCq",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163204-joint-configurations.js?container_id=buzzsprout-player-11163204&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163204-joint-configurations.js?container_id=buzzsprout-player-11163204&player=small",
     "externalEpisodeId": 11163204
   },
   "KbeHkLNY5ETJ3TN3W": {
     "serverTitle": "Distinct Configurations",
     "postId": "KbeHkLNY5ETJ3TN3W",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163203-distinct-configurations.js?container_id=buzzsprout-player-11163203&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163203-distinct-configurations.js?container_id=buzzsprout-player-11163203&player=small",
     "externalEpisodeId": 11163203
   },
   "xsZnufn3cQw7tJeQ3": {
     "serverTitle": "Collapse Postulates",
     "postId": "xsZnufn3cQw7tJeQ3",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163202-collapse-postulates.js?container_id=buzzsprout-player-11163202&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163202-collapse-postulates.js?container_id=buzzsprout-player-11163202&player=small",
     "externalEpisodeId": 11163202
   },
   "Atu4teGvob5vKvEAF": {
     "serverTitle": "Decoherence is Simple",
     "postId": "Atu4teGvob5vKvEAF",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163201-decoherence-is-simple.js?container_id=buzzsprout-player-11163201&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163201-decoherence-is-simple.js?container_id=buzzsprout-player-11163201&player=small",
     "externalEpisodeId": 11163201
   },
   "DFxoaWGEh9ndwtZhk": {
     "serverTitle": "Decoherence is Falsifiable and Testable",
     "postId": "DFxoaWGEh9ndwtZhk",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163200-decoherence-is-falsifiable-and-testable.js?container_id=buzzsprout-player-11163200&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163200-decoherence-is-falsifiable-and-testable.js?container_id=buzzsprout-player-11163200&player=small",
     "externalEpisodeId": 11163200
   },
   "X2AD2LgtKgkRNPj2a": {
     "serverTitle": "Privileging the Hypothesis",
     "postId": "X2AD2LgtKgkRNPj2a",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163199-privileging-the-hypothesis.js?container_id=buzzsprout-player-11163199&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163199-privileging-the-hypothesis.js?container_id=buzzsprout-player-11163199&player=small",
     "externalEpisodeId": 11163199
   },
   "qcYCAxYZT4Xp9iMZY": {
     "serverTitle": "Living in Many Worlds",
     "postId": "qcYCAxYZT4Xp9iMZY",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163198-living-in-many-worlds.js?container_id=buzzsprout-player-11163198&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163198-living-in-many-worlds.js?container_id=buzzsprout-player-11163198&player=small",
     "externalEpisodeId": 11163198
   },
   "k3823vuarnmL5Pqin": {
     "serverTitle": "Quantum Non-Realism",
     "postId": "k3823vuarnmL5Pqin",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163197-quantum-non-realism.js?container_id=buzzsprout-player-11163197&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163197-quantum-non-realism.js?container_id=buzzsprout-player-11163197&player=small",
     "externalEpisodeId": 11163197
   },
   "WqGCaRhib42dhKWRL": {
     "serverTitle": "If Many-Worlds Had Come First",
     "postId": "WqGCaRhib42dhKWRL",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163196-if-many-worlds-had-come-first.js?container_id=buzzsprout-player-11163196&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163196-if-many-worlds-had-come-first.js?container_id=buzzsprout-player-11163196&player=small",
     "externalEpisodeId": 11163196
   },
   "Bh9cdfMjATrTdLrGH": {
     "serverTitle": "Where Philosophy Meets Science",
     "postId": "Bh9cdfMjATrTdLrGH",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163195-where-philosophy-meets-science.js?container_id=buzzsprout-player-11163195&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163195-where-philosophy-meets-science.js?container_id=buzzsprout-player-11163195&player=small",
     "externalEpisodeId": 11163195
   },
   "NEeW7eSXThPz7o4Ne": {
     "serverTitle": "Thou Art Physics",
     "postId": "NEeW7eSXThPz7o4Ne",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163194-thou-art-physics.js?container_id=buzzsprout-player-11163194&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163194-thou-art-physics.js?container_id=buzzsprout-player-11163194&player=small",
     "externalEpisodeId": 11163194
   },
   "S8ysHqeRGuySPttrS": {
     "serverTitle": "Many Worlds, One Best Guess",
     "postId": "S8ysHqeRGuySPttrS",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163193-many-worlds-one-best-guess.js?container_id=buzzsprout-player-11163193&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163193-many-worlds-one-best-guess.js?container_id=buzzsprout-player-11163193&player=small",
     "externalEpisodeId": 11163193
   },
   "ZxR8P8hBFQ9kC8wMy": {
     "serverTitle": "The Failures of Eld Science",
     "postId": "ZxR8P8hBFQ9kC8wMy",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163192-the-failures-of-eld-science.js?container_id=buzzsprout-player-11163192&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163192-the-failures-of-eld-science.js?container_id=buzzsprout-player-11163192&player=small",
     "externalEpisodeId": 11163192
   },
   "viPPjojmChxLGPE2v": {
     "serverTitle": "The Dilemma: Science or Bayes?",
     "postId": "viPPjojmChxLGPE2v",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163191-the-dilemma-science-or-bayes.js?container_id=buzzsprout-player-11163191&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163191-the-dilemma-science-or-bayes.js?container_id=buzzsprout-player-11163191&player=small",
     "externalEpisodeId": 11163191
   },
   "5bJyRMZzwMov5u3hW": {
     "serverTitle": "Science Doesn't Trust Your Rationality",
     "postId": "5bJyRMZzwMov5u3hW",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163190-science-doesn-t-trust-your-rationality.js?container_id=buzzsprout-player-11163190&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163190-science-doesn-t-trust-your-rationality.js?container_id=buzzsprout-player-11163190&player=small",
     "externalEpisodeId": 11163190
   },
   "wzxneh7wxkdNYNbtB": {
     "serverTitle": "When Science Can't Help",
     "postId": "wzxneh7wxkdNYNbtB",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163189-when-science-can-t-help.js?container_id=buzzsprout-player-11163189&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163189-when-science-can-t-help.js?container_id=buzzsprout-player-11163189&player=small",
     "externalEpisodeId": 11163189
   },
   "PGfJdgemDJSwWBZSX": {
     "serverTitle": "Science Isn't Strict Enough",
     "postId": "PGfJdgemDJSwWBZSX",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163188-science-isn-t-strict-enough.js?container_id=buzzsprout-player-11163188&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163188-science-isn-t-strict-enough.js?container_id=buzzsprout-player-11163188&player=small",
     "externalEpisodeId": 11163188
   },
   "WijMw9WkcafmCFgj4": {
     "serverTitle": "Do Scientists Already Know This Stuff?",
     "postId": "WijMw9WkcafmCFgj4",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163187-do-scientists-already-know-this-stuff.js?container_id=buzzsprout-player-11163187&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163187-do-scientists-already-know-this-stuff.js?container_id=buzzsprout-player-11163187&player=small",
     "externalEpisodeId": 11163187
   },
   "wustx45CPL5rZenuo": {
     "serverTitle": "No Safe Defense, Not Even Science",
     "postId": "wustx45CPL5rZenuo",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163186-no-safe-defense-not-even-science.js?container_id=buzzsprout-player-11163186&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163186-no-safe-defense-not-even-science.js?container_id=buzzsprout-player-11163186&player=small",
     "externalEpisodeId": 11163186
   },
   "SoDsr8GEZmRKMZNkj": {
     "serverTitle": "Changing the Definition of Science",
     "postId": "SoDsr8GEZmRKMZNkj",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163185-changing-the-definition-of-science.js?container_id=buzzsprout-player-11163185&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163185-changing-the-definition-of-science.js?container_id=buzzsprout-player-11163185&player=small",
     "externalEpisodeId": 11163185
   },
   "xTyuQ3cgsPjifr7oj": {
     "serverTitle": "Faster Than Science",
     "postId": "xTyuQ3cgsPjifr7oj",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163184-faster-than-science.js?container_id=buzzsprout-player-11163184&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163184-faster-than-science.js?container_id=buzzsprout-player-11163184&player=small",
     "externalEpisodeId": 11163184
   },
   "mpaqTWGiLT7GA3w76": {
     "serverTitle": "Einstein's Speed",
     "postId": "mpaqTWGiLT7GA3w76",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163183-einstein-s-speed.js?container_id=buzzsprout-player-11163183&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163183-einstein-s-speed.js?container_id=buzzsprout-player-11163183&player=small",
     "externalEpisodeId": 11163183
   },
   "5wMcKNAwB6X4mp9og": {
     "serverTitle": "That Alien Message",
     "postId": "5wMcKNAwB6X4mp9og",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163182-that-alien-message.js?container_id=buzzsprout-player-11163182&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163182-that-alien-message.js?container_id=buzzsprout-player-11163182&player=small",
     "externalEpisodeId": 11163182
   },
   "3Jpchgy53D2gB5qdk": {
     "serverTitle": "My Childhood Role Model",
     "postId": "3Jpchgy53D2gB5qdk",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163181-my-childhood-role-model.js?container_id=buzzsprout-player-11163181&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163181-my-childhood-role-model.js?container_id=buzzsprout-player-11163181&player=small",
     "externalEpisodeId": 11163181
   },
   "5o4EZJyqmHY4XgRCY": {
     "serverTitle": "Einstein's Superpowers",
     "postId": "5o4EZJyqmHY4XgRCY",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163180-einstein-s-superpowers.js?container_id=buzzsprout-player-11163180&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163180-einstein-s-superpowers.js?container_id=buzzsprout-player-11163180&player=small",
     "externalEpisodeId": 11163180
   },
   "xAXrEpF5FYjwqKMfZ": {
     "serverTitle": "Class Project",
     "postId": "xAXrEpF5FYjwqKMfZ",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163179-class-project.js?container_id=buzzsprout-player-11163179&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163179-class-project.js?container_id=buzzsprout-player-11163179&player=small",
     "externalEpisodeId": 11163179
   },
   "afmj8TKAqH6F2QMfZ": {
     "serverTitle": "A Technical Explanation of Technical Explanation",
     "postId": "afmj8TKAqH6F2QMfZ",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163178-interlude-a-technical-explanation-of-technical-explanation.js?container_id=buzzsprout-player-11163178&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163178-interlude-a-technical-explanation-of-technical-explanation.js?container_id=buzzsprout-player-11163178&player=small",
     "externalEpisodeId": 11163178
   },
   "tPWZfmNpstRMCBjFM": {
     "serverTitle": "Beginnings: An Introduction",
     "postId": "tPWZfmNpstRMCBjFM",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163140-beginnings-an-introduction.js?container_id=buzzsprout-player-11163140&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163140-beginnings-an-introduction.js?container_id=buzzsprout-player-11163140&player=small",
     "externalEpisodeId": 11163140
   },
   "uD9TDHPwQ5hx4CgaX": {
     "serverTitle": "My Childhood Death Spiral",
     "postId": "uD9TDHPwQ5hx4CgaX",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163139-my-childhood-death-spiral.js?container_id=buzzsprout-player-11163139&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163139-my-childhood-death-spiral.js?container_id=buzzsprout-player-11163139&player=small",
     "externalEpisodeId": 11163139
   },
   "BA7dRRrzMLyvfJr9J": {
     "serverTitle": "My Best and Worst Mistake",
     "postId": "BA7dRRrzMLyvfJr9J",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163138-my-best-and-worst-mistake.js?container_id=buzzsprout-player-11163138&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163138-my-best-and-worst-mistake.js?container_id=buzzsprout-player-11163138&player=small",
     "externalEpisodeId": 11163138
   },
   "uNWRXtdwL33ELgWjD": {
     "serverTitle": "Raised in Technophilia",
     "postId": "uNWRXtdwL33ELgWjD",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163137-raised-in-technophilia.js?container_id=buzzsprout-player-11163137&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163137-raised-in-technophilia.js?container_id=buzzsprout-player-11163137&player=small",
     "externalEpisodeId": 11163137
   },
   "CcBe9aCKDgT5FSoty": {
     "serverTitle": "A Prodigy of Refutation",
     "postId": "CcBe9aCKDgT5FSoty",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163136-a-prodigy-of-refutation.js?container_id=buzzsprout-player-11163136&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163136-a-prodigy-of-refutation.js?container_id=buzzsprout-player-11163136&player=small",
     "externalEpisodeId": 11163136
   },
   "Yicjw6wSSaPdb83w9": {
     "serverTitle": "The Sheer Folly of Callow Youth",
     "postId": "Yicjw6wSSaPdb83w9",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163135-the-sheer-folly-of-callow-youth.js?container_id=buzzsprout-player-11163135&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163135-the-sheer-folly-of-callow-youth.js?container_id=buzzsprout-player-11163135&player=small",
     "externalEpisodeId": 11163135
   },
   "SwCwG9wZcAzQtckwx": {
     "serverTitle": "That Tiny Note of Discord",
     "postId": "SwCwG9wZcAzQtckwx",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163134-that-tiny-note-of-discord.js?container_id=buzzsprout-player-11163134&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163134-that-tiny-note-of-discord.js?container_id=buzzsprout-player-11163134&player=small",
     "externalEpisodeId": 11163134
   },
   "PCfaLLtuxes6Jk4S2": {
     "serverTitle": "Fighting a Rearguard Action Against the Truth",
     "postId": "PCfaLLtuxes6Jk4S2",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163133-fighting-a-rearguard-action-against-the-truth.js?container_id=buzzsprout-player-11163133&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163133-fighting-a-rearguard-action-against-the-truth.js?container_id=buzzsprout-player-11163133&player=small",
     "externalEpisodeId": 11163133
   },
   "75LZMCCePG4Pwj3dB": {
     "serverTitle": "My Naturalistic Awakening",
     "postId": "75LZMCCePG4Pwj3dB",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163132-my-naturalistic-awakening.js?container_id=buzzsprout-player-11163132&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163132-my-naturalistic-awakening.js?container_id=buzzsprout-player-11163132&player=small",
     "externalEpisodeId": 11163132
   },
   "kXSETKZ3X9oidMozA": {
     "serverTitle": "The Level Above Mine",
     "postId": "kXSETKZ3X9oidMozA",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163131-the-level-above-mine.js?container_id=buzzsprout-player-11163131&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163131-the-level-above-mine.js?container_id=buzzsprout-player-11163131&player=small",
     "externalEpisodeId": 11163131
   },
   "fLRPeXihRaiRo5dyX": {
     "serverTitle": "The Magnitude of His Own Folly",
     "postId": "fLRPeXihRaiRo5dyX",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163130-the-magnitude-of-his-own-folly.js?container_id=buzzsprout-player-11163130&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163130-the-magnitude-of-his-own-folly.js?container_id=buzzsprout-player-11163130&player=small",
     "externalEpisodeId": 11163130
   },
   "sYgv4eYH82JEsTD34": {
     "serverTitle": "Beyond the Reach of God",
     "postId": "sYgv4eYH82JEsTD34",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163129-beyond-the-reach-of-god.js?container_id=buzzsprout-player-11163129&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163129-beyond-the-reach-of-god.js?container_id=buzzsprout-player-11163129&player=small",
     "externalEpisodeId": 11163129
   },
   "Ti3Z7eZtud32LhGZT": {
     "serverTitle": "My Bayesian Enlightenment",
     "postId": "Ti3Z7eZtud32LhGZT",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163128-my-bayesian-enlightenment.js?container_id=buzzsprout-player-11163128&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163128-my-bayesian-enlightenment.js?container_id=buzzsprout-player-11163128&player=small",
     "externalEpisodeId": 11163128
   },
   "WLJwTJ7uGPA5Qphbp": {
     "serverTitle": "Trying to Try",
     "postId": "WLJwTJ7uGPA5Qphbp",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163125-trying-to-try.js?container_id=buzzsprout-player-11163125&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163125-trying-to-try.js?container_id=buzzsprout-player-11163125&player=small",
     "externalEpisodeId": 11163125
   },
   "fhEPnveFhb9tmd7Pe": {
     "serverTitle": "Use the Try Harder, Luke",
     "postId": "fhEPnveFhb9tmd7Pe",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163124-use-the-try-harder-luke.js?container_id=buzzsprout-player-11163124&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163124-use-the-try-harder-luke.js?container_id=buzzsprout-player-11163124&player=small",
     "externalEpisodeId": 11163124
   },
   "fpecAJLG9czABgCe9": {
     "serverTitle": "On Doing the Impossible",
     "postId": "fpecAJLG9czABgCe9",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163123-on-doing-the-impossible.js?container_id=buzzsprout-player-11163123&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163123-on-doing-the-impossible.js?container_id=buzzsprout-player-11163123&player=small",
     "externalEpisodeId": 11163123
   },
   "GuEsfTpSDSbXFiseH": {
     "serverTitle": "Make an Extraordinary Effort",
     "postId": "GuEsfTpSDSbXFiseH",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163122-make-an-extraordinary-effort.js?container_id=buzzsprout-player-11163122&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163122-make-an-extraordinary-effort.js?container_id=buzzsprout-player-11163122&player=small",
     "externalEpisodeId": 11163122
   },
   "nCvvhFBaayaXyuBiD": {
     "serverTitle": "Shut up and do the impossible!",
     "postId": "nCvvhFBaayaXyuBiD",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163121-shut-up-and-do-the-impossible.js?container_id=buzzsprout-player-11163121&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163121-shut-up-and-do-the-impossible.js?container_id=buzzsprout-player-11163121&player=small",
     "externalEpisodeId": 11163121
   },
   "yffPyiu7hRLyc7r23": {
     "serverTitle": "Final Words",
     "postId": "yffPyiu7hRLyc7r23",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163120-final-words.js?container_id=buzzsprout-player-11163120&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163120-final-words.js?container_id=buzzsprout-player-11163120&player=small",
     "externalEpisodeId": 11163120
   },
   "XqmjdBKa4ZaXJtNmf": {
     "serverTitle": "Raising the Sanity Waterline",
     "postId": "XqmjdBKa4ZaXJtNmf",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163119-pt-z-raising-the-sanity-waterline.js?container_id=buzzsprout-player-11163119&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163119-pt-z-raising-the-sanity-waterline.js?container_id=buzzsprout-player-11163119&player=small",
     "externalEpisodeId": 11163119
   },
   "Nu3wa6npK4Ry66vFp": {
     "serverTitle": "A Sense That More Is Possible",
     "postId": "Nu3wa6npK4Ry66vFp",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163118-a-sense-that-more-is-possible.js?container_id=buzzsprout-player-11163118&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163118-a-sense-that-more-is-possible.js?container_id=buzzsprout-player-11163118&player=small",
     "externalEpisodeId": 11163118
   },
   "T8ddXNtmNSHexhQh8": {
     "serverTitle": "Epistemic Viciousness",
     "postId": "T8ddXNtmNSHexhQh8",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163117-epistemic-viciousness.js?container_id=buzzsprout-player-11163117&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163117-epistemic-viciousness.js?container_id=buzzsprout-player-11163117&player=small",
     "externalEpisodeId": 11163117
   },
   "JnKCaGcgZL4Rsep8m": {
     "serverTitle": "Schools Proliferating Without Evidence",
     "postId": "JnKCaGcgZL4Rsep8m",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163116-schools-proliferating-without-evidence.js?container_id=buzzsprout-player-11163116&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163116-schools-proliferating-without-evidence.js?container_id=buzzsprout-player-11163116&player=small",
     "externalEpisodeId": 11163116
   },
   "5K7CMa6dEL7TN7sae": {
     "serverTitle": "3 Levels of Rationality Verification",
     "postId": "5K7CMa6dEL7TN7sae",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163115-3-levels-of-rationality-verification.js?container_id=buzzsprout-player-11163115&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163115-3-levels-of-rationality-verification.js?container_id=buzzsprout-player-11163115&player=small",
     "externalEpisodeId": 11163115
   },
   "7FzD7pNm9X68Gp5ZC": {
     "serverTitle": "Why Our Kind Can't Cooperate",
     "postId": "7FzD7pNm9X68Gp5ZC",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163114-why-our-kind-can-t-cooperate.js?container_id=buzzsprout-player-11163114&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163114-why-our-kind-can-t-cooperate.js?container_id=buzzsprout-player-11163114&player=small",
     "externalEpisodeId": 11163114
   },
   "JKxxFseBWz8SHkTgt": {
     "serverTitle": "Tolerate Tolerance",
     "postId": "JKxxFseBWz8SHkTgt",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163113-tolerate-tolerance.js?container_id=buzzsprout-player-11163113&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163113-tolerate-tolerance.js?container_id=buzzsprout-player-11163113&player=small",
     "externalEpisodeId": 11163113
   },
   "Q8evewZW5SeidLdbA": {
     "serverTitle": "Your Price for Joining",
     "postId": "Q8evewZW5SeidLdbA",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163112-your-price-for-joining.js?container_id=buzzsprout-player-11163112&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163112-your-price-for-joining.js?container_id=buzzsprout-player-11163112&player=small",
     "externalEpisodeId": 11163112
   },
   "3fNL2ssfvRzpApvdN": {
     "serverTitle": "Can Humanism Match Religion's Output?",
     "postId": "3fNL2ssfvRzpApvdN",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163111-can-humanism-match-religions-output.js?container_id=buzzsprout-player-11163111&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163111-can-humanism-match-religions-output.js?container_id=buzzsprout-player-11163111&player=small",
     "externalEpisodeId": 11163111
   },
   "p5DmraxDmhvMoZx8J": {
     "serverTitle": "Church vs. Taskforce",
     "postId": "p5DmraxDmhvMoZx8J",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163110-church-vs-taskforce.js?container_id=buzzsprout-player-11163110&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163110-church-vs-taskforce.js?container_id=buzzsprout-player-11163110&player=small",
     "externalEpisodeId": 11163110
   },
   "4PPE6D635iBcGPGRy": {
     "serverTitle": "Rationality: Common Interest of Many Causes",
     "postId": "4PPE6D635iBcGPGRy",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163109-rationality-common-interest-of-many-causes.js?container_id=buzzsprout-player-11163109&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163109-rationality-common-interest-of-many-causes.js?container_id=buzzsprout-player-11163109&player=small",
     "externalEpisodeId": 11163109
   },
   "f42BHX7rMw2dyFJfT": {
     "serverTitle": "Helpless Individuals",
     "postId": "f42BHX7rMw2dyFJfT",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163108-helpless-individuals.js?container_id=buzzsprout-player-11163108&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163108-helpless-individuals.js?container_id=buzzsprout-player-11163108&player=small",
     "externalEpisodeId": 11163108
   },
   "ZpDnRCeef2CLEFeKM": {
     "serverTitle": "Money: The Unit of Caring",
     "postId": "ZpDnRCeef2CLEFeKM",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163107-money-the-unit-of-caring.js?container_id=buzzsprout-player-11163107&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163107-money-the-unit-of-caring.js?container_id=buzzsprout-player-11163107&player=small",
     "externalEpisodeId": 11163107
   },
   "3p3CYauiX8oLjmwRF": {
     "serverTitle": "Purchase Fuzzies and Utilons Separately",
     "postId": "3p3CYauiX8oLjmwRF",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163106-purchase-fuzzies-and-utilons-separately.js?container_id=buzzsprout-player-11163106&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163106-purchase-fuzzies-and-utilons-separately.js?container_id=buzzsprout-player-11163106&player=small",
     "externalEpisodeId": 11163106
   },
   "oZNXmHcdhb4m7vwsv": {
     "serverTitle": "Incremental Progress and the Valley",
     "postId": "oZNXmHcdhb4m7vwsv",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163105-incremental-progress-and-the-valley.js?container_id=buzzsprout-player-11163105&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163105-incremental-progress-and-the-valley.js?container_id=buzzsprout-player-11163105&player=small",
     "externalEpisodeId": 11163105
   },
   "KsHmn6iJAEr9bACQW": {
     "serverTitle": "Bayesians vs. Barbarians",
     "postId": "KsHmn6iJAEr9bACQW",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163104-bayesians-vs-barbarians.js?container_id=buzzsprout-player-11163104&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163104-bayesians-vs-barbarians.js?container_id=buzzsprout-player-11163104&player=small",
     "externalEpisodeId": 11163104
   },
   "6NvbSwuSAooQxxf7f": {
     "serverTitle": "Beware of Other-Optimizing",
     "postId": "6NvbSwuSAooQxxf7f",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163103-beware-of-other-optimizing.js?container_id=buzzsprout-player-11163103&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163103-beware-of-other-optimizing.js?container_id=buzzsprout-player-11163103&player=small",
     "externalEpisodeId": 11163103
   },
   "LqjKP255fPRY7aMzw": {
     "serverTitle": "Practical Advice Backed By Deep Theories",
     "postId": "LqjKP255fPRY7aMzw",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163102-practical-advice-backed-by-deep-theories.js?container_id=buzzsprout-player-11163102&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163102-practical-advice-backed-by-deep-theories.js?container_id=buzzsprout-player-11163102&player=small",
     "externalEpisodeId": 11163102
   },
   "pkFazhcTErMw7TFtT": {
     "serverTitle": "The Sin of Underconfidence",
     "postId": "pkFazhcTErMw7TFtT",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11155707-the-sin-of-underconfidence.js?container_id=buzzsprout-player-11155707&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11155707-the-sin-of-underconfidence.js?container_id=buzzsprout-player-11155707&player=small",
     "externalEpisodeId": 11155707
   },
   "aFEsqd6ofwnkNqaXo": {
     "serverTitle": "Go Forth and Create the Art!",
     "postId": "aFEsqd6ofwnkNqaXo",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11155706-go-forth-and-create-the-art.js?container_id=buzzsprout-player-11155706&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11155706-go-forth-and-create-the-art.js?container_id=buzzsprout-player-11155706&player=small",
     "externalEpisodeId": 11155706
   },
   "8qccXytpkEhEAkjjM": {
     "serverTitle": "Rationality: An Introduction",
     "postId": "8qccXytpkEhEAkjjM",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163395-rationality-an-introduction.js?container_id=buzzsprout-player-11163395&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163395-rationality-an-introduction.js?container_id=buzzsprout-player-11163395&player=small",
     "externalEpisodeId": 11163395
   },
   "DoLQN5ryZ9XkZjq5h": {
     "serverTitle": "Tsuyoku Naritai! (I Want To Become Stronger)",
     "postId": "DoLQN5ryZ9XkZjq5h",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163127-tsuyoku-naritai-i-want-to-become-stronger.js?container_id=buzzsprout-player-11163127&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163127-tsuyoku-naritai-i-want-to-become-stronger.js?container_id=buzzsprout-player-11163127&player=small",
     "externalEpisodeId": 11163127
   },
   "GrDqnMjhqoxiqpQPw": {
     "serverTitle": "The Proper Use of Humility",
     "postId": "GrDqnMjhqoxiqpQPw",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163394-the-proper-use-of-humility.js?container_id=buzzsprout-player-11163394&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163394-the-proper-use-of-humility.js?container_id=buzzsprout-player-11163394&player=small",
     "externalEpisodeId": 11163394
   },
   "gWGA8Da539EQmAR9F": {
     "serverTitle": "Tsuyoku vs. the Egalitarian Instinct",
     "postId": "gWGA8Da539EQmAR9F",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163126-tsuyoku-vs-the-egalitarian-instinct.js?container_id=buzzsprout-player-11163126&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163126-tsuyoku-vs-the-egalitarian-instinct.js?container_id=buzzsprout-player-11163126&player=small",
     "externalEpisodeId": 11163126
   },
   "erGipespbbzdG5zYb": {
     "serverTitle": "The Third Alternative",
     "postId": "erGipespbbzdG5zYb",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163393-the-third-alternative.js?container_id=buzzsprout-player-11163393&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163393-the-third-alternative.js?container_id=buzzsprout-player-11163393&player=small",
     "externalEpisodeId": 11163393
   },
   "vYsuM8cpuRgZS5rYB": {
     "serverTitle": "Lotteries: A Waste of Hope",
     "postId": "vYsuM8cpuRgZS5rYB",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163392-lotteries-a-waste-of-hope.js?container_id=buzzsprout-player-11163392&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163392-lotteries-a-waste-of-hope.js?container_id=buzzsprout-player-11163392&player=small",
     "externalEpisodeId": 11163392
   },
   "QawvGzYWhqdyPWgBL": {
     "serverTitle": "New Improved Lottery",
     "postId": "QawvGzYWhqdyPWgBL",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163391-new-improved-lottery.js?container_id=buzzsprout-player-11163391&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163391-new-improved-lottery.js?container_id=buzzsprout-player-11163391&player=small",
     "externalEpisodeId": 11163391
   },
   "q7Me34xvSG3Wm97As": {
     "serverTitle": "But There's Still A Chance, Right?",
     "postId": "q7Me34xvSG3Wm97As",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163390-but-there-s-still-a-chance-right.js?container_id=buzzsprout-player-11163390&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163390-but-there-s-still-a-chance-right.js?container_id=buzzsprout-player-11163390&player=small",
     "externalEpisodeId": 11163390
   },
   "dLJv2CoRCgeC2mPgj": {
     "serverTitle": "The Fallacy of Gray",
     "postId": "dLJv2CoRCgeC2mPgj",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163389-the-fallacy-of-gray.js?container_id=buzzsprout-player-11163389&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163389-the-fallacy-of-gray.js?container_id=buzzsprout-player-11163389&player=small",
     "externalEpisodeId": 11163389
   },
   "PmQkensvTGg7nGtJE": {
     "serverTitle": "Absolute Authority",
     "postId": "PmQkensvTGg7nGtJE",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163387-absolute-authority.js?container_id=buzzsprout-player-11163387&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163387-absolute-authority.js?container_id=buzzsprout-player-11163387&player=small",
     "externalEpisodeId": 11163387
   },
   "6FmqiAgS8h4EJm86s": {
     "serverTitle": "How to Convince Me That 2 + 2 = 3",
     "postId": "6FmqiAgS8h4EJm86s",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11167197-how-to-convince-me-that-2-2-3.js?container_id=buzzsprout-player-11167197&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11167197-how-to-convince-me-that-2-2-3.js?container_id=buzzsprout-player-11167197&player=small",
     "externalEpisodeId": 11167197
   },
   "ooypcn7qFzsMcy53R": {
     "serverTitle": "Infinite Certainty",
     "postId": "ooypcn7qFzsMcy53R",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163385-infinite-certainty.js?container_id=buzzsprout-player-11163385&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163385-infinite-certainty.js?container_id=buzzsprout-player-11163385&player=small",
     "externalEpisodeId": 11163385
   },
   "QGkYCwyC7wTDyt3yT": {
     "serverTitle": "0 And 1 Are Not Probabilities",
     "postId": "QGkYCwyC7wTDyt3yT",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163384-0-and-1-are-not-probabilities.js?container_id=buzzsprout-player-11163384&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163384-0-and-1-are-not-probabilities.js?container_id=buzzsprout-player-11163384&player=small",
     "externalEpisodeId": 11163384
   },
   "anCubLdggTWjnEvBS": {
     "serverTitle": "Your Rationality is My Business",
     "postId": "anCubLdggTWjnEvBS",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163383-your-rationality-is-my-business.js?container_id=buzzsprout-player-11163383&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163383-your-rationality-is-my-business.js?container_id=buzzsprout-player-11163383&player=small",
     "externalEpisodeId": 11163383
   },
   "9weLK2AJ9JEt2Tt8f": {
     "serverTitle": "Politics is the Mind-Killer",
     "postId": "9weLK2AJ9JEt2Tt8f",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163382-politics-is-the-mind-killer.js?container_id=buzzsprout-player-11163382&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163382-politics-is-the-mind-killer.js?container_id=buzzsprout-player-11163382&player=small",
     "externalEpisodeId": 11163382
   },
   "PeSzc9JTBxhaYRp9b": {
     "serverTitle": "Policy Debates Should Not Appear One-Sided",
     "postId": "PeSzc9JTBxhaYRp9b",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163381-policy-debates-should-not-appear-one-sided.js?container_id=buzzsprout-player-11163381&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163381-policy-debates-should-not-appear-one-sided.js?container_id=buzzsprout-player-11163381&player=small",
     "externalEpisodeId": 11163381
   },
   "XYCEB9roxEBfgjfxs": {
     "serverTitle": "The Scales of Justice, the Notebook of Rationality",
     "postId": "XYCEB9roxEBfgjfxs",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163380-the-scales-of-justice-the-notebook-of-rationality.js?container_id=buzzsprout-player-11163380&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163380-the-scales-of-justice-the-notebook-of-rationality.js?container_id=buzzsprout-player-11163380&player=small",
     "externalEpisodeId": 11163380
   },
   "DB6wbyrMugYMK5o6a": {
     "serverTitle": "Correspondence Bias",
     "postId": "DB6wbyrMugYMK5o6a",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163379-correspondence-bias.js?container_id=buzzsprout-player-11163379&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163379-correspondence-bias.js?container_id=buzzsprout-player-11163379&player=small",
     "externalEpisodeId": 11163379
   },
   "28bAMAxhoX3bwbAKC": {
     "serverTitle": "Are Your Enemies Innately Evil?",
     "postId": "28bAMAxhoX3bwbAKC",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163378-are-your-enemies-innately-evil.js?container_id=buzzsprout-player-11163378&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163378-are-your-enemies-innately-evil.js?container_id=buzzsprout-player-11163378&player=small",
     "externalEpisodeId": 11163378
   },
   "qNZM3EGoE5ZeMdCRt": {
     "serverTitle": "Reversed Stupidity Is Not Intelligence",
     "postId": "qNZM3EGoE5ZeMdCRt",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163377-reversed-stupidity-is-not-intelligence.js?container_id=buzzsprout-player-11163377&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163377-reversed-stupidity-is-not-intelligence.js?container_id=buzzsprout-player-11163377&player=small",
     "externalEpisodeId": 11163377
   },
   "5yFRd3cjLpm3Nd6Di": {
     "serverTitle": "Argument Screens Off Authority",
     "postId": "5yFRd3cjLpm3Nd6Di",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163376-argument-screens-off-authority.js?container_id=buzzsprout-player-11163376&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163376-argument-screens-off-authority.js?container_id=buzzsprout-player-11163376&player=small",
     "externalEpisodeId": 11163376
   },
   "2jp98zdLo898qExrr": {
     "serverTitle": "Hug the Query",
     "postId": "2jp98zdLo898qExrr",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163375-hug-the-query.js?container_id=buzzsprout-player-11163375&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163375-hug-the-query.js?container_id=buzzsprout-player-11163375&player=small",
     "externalEpisodeId": 11163375
   },
   "Lz64L3yJEtYGkzMzu": {
     "serverTitle": "Rationality and the English Language",
     "postId": "Lz64L3yJEtYGkzMzu",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163374-rationality-and-the-english-language.js?container_id=buzzsprout-player-11163374&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163374-rationality-and-the-english-language.js?container_id=buzzsprout-player-11163374&player=small",
     "externalEpisodeId": 11163374
   },
   "i8q4vXestDkGTFwsc": {
     "serverTitle": "Human Evil and Muddled Thinking",
     "postId": "i8q4vXestDkGTFwsc",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163373-human-evil-and-muddled-thinking.js?container_id=buzzsprout-player-11163373&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163373-human-evil-and-muddled-thinking.js?container_id=buzzsprout-player-11163373&player=small",
     "externalEpisodeId": 11163373
   },
   "AdYdLP2sRqPMoe8fb": {
     "serverTitle": "Knowing About Biases Can Hurt People",
     "postId": "AdYdLP2sRqPMoe8fb",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163372-knowing-about-biases-can-hurt-people.js?container_id=buzzsprout-player-11163372&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163372-knowing-about-biases-can-hurt-people.js?container_id=buzzsprout-player-11163372&player=small",
     "externalEpisodeId": 11163372
   },
   "627DZcvme7nLDrbZu": {
     "serverTitle": "Update Yourself Incrementally",
     "postId": "627DZcvme7nLDrbZu",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163371-update-yourself-incrementally.js?container_id=buzzsprout-player-11163371&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163371-update-yourself-incrementally.js?container_id=buzzsprout-player-11163371&player=small",
     "externalEpisodeId": 11163371
   },
   "WN73eiLQkuDtSC8Ag": {
     "serverTitle": "One Argument Against An Army",
     "postId": "WN73eiLQkuDtSC8Ag",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163370-one-argument-against-an-army.js?container_id=buzzsprout-player-11163370&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163370-one-argument-against-an-army.js?container_id=buzzsprout-player-11163370&player=small",
     "externalEpisodeId": 11163370
   },
   "34XxbRFe54FycoCDw": {
     "serverTitle": "The Bottom Line",
     "postId": "34XxbRFe54FycoCDw",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163369-the-bottom-line.js?container_id=buzzsprout-player-11163369&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163369-the-bottom-line.js?container_id=buzzsprout-player-11163369&player=small",
     "externalEpisodeId": 11163369
   },
   "kJiPnaQPiy4p9Eqki": {
     "serverTitle": "What Evidence Filtered Evidence?",
     "postId": "kJiPnaQPiy4p9Eqki",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163368-what-evidence-filtered-evidence.js?container_id=buzzsprout-player-11163368&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163368-what-evidence-filtered-evidence.js?container_id=buzzsprout-player-11163368&player=small",
     "externalEpisodeId": 11163368
   },
   "SFZoEBpLo9frSJGkc": {
     "serverTitle": "Rationalization",
     "postId": "SFZoEBpLo9frSJGkc",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163367-rationalization.js?container_id=buzzsprout-player-11163367&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163367-rationalization.js?container_id=buzzsprout-player-11163367&player=small",
     "externalEpisodeId": 11163367
   },
   "9f5EXt8KNNxTAihtZ": {
     "serverTitle": "A Rational Argument",
     "postId": "9f5EXt8KNNxTAihtZ",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163366-a-rational-argument.js?container_id=buzzsprout-player-11163366&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163366-a-rational-argument.js?container_id=buzzsprout-player-11163366&player=small",
     "externalEpisodeId": 11163366
   },
   "dHQkDNMhj692ayx78": {
     "serverTitle": "Avoiding Your Belief's Real Weak Points",
     "postId": "dHQkDNMhj692ayx78",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163365-avoiding-your-belief-s-real-weak-points.js?container_id=buzzsprout-player-11163365&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163365-avoiding-your-belief-s-real-weak-points.js?container_id=buzzsprout-player-11163365&player=small",
     "externalEpisodeId": 11163365
   },
   "L32LHWzy9FzSDazEg": {
     "serverTitle": "Motivated Stopping and Motivated Continuation",
     "postId": "L32LHWzy9FzSDazEg",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163364-motivated-stopping-and-motivated-continuation.js?container_id=buzzsprout-player-11163364&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163364-motivated-stopping-and-motivated-continuation.js?container_id=buzzsprout-player-11163364&player=small",
     "externalEpisodeId": 11163364
   },
   "bfbiyTogEKWEGP96S": {
     "serverTitle": "Fake Justification",
     "postId": "bfbiyTogEKWEGP96S",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163363-fake-justification.js?container_id=buzzsprout-player-11163363&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163363-fake-justification.js?container_id=buzzsprout-player-11163363&player=small",
     "externalEpisodeId": 11163363
   },
   "TGux5Fhcd7GmTfNGC": {
     "serverTitle": "Is That Your True Rejection?",
     "postId": "TGux5Fhcd7GmTfNGC",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163362-is-that-your-true-rejection.js?container_id=buzzsprout-player-11163362&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163362-is-that-your-true-rejection.js?container_id=buzzsprout-player-11163362&player=small",
     "externalEpisodeId": 11163362
   },
   "wyyfFfaRar2jEdeQK": {
     "serverTitle": "Entangled Truths, Contagious Lies",
     "postId": "wyyfFfaRar2jEdeQK",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163361-entangled-truths-contagious-lies.js?container_id=buzzsprout-player-11163361&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163361-entangled-truths-contagious-lies.js?container_id=buzzsprout-player-11163361&player=small",
     "externalEpisodeId": 11163361
   },
   "E7CKXxtGKPmdM9ZRc": {
     "serverTitle": "Of Lies and Black Swan Blowups",
     "postId": "E7CKXxtGKPmdM9ZRc",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163360-of-lies-and-black-swan-blow-ups.js?container_id=buzzsprout-player-11163360&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163360-of-lies-and-black-swan-blow-ups.js?container_id=buzzsprout-player-11163360&player=small",
     "externalEpisodeId": 11163360
   },
   "XTWkjCJScy2GFAgDt": {
     "serverTitle": "Dark Side Epistemology",
     "postId": "XTWkjCJScy2GFAgDt",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163359-dark-side-epistemology.js?container_id=buzzsprout-player-11163359&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163359-dark-side-epistemology.js?container_id=buzzsprout-player-11163359&player=small",
     "externalEpisodeId": 11163359
   },
   "Hs3ymqypvhgFMkgLb": {
     "serverTitle": "Doublethink (Choosing to be Biased)",
     "postId": "Hs3ymqypvhgFMkgLb",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163357-doublethink-choosing-to-be-biased.js?container_id=buzzsprout-player-11163357&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163357-doublethink-choosing-to-be-biased.js?container_id=buzzsprout-player-11163357&player=small",
     "externalEpisodeId": 11163357
   },
   "rZX4WuufAPbN6wQTv": {
     "serverTitle": "No, Really, I've Deceived Myself",
     "postId": "rZX4WuufAPbN6wQTv",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163356-no-really-i-ve-deceived-myself.js?container_id=buzzsprout-player-11163356&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163356-no-really-i-ve-deceived-myself.js?container_id=buzzsprout-player-11163356&player=small",
     "externalEpisodeId": 11163356
   },
   "wP2ymm44kZZwaFPYh": {
     "serverTitle": "Belief in Self-Deception",
     "postId": "wP2ymm44kZZwaFPYh",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163355-belief-in-self-deception.js?container_id=buzzsprout-player-11163355&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163355-belief-in-self-deception.js?container_id=buzzsprout-player-11163355&player=small",
     "externalEpisodeId": 11163355
   },
   "ERRk4thxxYNcScqR4": {
     "serverTitle": "Moore's Paradox",
     "postId": "ERRk4thxxYNcScqR4",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163354-moore-s-paradox.js?container_id=buzzsprout-player-11163354&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163354-moore-s-paradox.js?container_id=buzzsprout-player-11163354&player=small",
     "externalEpisodeId": 11163354
   },
   "W7LcN9gmdnaAk9K52": {
     "serverTitle": "Don't Believe You'll Self-Deceive",
     "postId": "W7LcN9gmdnaAk9K52",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163353-don-t-believe-you-ll-self-deceive.js?container_id=buzzsprout-player-11163353&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163353-don-t-believe-you-ll-self-deceive.js?container_id=buzzsprout-player-11163353&player=small",
     "externalEpisodeId": 11163353
   },
   "bMkCEZoBNhgRBtzoj": {
     "serverTitle": "Anchoring and Adjustment",
     "postId": "bMkCEZoBNhgRBtzoj",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163352-anchoring-and-adjustment.js?container_id=buzzsprout-player-11163352&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163352-anchoring-and-adjustment.js?container_id=buzzsprout-player-11163352&player=small",
     "externalEpisodeId": 11163352
   },
   "BaCWFCxBQYjJXSsah": {
     "serverTitle": "Priming and Contamination",
     "postId": "BaCWFCxBQYjJXSsah",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163351-priming-and-contamination.js?container_id=buzzsprout-player-11163351&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163351-priming-and-contamination.js?container_id=buzzsprout-player-11163351&player=small",
     "externalEpisodeId": 11163351
   },
   "TiDGXt3WrQwtCdDj3": {
     "serverTitle": "Do We Believe Everything We're Told?",
     "postId": "TiDGXt3WrQwtCdDj3",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163350-do-we-believe-everything-we-re-told.js?container_id=buzzsprout-player-11163350&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163350-do-we-believe-everything-we-re-told.js?container_id=buzzsprout-player-11163350&player=small",
     "externalEpisodeId": 11163350
   },
   "2MD3NMLBPCqPfnfre": {
     "serverTitle": "Cached Thoughts",
     "postId": "2MD3NMLBPCqPfnfre",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163349-cached-thoughts.js?container_id=buzzsprout-player-11163349&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163349-cached-thoughts.js?container_id=buzzsprout-player-11163349&player=small",
     "externalEpisodeId": 11163349
   },
   "SA79JMXKWke32A3hG": {
     "serverTitle": "Original Seeing",
     "postId": "SA79JMXKWke32A3hG",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163347-original-seeing.js?container_id=buzzsprout-player-11163347&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163347-original-seeing.js?container_id=buzzsprout-player-11163347&player=small",
     "externalEpisodeId": 11163347
   },
   "yDfxTj9TKYsYiWH5o": {
     "serverTitle": "The Virtue of Narrowness",
     "postId": "yDfxTj9TKYsYiWH5o",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163344-the-virtue-of-narrowness.js?container_id=buzzsprout-player-11163344&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163344-the-virtue-of-narrowness.js?container_id=buzzsprout-player-11163344&player=small",
     "externalEpisodeId": 11163344
   },
   "h3vdnR34ZvohDEFT5": {
     "serverTitle": "Stranger Than History",
     "postId": "h3vdnR34ZvohDEFT5",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163346-stranger-than-history.js?container_id=buzzsprout-player-11163346&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163346-stranger-than-history.js?container_id=buzzsprout-player-11163346&player=small",
     "externalEpisodeId": 11163346
   },
   "rHBdcHGLJ7KvLJQPk": {
     "serverTitle": "The Logical Fallacy of Generalization from Fictional Evidence",
     "postId": "rHBdcHGLJ7KvLJQPk",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163345-the-logical-fallacy-of-generalization-from-fictional-evidence.js?container_id=buzzsprout-player-11163345&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163345-the-logical-fallacy-of-generalization-from-fictional-evidence.js?container_id=buzzsprout-player-11163345&player=small",
     "externalEpisodeId": 11163345
   },
   "buixYfcXBah9hbSNZ": {
     "serverTitle": "We Change Our Minds Less Often Than We Think",
     "postId": "buixYfcXBah9hbSNZ",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163342-we-change-our-minds-less-often-than-we-think.js?container_id=buzzsprout-player-11163342&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163342-we-change-our-minds-less-often-than-we-think.js?container_id=buzzsprout-player-11163342&player=small",
     "externalEpisodeId": 11163342
   },
   "uHYYA32CKgKT3FagE": {
     "serverTitle": "Hold Off On Proposing Solutions",
     "postId": "uHYYA32CKgKT3FagE",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163341-hold-off-on-proposing-solutions.js?container_id=buzzsprout-player-11163341&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163341-hold-off-on-proposing-solutions.js?container_id=buzzsprout-player-11163341&player=small",
     "externalEpisodeId": 11163341
   },
   "KZLa74SzyKhSJ3M55": {
     "serverTitle": "The Genetic Fallacy",
     "postId": "KZLa74SzyKhSJ3M55",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163340-the-genetic-fallacy.js?container_id=buzzsprout-player-11163340&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163340-the-genetic-fallacy.js?container_id=buzzsprout-player-11163340&player=small",
     "externalEpisodeId": 11163340
   },
   "Kow8xRzpfkoY7pa69": {
     "serverTitle": "The Affect Heuristic",
     "postId": "Kow8xRzpfkoY7pa69",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163339-the-affect-heuristic.js?container_id=buzzsprout-player-11163339&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163339-the-affect-heuristic.js?container_id=buzzsprout-player-11163339&player=small",
     "externalEpisodeId": 11163339
   },
   "3T6p93Mut7G8qdkAs": {
     "serverTitle": "Evaluability (And Cheap Holiday Shopping)",
     "postId": "3T6p93Mut7G8qdkAs",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163338-evaluability-and-cheap-holiday-shopping.js?container_id=buzzsprout-player-11163338&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163338-evaluability-and-cheap-holiday-shopping.js?container_id=buzzsprout-player-11163338&player=small",
     "externalEpisodeId": 11163338
   },
   "5u5THLyRkTpPHiaG5": {
     "serverTitle": "Unbounded Scales, Huge Jury Awards, & Futurism",
     "postId": "5u5THLyRkTpPHiaG5",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163337-unbounded-scales-huge-jury-awards-futurism.js?container_id=buzzsprout-player-11163337&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163337-unbounded-scales-huge-jury-awards-futurism.js?container_id=buzzsprout-player-11163337&player=small",
     "externalEpisodeId": 11163337
   },
   "ACGeaAk6KButv2xwQ": {
     "serverTitle": "The Halo Effect",
     "postId": "ACGeaAk6KButv2xwQ",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163336-the-halo-effect.js?container_id=buzzsprout-player-11163336&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163336-the-halo-effect.js?container_id=buzzsprout-player-11163336&player=small",
     "externalEpisodeId": 11163336
   },
   "krMzmSXgvEdf7iBT6": {
     "serverTitle": "Superhero Bias",
     "postId": "krMzmSXgvEdf7iBT6",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163335-superhero-bias.js?container_id=buzzsprout-player-11163335&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163335-superhero-bias.js?container_id=buzzsprout-player-11163335&player=small",
     "externalEpisodeId": 11163335
   },
   "XrzQW69HpidzvBxGr": {
     "serverTitle": "Affective Death Spirals",
     "postId": "XrzQW69HpidzvBxGr",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163333-affective-death-spirals.js?container_id=buzzsprout-player-11163333&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163333-affective-death-spirals.js?container_id=buzzsprout-player-11163333&player=small",
     "externalEpisodeId": 11163333
   },
   "hwi8JQjspnMWyWs4g": {
     "serverTitle": "Resist the Happy Death Spiral",
     "postId": "hwi8JQjspnMWyWs4g",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163332-resist-the-happy-death-spiral.js?container_id=buzzsprout-player-11163332&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163332-resist-the-happy-death-spiral.js?container_id=buzzsprout-player-11163332&player=small",
     "externalEpisodeId": 11163332
   },
   "NCefvet6X3Sd4wrPc": {
     "serverTitle": "Uncritical Supercriticality",
     "postId": "NCefvet6X3Sd4wrPc",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163331-uncritical-supercriticality.js?container_id=buzzsprout-player-11163331&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163331-uncritical-supercriticality.js?container_id=buzzsprout-player-11163331&player=small",
     "externalEpisodeId": 11163331
   },
   "ZQG9cwKbct2LtmL3p": {
     "serverTitle": "Evaporative Cooling of Group Beliefs",
     "postId": "ZQG9cwKbct2LtmL3p",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163330-evaporative-cooling-of-group-beliefs.js?container_id=buzzsprout-player-11163330&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163330-evaporative-cooling-of-group-beliefs.js?container_id=buzzsprout-player-11163330&player=small",
     "externalEpisodeId": 11163330
   },
   "Tw9cLvzSKrkGjNHW3": {
     "serverTitle": "When None Dare Urge Restraint",
     "postId": "Tw9cLvzSKrkGjNHW3",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163329-when-none-dare-urge-restraint.js?container_id=buzzsprout-player-11163329&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163329-when-none-dare-urge-restraint.js?container_id=buzzsprout-player-11163329&player=small",
     "externalEpisodeId": 11163329
   },
   "yEjaj7PWacno5EvWa": {
     "serverTitle": "Every Cause Wants To Be A Cult",
     "postId": "yEjaj7PWacno5EvWa",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163327-every-cause-wants-to-be-a-cult.js?container_id=buzzsprout-player-11163327&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163327-every-cause-wants-to-be-a-cult.js?container_id=buzzsprout-player-11163327&player=small",
     "externalEpisodeId": 11163327
   },
   "Qr4MB9hFRzamuMRHJ": {
     "serverTitle": "Two Cult Koans",
     "postId": "Qr4MB9hFRzamuMRHJ",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163323-two-cult-koans.js?container_id=buzzsprout-player-11163323&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163323-two-cult-koans.js?container_id=buzzsprout-player-11163323&player=small",
     "externalEpisodeId": 11163323
   },
   "WHK94zXkQm7qm7wXk": {
     "serverTitle": "Asch's Conformity Experiment",
     "postId": "WHK94zXkQm7qm7wXk",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163322-asch-s-conformity-experiment.js?container_id=buzzsprout-player-11163322&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163322-asch-s-conformity-experiment.js?container_id=buzzsprout-player-11163322&player=small",
     "externalEpisodeId": 11163322
   },
   "ovvwAhKKoNbfcMz8K": {
     "serverTitle": "On Expressing Your Concerns",
     "postId": "ovvwAhKKoNbfcMz8K",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163321-on-expressing-your-concerns.js?container_id=buzzsprout-player-11163321&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163321-on-expressing-your-concerns.js?container_id=buzzsprout-player-11163321&player=small",
     "externalEpisodeId": 11163321
   },
   "CEGnJBHmkcwPTysb7": {
     "serverTitle": "Lonely Dissent",
     "postId": "CEGnJBHmkcwPTysb7",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163320-lonely-dissent.js?container_id=buzzsprout-player-11163320&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163320-lonely-dissent.js?container_id=buzzsprout-player-11163320&player=small",
     "externalEpisodeId": 11163320
   },
   "gBma88LH3CLQsqyfS": {
     "serverTitle": "Cultish Countercultishness",
     "postId": "gBma88LH3CLQsqyfS",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163319-cultish-countercultishness.js?container_id=buzzsprout-player-11163319&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163319-cultish-countercultishness.js?container_id=buzzsprout-player-11163319&player=small",
     "externalEpisodeId": 11163319
   },
   "CahCppKy9HuXe3j2i": {
     "serverTitle": "Singlethink",
     "postId": "CahCppKy9HuXe3j2i",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163358-singlethink.js?container_id=buzzsprout-player-11163358&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163358-singlethink.js?container_id=buzzsprout-player-11163358&player=small",
     "externalEpisodeId": 11163358
   },
   "wCqfCLs8z5Qw4GbKS": {
     "serverTitle": "The Importance of Saying \"Oops\"",
     "postId": "wCqfCLs8z5Qw4GbKS",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163318-the-importance-of-saying-oops.js?container_id=buzzsprout-player-11163318&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163318-the-importance-of-saying-oops.js?container_id=buzzsprout-player-11163318&player=small",
     "externalEpisodeId": 11163318
   },
   "qRWfvgJG75ESLRNu9": {
     "serverTitle": "The Crackpot Offer",
     "postId": "qRWfvgJG75ESLRNu9",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163317-the-crackpot-offer.js?container_id=buzzsprout-player-11163317&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163317-the-crackpot-offer.js?container_id=buzzsprout-player-11163317&player=small",
     "externalEpisodeId": 11163317
   },
   "waqC6FihC2ryAZuAq": {
     "serverTitle": "Just Lose Hope Already",
     "postId": "waqC6FihC2ryAZuAq",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163316-just-lose-hope-already.js?container_id=buzzsprout-player-11163316&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163316-just-lose-hope-already.js?container_id=buzzsprout-player-11163316&player=small",
     "externalEpisodeId": 11163316
   },
   "43PTNr4ZMaezyAJ5o": {
     "serverTitle": "The Proper Use of Doubt",
     "postId": "43PTNr4ZMaezyAJ5o",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163315-the-proper-use-of-doubt.js?container_id=buzzsprout-player-11163315&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163315-the-proper-use-of-doubt.js?container_id=buzzsprout-player-11163315&player=small",
     "externalEpisodeId": 11163315
   },
   "HYWhKXRsMAyvRKRYz": {
     "serverTitle": "You Can Face Reality",
     "postId": "HYWhKXRsMAyvRKRYz",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163314-you-can-face-reality.js?container_id=buzzsprout-player-11163314&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163314-you-can-face-reality.js?container_id=buzzsprout-player-11163314&player=small",
     "externalEpisodeId": 11163314
   },
   "3nZMgRTfFEfHp34Gb": {
     "serverTitle": "The Meditation on Curiosity",
     "postId": "3nZMgRTfFEfHp34Gb",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163313-the-meditation-on-curiosity.js?container_id=buzzsprout-player-11163313&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163313-the-meditation-on-curiosity.js?container_id=buzzsprout-player-11163313&player=small",
     "externalEpisodeId": 11163313
   },
   "eY45uCCX7DdwJ4Jha": {
     "serverTitle": "No One Can Exempt You From Rationality's Laws",
     "postId": "eY45uCCX7DdwJ4Jha",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163312-no-one-can-exempt-you-from-rationality-s-laws.js?container_id=buzzsprout-player-11163312&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163312-no-one-can-exempt-you-from-rationality-s-laws.js?container_id=buzzsprout-player-11163312&player=small",
     "externalEpisodeId": 11163312
   },
   "3XgYbghWruBMrPTAL": {
     "serverTitle": "Leave a Line of Retreat",
     "postId": "3XgYbghWruBMrPTAL",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163311-leave-a-line-of-retreat.js?container_id=buzzsprout-player-11163311&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163311-leave-a-line-of-retreat.js?container_id=buzzsprout-player-11163311&player=small",
     "externalEpisodeId": 11163311
   },
   "BcYBfG8KomcpcxkEg": {
     "serverTitle": "Crisis of Faith",
     "postId": "BcYBfG8KomcpcxkEg",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163310-crisis-of-faith.js?container_id=buzzsprout-player-11163310&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163310-crisis-of-faith.js?container_id=buzzsprout-player-11163310&player=small",
     "externalEpisodeId": 11163310
   },
   "kXAb5riiaJNrfR8v8": {
     "serverTitle": "The Ritual",
     "postId": "kXAb5riiaJNrfR8v8",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163309-the-ritual.js?container_id=buzzsprout-player-11163309&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163309-the-ritual.js?container_id=buzzsprout-player-11163309&player=small",
     "externalEpisodeId": 11163309
   },
   "8GhSZzsQmusCN9is7": {
     "serverTitle": "Minds: An Introduction",
     "postId": "8GhSZzsQmusCN9is7",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163308-minds-an-introduction.js?container_id=buzzsprout-player-11163308&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163308-minds-an-introduction.js?container_id=buzzsprout-player-11163308&player=small",
     "externalEpisodeId": 11163308
   },
   "aiQabnugDhcrFtr9n": {
     "serverTitle": "The Power of Intelligence",
     "postId": "aiQabnugDhcrFtr9n",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163307-interlude-the-power-of-intelligence.js?container_id=buzzsprout-player-11163307&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163307-interlude-the-power-of-intelligence.js?container_id=buzzsprout-player-11163307&player=small",
     "externalEpisodeId": 11163307
   },
   "pLRogvJLPPg6Mrvg4": {
     "serverTitle": "An Alien God",
     "postId": "pLRogvJLPPg6Mrvg4",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163306-an-alien-god.js?container_id=buzzsprout-player-11163306&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163306-an-alien-god.js?container_id=buzzsprout-player-11163306&player=small",
     "externalEpisodeId": 11163306
   },
   "ZyNak8F6WXjuEbWWc": {
     "serverTitle": "The Wonder of Evolution",
     "postId": "ZyNak8F6WXjuEbWWc",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163305-the-wonder-of-evolution.js?container_id=buzzsprout-player-11163305&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163305-the-wonder-of-evolution.js?container_id=buzzsprout-player-11163305&player=small",
     "externalEpisodeId": 11163305
   },
   "jAToJHtg39AMTAuJo": {
     "serverTitle": "Evolutions Are Stupid (But Work Anyway)",
     "postId": "jAToJHtg39AMTAuJo",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163304-evolutions-are-stupid-but-work-anyway.js?container_id=buzzsprout-player-11163304&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163304-evolutions-are-stupid-but-work-anyway.js?container_id=buzzsprout-player-11163304&player=small",
     "externalEpisodeId": 11163304
   },
   "XC7Kry5q6CD9TyG4K": {
     "serverTitle": "No Evolutions for Corporations or Nanodevices",
     "postId": "XC7Kry5q6CD9TyG4K",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163303-no-evolutions-for-corporations-or-nanodevices.js?container_id=buzzsprout-player-11163303&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163303-no-evolutions-for-corporations-or-nanodevices.js?container_id=buzzsprout-player-11163303&player=small",
     "externalEpisodeId": 11163303
   },
   "gDNrpuwahdRrDJ9iY": {
     "serverTitle": "Evolving to Extinction",
     "postId": "gDNrpuwahdRrDJ9iY",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163302-evolving-to-extinction.js?container_id=buzzsprout-player-11163302&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163302-evolving-to-extinction.js?container_id=buzzsprout-player-11163302&player=small",
     "externalEpisodeId": 11163302
   },
   "QsMJQSFj7WfoTMNgW": {
     "serverTitle": "The Tragedy of Group Selectionism",
     "postId": "QsMJQSFj7WfoTMNgW",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163301-the-tragedy-of-group-selectionism.js?container_id=buzzsprout-player-11163301&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163301-the-tragedy-of-group-selectionism.js?container_id=buzzsprout-player-11163301&player=small",
     "externalEpisodeId": 11163301
   },
   "i6fKszWY6gLZSX2Ey": {
     "serverTitle": "Fake Optimization Criteria",
     "postId": "i6fKszWY6gLZSX2Ey",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163300-fake-optimization-criteria.js?container_id=buzzsprout-player-11163300&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163300-fake-optimization-criteria.js?container_id=buzzsprout-player-11163300&player=small",
     "externalEpisodeId": 11163300
   },
   "XPErvb8m9FapXCjhA": {
     "serverTitle": "Adaptation-Executers, not Fitness-Maximizers",
     "postId": "XPErvb8m9FapXCjhA",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163299-adaptation-executers-not-fitness-maximizers.js?container_id=buzzsprout-player-11163299&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163299-adaptation-executers-not-fitness-maximizers.js?container_id=buzzsprout-player-11163299&player=small",
     "externalEpisodeId": 11163299
   },
   "epZLSoNvjW53tqNj9": {
     "serverTitle": "Evolutionary Psychology",
     "postId": "epZLSoNvjW53tqNj9",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163298-evolutionary-psychology.js?container_id=buzzsprout-player-11163298&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163298-evolutionary-psychology.js?container_id=buzzsprout-player-11163298&player=small",
     "externalEpisodeId": 11163298
   },
   "J4vdsSKB7LzAvaAMB": {
     "serverTitle": "An Especially Elegant Evpsych Experiment",
     "postId": "J4vdsSKB7LzAvaAMB",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163297-an-especially-elegant-evpsych-experiment.js?container_id=buzzsprout-player-11163297&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163297-an-especially-elegant-evpsych-experiment.js?container_id=buzzsprout-player-11163297&player=small",
     "externalEpisodeId": 11163297
   },
   "Jq73GozjsuhdwMLEG": {
     "serverTitle": "Superstimuli and the Collapse of Western Civilization",
     "postId": "Jq73GozjsuhdwMLEG",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163296-superstimuli-and-the-collapse-of-western-civilization.js?container_id=buzzsprout-player-11163296&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163296-superstimuli-and-the-collapse-of-western-civilization.js?container_id=buzzsprout-player-11163296&player=small",
     "externalEpisodeId": 11163296
   },
   "cSXZpvqpa9vbGGLtG": {
     "serverTitle": "Thou Art Godshatter",
     "postId": "cSXZpvqpa9vbGGLtG",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163295-thou-art-godshatter.js?container_id=buzzsprout-player-11163295&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163295-thou-art-godshatter.js?container_id=buzzsprout-player-11163295&player=small",
     "externalEpisodeId": 11163295
   },
   "HktFCy6dgsqJ9WPpX": {
     "serverTitle": "Belief in Intelligence",
     "postId": "HktFCy6dgsqJ9WPpX",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163294-belief-in-intelligence.js?container_id=buzzsprout-player-11163294&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163294-belief-in-intelligence.js?container_id=buzzsprout-player-11163294&player=small",
     "externalEpisodeId": 11163294
   },
   "Zkzzjg3h7hW5Z36hK": {
     "serverTitle": "Humans in Funny Suits",
     "postId": "Zkzzjg3h7hW5Z36hK",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163293-humans-in-funny-suits.js?container_id=buzzsprout-player-11163293&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163293-humans-in-funny-suits.js?container_id=buzzsprout-player-11163293&player=small",
     "externalEpisodeId": 11163293
   },
   "8vpf46nLMDYPC6wA4": {
     "serverTitle": "Optimization and the Intelligence Explosion",
     "postId": "8vpf46nLMDYPC6wA4",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163292-optimization-and-the-intelligence-explosion.js?container_id=buzzsprout-player-11163292&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163292-optimization-and-the-intelligence-explosion.js?container_id=buzzsprout-player-11163292&player=small",
     "externalEpisodeId": 11163292
   },
   "cnYHFNBF3kZEyx24v": {
     "serverTitle": "Ghosts in the Machine",
     "postId": "cnYHFNBF3kZEyx24v",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163291-ghosts-in-the-machine.js?container_id=buzzsprout-player-11163291&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163291-ghosts-in-the-machine.js?container_id=buzzsprout-player-11163291&player=small",
     "externalEpisodeId": 11163291
   },
   "YhgjmCxcQXixStWMC": {
     "serverTitle": "Artificial Addition",
     "postId": "YhgjmCxcQXixStWMC",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163290-artificial-addition.js?container_id=buzzsprout-player-11163290&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163290-artificial-addition.js?container_id=buzzsprout-player-11163290&player=small",
     "externalEpisodeId": 11163290
   },
   "n5ucT5ZbPdhfGNLtP": {
     "serverTitle": "Terminal Values and Instrumental Values",
     "postId": "n5ucT5ZbPdhfGNLtP",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163289-terminal-values-and-instrumental-values.js?container_id=buzzsprout-player-11163289&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163289-terminal-values-and-instrumental-values.js?container_id=buzzsprout-player-11163289&player=small",
     "externalEpisodeId": 11163289
   },
   "Tc2H9KbKRjuDJ3WSS": {
     "serverTitle": "Leaky Generalizations",
     "postId": "Tc2H9KbKRjuDJ3WSS",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163288-leaky-generalizations.js?container_id=buzzsprout-player-11163288&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163288-leaky-generalizations.js?container_id=buzzsprout-player-11163288&player=small",
     "externalEpisodeId": 11163288
   },
   "4ARaTpNX62uaL86j6": {
     "serverTitle": "The Hidden Complexity of Wishes",
     "postId": "4ARaTpNX62uaL86j6",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163287-the-hidden-complexity-of-wishes.js?container_id=buzzsprout-player-11163287&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163287-the-hidden-complexity-of-wishes.js?container_id=buzzsprout-player-11163287&player=small",
     "externalEpisodeId": 11163287
   },
   "RcZeZt8cPk48xxiQ8": {
     "serverTitle": "Anthropomorphic Optimism",
     "postId": "RcZeZt8cPk48xxiQ8",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163286-anthropomorphic-optimism.js?container_id=buzzsprout-player-11163286&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163286-anthropomorphic-optimism.js?container_id=buzzsprout-player-11163286&player=small",
     "externalEpisodeId": 11163286
   },
   "sP2Hg6uPwpfp3jZJN": {
     "serverTitle": "Lost Purposes",
     "postId": "sP2Hg6uPwpfp3jZJN",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163285-lost-purposes.js?container_id=buzzsprout-player-11163285&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163285-lost-purposes.js?container_id=buzzsprout-player-11163285&player=small",
     "externalEpisodeId": 11163285
   },
   "hQxYBfu2LPc9Ydo6w": {
     "serverTitle": "The Parable of the Dagger",
     "postId": "hQxYBfu2LPc9Ydo6w",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163284-the-parable-of-the-dagger.js?container_id=buzzsprout-player-11163284&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163284-the-parable-of-the-dagger.js?container_id=buzzsprout-player-11163284&player=small",
     "externalEpisodeId": 11163284
   },
   "bcM5ft8jvsffsZZ4Y": {
     "serverTitle": "The Parable of Hemlock",
     "postId": "bcM5ft8jvsffsZZ4Y",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163283-the-parable-of-hemlock.js?container_id=buzzsprout-player-11163283&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163283-the-parable-of-hemlock.js?container_id=buzzsprout-player-11163283&player=small",
     "externalEpisodeId": 11163283
   },
   "3nxs2WYDGzJbzcLMp": {
     "serverTitle": "Words as Hidden Inferences",
     "postId": "3nxs2WYDGzJbzcLMp",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163282-words-as-hidden-inferences.js?container_id=buzzsprout-player-11163282&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163282-words-as-hidden-inferences.js?container_id=buzzsprout-player-11163282&player=small",
     "externalEpisodeId": 11163282
   },
   "HsznWM9A7NiuGsp28": {
     "serverTitle": "Extensions and Intensions",
     "postId": "HsznWM9A7NiuGsp28",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163281-extensions-and-intensions.js?container_id=buzzsprout-player-11163281&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163281-extensions-and-intensions.js?container_id=buzzsprout-player-11163281&player=small",
     "externalEpisodeId": 11163281
   },
   "jMTbQj9XB5ah2maup": {
     "serverTitle": "Similarity Clusters",
     "postId": "jMTbQj9XB5ah2maup",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163280-similarity-clusters.js?container_id=buzzsprout-player-11163280&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163280-similarity-clusters.js?container_id=buzzsprout-player-11163280&player=small",
     "externalEpisodeId": 11163280
   },
   "4mEsPHqcbRWxnaE5b": {
     "serverTitle": "Typicality and Asymmetrical Similarity",
     "postId": "4mEsPHqcbRWxnaE5b",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163279-typicality-and-asymmetrical-similarity.js?container_id=buzzsprout-player-11163279&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163279-typicality-and-asymmetrical-similarity.js?container_id=buzzsprout-player-11163279&player=small",
     "externalEpisodeId": 11163279
   },
   "WBw8dDkAWohFjWQSk": {
     "serverTitle": "The Cluster Structure of Thingspace",
     "postId": "WBw8dDkAWohFjWQSk",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163278-the-cluster-structure-of-thingspace.js?container_id=buzzsprout-player-11163278&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163278-the-cluster-structure-of-thingspace.js?container_id=buzzsprout-player-11163278&player=small",
     "externalEpisodeId": 11163278
   },
   "4FcxgdvdQP45D6Skg": {
     "serverTitle": "Disguised Queries",
     "postId": "4FcxgdvdQP45D6Skg",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163277-disguised-queries.js?container_id=buzzsprout-player-11163277&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163277-disguised-queries.js?container_id=buzzsprout-player-11163277&player=small",
     "externalEpisodeId": 11163277
   },
   "yFDKvfN6D87Tf5J9f": {
     "serverTitle": "Neural Categories",
     "postId": "yFDKvfN6D87Tf5J9f",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163276-neural-categories.js?container_id=buzzsprout-player-11163276&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163276-neural-categories.js?container_id=buzzsprout-player-11163276&player=small",
     "externalEpisodeId": 11163276
   },
   "yA4gF5KrboK2m2Xu7": {
     "serverTitle": "How An Algorithm Feels From Inside",
     "postId": "yA4gF5KrboK2m2Xu7",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163275-how-an-algorithm-feels-from-inside.js?container_id=buzzsprout-player-11163275&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163275-how-an-algorithm-feels-from-inside.js?container_id=buzzsprout-player-11163275&player=small",
     "externalEpisodeId": 11163275
   },
   "7X2j8HAkWdmMoS8PE": {
     "serverTitle": "Disputing Definitions",
     "postId": "7X2j8HAkWdmMoS8PE",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163274-disputing-definitions.js?container_id=buzzsprout-player-11163274&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163274-disputing-definitions.js?container_id=buzzsprout-player-11163274&player=small",
     "externalEpisodeId": 11163274
   },
   "dMCFk2n2ur8n62hqB": {
     "serverTitle": "Feel the Meaning",
     "postId": "dMCFk2n2ur8n62hqB",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163273-feel-the-meaning.js?container_id=buzzsprout-player-11163273&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163273-feel-the-meaning.js?container_id=buzzsprout-player-11163273&player=small",
     "externalEpisodeId": 11163273
   },
   "9ZooAqfh2TC9SBDvq": {
     "serverTitle": "The Argument from Common Usage",
     "postId": "9ZooAqfh2TC9SBDvq",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163272-the-argument-from-common-usage.js?container_id=buzzsprout-player-11163272&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163272-the-argument-from-common-usage.js?container_id=buzzsprout-player-11163272&player=small",
     "externalEpisodeId": 11163272
   },
   "i2dfY65JciebF3CAo": {
     "serverTitle": "Empty Labels",
     "postId": "i2dfY65JciebF3CAo",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163271-empty-labels.js?container_id=buzzsprout-player-11163271&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163271-empty-labels.js?container_id=buzzsprout-player-11163271&player=small",
     "externalEpisodeId": 11163271
   },
   "WBdvyyHLdxZSAMmoz": {
     "serverTitle": "Taboo Your Words",
     "postId": "WBdvyyHLdxZSAMmoz",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163270-taboo-your-words.js?container_id=buzzsprout-player-11163270&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163270-taboo-your-words.js?container_id=buzzsprout-player-11163270&player=small",
     "externalEpisodeId": 11163270
   },
   "GKfPL6LQFgB49FEnv": {
     "serverTitle": "Replace the Symbol with the Substance",
     "postId": "GKfPL6LQFgB49FEnv",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163269-replace-the-symbol-with-the-substance.js?container_id=buzzsprout-player-11163269&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163269-replace-the-symbol-with-the-substance.js?container_id=buzzsprout-player-11163269&player=small",
     "externalEpisodeId": 11163269
   },
   "y5MxoeacRKKM3KQth": {
     "serverTitle": "Fallacies of Compression",
     "postId": "y5MxoeacRKKM3KQth",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163268-fallacies-of-compression.js?container_id=buzzsprout-player-11163268&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163268-fallacies-of-compression.js?container_id=buzzsprout-player-11163268&player=small",
     "externalEpisodeId": 11163268
   },
   "veN86cBhoe7mBxXLk": {
     "serverTitle": "Categorizing Has Consequences",
     "postId": "veN86cBhoe7mBxXLk",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163267-categorizing-has-consequences.js?container_id=buzzsprout-player-11163267&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163267-categorizing-has-consequences.js?container_id=buzzsprout-player-11163267&player=small",
     "externalEpisodeId": 11163267
   },
   "yuKaWPRTxZoov4z8K": {
     "serverTitle": "Sneaking in Connotations",
     "postId": "yuKaWPRTxZoov4z8K",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163266-sneaking-in-connotations.js?container_id=buzzsprout-player-11163266&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163266-sneaking-in-connotations.js?container_id=buzzsprout-player-11163266&player=small",
     "externalEpisodeId": 11163266
   },
   "cFzC996D7Jjds3vS9": {
     "serverTitle": "Arguing \"By Definition\"",
     "postId": "cFzC996D7Jjds3vS9",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163265-arguing-by-definition.js?container_id=buzzsprout-player-11163265&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163265-arguing-by-definition.js?container_id=buzzsprout-player-11163265&player=small",
     "externalEpisodeId": 11163265
   },
   "d5NyJ2Lf6N22AD9PB": {
     "serverTitle": "Where to Draw the Boundary?",
     "postId": "d5NyJ2Lf6N22AD9PB",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163264-where-to-draw-the-boundary.js?container_id=buzzsprout-player-11163264&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163264-where-to-draw-the-boundary.js?container_id=buzzsprout-player-11163264&player=small",
     "externalEpisodeId": 11163264
   },
   "soQX8yXLbKy7cFvy8": {
     "serverTitle": "Entropy, and Short Codes",
     "postId": "soQX8yXLbKy7cFvy8",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163263-entropy-and-short-codes.js?container_id=buzzsprout-player-11163263&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163263-entropy-and-short-codes.js?container_id=buzzsprout-player-11163263&player=small",
     "externalEpisodeId": 11163263
   },
   "yLcuygFfMfrfK8KjF": {
     "serverTitle": "Mutual Information, and Density in Thingspace",
     "postId": "yLcuygFfMfrfK8KjF",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163262-mutual-information-and-density-in-thingspace.js?container_id=buzzsprout-player-11163262&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163262-mutual-information-and-density-in-thingspace.js?container_id=buzzsprout-player-11163262&player=small",
     "externalEpisodeId": 11163262
   },
   "82eMd5KLiJ5Z6rTrr": {
     "serverTitle": "Superexponential Conceptspace, and Simple Words",
     "postId": "82eMd5KLiJ5Z6rTrr",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163261-superexponential-conceptspace-and-simple-words.js?container_id=buzzsprout-player-11163261&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163261-superexponential-conceptspace-and-simple-words.js?container_id=buzzsprout-player-11163261&player=small",
     "externalEpisodeId": 11163261
   },
   "gDWvLicHhcMfGmwaK": {
     "serverTitle": "Conditional Independence, and Naive Bayes",
     "postId": "gDWvLicHhcMfGmwaK",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163260-conditional-independence-and-naive-bayes.js?container_id=buzzsprout-player-11163260&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163260-conditional-independence-and-naive-bayes.js?container_id=buzzsprout-player-11163260&player=small",
     "externalEpisodeId": 11163260
   },
   "YF9HB6cWCJrDK5pBM": {
     "serverTitle": "Words as Mental Paintbrush Handles",
     "postId": "YF9HB6cWCJrDK5pBM",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163259-words-as-mental-paintbrush-handles.js?container_id=buzzsprout-player-11163259&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163259-words-as-mental-paintbrush-handles.js?container_id=buzzsprout-player-11163259&player=small",
     "externalEpisodeId": 11163259
   },
   "shoMpaoZypfkXv84Y": {
     "serverTitle": "Variable Question Fallacies",
     "postId": "shoMpaoZypfkXv84Y",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163258-variable-question-fallacies.js?container_id=buzzsprout-player-11163258&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163258-variable-question-fallacies.js?container_id=buzzsprout-player-11163258&player=small",
     "externalEpisodeId": 11163258
   },
   "FaJaCgqBKphrDzDSj": {
     "serverTitle": "37 Ways That Words Can Be Wrong",
     "postId": "FaJaCgqBKphrDzDSj",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163257-37-ways-that-words-can-be-wrong.js?container_id=buzzsprout-player-11163257&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163257-37-ways-that-words-can-be-wrong.js?container_id=buzzsprout-player-11163257&player=small",
     "externalEpisodeId": 11163257
   },
   "XTXWPQSEgoMkAupKt": {
     "serverTitle": "An Intuitive Explanation of Bayes's Theorem",
     "postId": "XTXWPQSEgoMkAupKt",
-    "episodeLink": "https://www.buzzsprout.com//2036194/11163256-interlude-an-intuitive-explanation-of-bayes-s-theorem.js?container_id=buzzsprout-player-11163256&amp;player=small",
+    "episodeLink": "https://www.buzzsprout.com//2036194/11163256-interlude-an-intuitive-explanation-of-bayes-s-theorem.js?container_id=buzzsprout-player-11163256&player=small",
     "externalEpisodeId": 11163256
   }
 }

--- a/packages/lesswrong/server/migrations/20260422T043345.fixPodcastEpisodeLinkAmpEntities.ts
+++ b/packages/lesswrong/server/migrations/20260422T043345.fixPodcastEpisodeLinkAmpEntities.ts
@@ -1,0 +1,21 @@
+// Some PodcastEpisodes rows (the ones bulk-imported from
+// razPostToBuzzsproutMappings.json and curatedPostToBuzzsproutMappings.json
+// in the 2022-08-19-createPodcastsForPosts manual migration) have HTML-encoded
+// "&amp;" in their episodeLink instead of "&". When PostsPodcastPlayer.tsx
+// later assigns that string directly to script.src, the literal "&amp;" is
+// sent to Buzzsprout, which then 404s (because the player=small query param
+// gets parsed as "amp;player=small"). The result is that the audio toggle
+// icon shows in the post header but the embedded player area is empty.
+// This migration replaces "&amp;" with "&" in episodeLink for all affected
+// rows.
+
+export const up = async ({db}: MigrationContext) => {
+  await db.none(`
+    UPDATE "PodcastEpisodes"
+    SET "episodeLink" = REPLACE("episodeLink", '&amp;', '&')
+    WHERE "episodeLink" LIKE '%&amp;%'
+  `);
+}
+
+export const down = async ({db}: MigrationContext) => {
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Symptom

On the post [_Use the Try Harder, Luke_](https://www.lesswrong.com/s/NBDFAKt3GbFwnwzQF/p/fhEPnveFhb9tmd7Pe) (and a few hundred other RAZ / curated sequence posts), the audio toggle icon shows in the top-right of the post header but clicking it reveals an empty player area — there is no actual audio iframe.

## Root cause

The `PodcastEpisodes` rows for these posts were bulk-imported in 2022 from `razPostToBuzzsproutMappings.json` and `curatedPostToBuzzsproutMappings.json`. Both files store `episodeLink` with HTML-encoded `&amp;` instead of `&`, e.g.:

```
https://www.buzzsprout.com//2036194/11163124-use-the-try-harder-luke.js?container_id=buzzsprout-player-11163124&amp;player=small
```

`PostsPodcastPlayer.tsx` does:

```ts
newScript.src = podcastEpisode.episodeLink;
```

Because `script.src` is a plain DOMString, the literal `&amp;` is sent to Buzzsprout. Buzzsprout then parses the query string as `container_id=...&amp;player=small`, sees a param called `amp;player` and never sees `player=small`. Without the `player=small` param the endpoint returns 404, no iframe gets injected, and the player div stays empty. But the audio toggle icon still appears because `postHasAudioPlayer()` only checks `('podcastEpisode' in post) && post.podcastEpisode`.

I confirmed the underlying audio file is fine on Buzzsprout's side — the corrected URL returns 200 and serves a valid 257-second mp3 with the right title/artist/album metadata.

## Fix

Three commits:

1. **Migration (`20260422T043345.fixPodcastEpisodeLinkAmpEntities.ts`)** — `UPDATE "PodcastEpisodes" SET "episodeLink" = REPLACE("episodeLink", '&amp;', '&') WHERE "episodeLink" LIKE '%&amp;%'`. This is what actually fixes the in-prod data; should hit ~350 rows.
2. **JSON resource files** — replace `&amp;` with `&` in `razPostToBuzzsproutMappings.json` (334 entries) and `curatedPostToBuzzsproutMappings.json` (16 entries) so the source data matches what's in the DB after the migration runs, and so re-running the manual `2022-08-19-createPodcastsForPosts` migration wouldn't reintroduce the bad encoding.
3. **Defensive client fix in `PostsPodcastPlayer.tsx`** — `.replace(/&amp;/g, '&')` on `episodeLink` before assigning to `script.src`, in case any future row comes in HTML-encoded.

## Out of scope

This PR doesn't change the broader logic of `postHasAudioPlayer()` to verify the player URL is actually loadable (would require a network probe). The audio icon will still appear for any post with a `podcastEpisode` row, but for the affected posts the embedded Buzzsprout player will now actually load.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a60ab3f0-9fcd-4f2d-b450-41741a769c07"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a60ab3f0-9fcd-4f2d-b450-41741a769c07"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1214177709812720) by [Unito](https://www.unito.io)
