### PR TITLE
Fix Pangram auto-run on post undraft and comment edit

### DIFF
--- a/packages/lesswrong/server/callbacks/commentCallbackFunctions.tsx
+++ b/packages/lesswrong/server/callbacks/commentCallbackFunctions.tsx
@@ -887,6 +887,12 @@ export async function newCommentTriggerPangram({document, context}: AfterCreateC
   void maybeRunPangramOnComment(document._id, context).catch(captureException);
 }
 
+export async function editedCommentTriggerPangram(updatedDocument: DbComment, oldDocument: DbComment, context: ResolverContext) {
+  // Status-only edits (retraction, tag changes) leave contents_latest unchanged and don't need re-scoring.
+  if (updatedDocument.contents_latest === oldDocument.contents_latest) return;
+  void maybeRunPangramOnComment(updatedDocument._id, context).catch(captureException);
+}
+
 async function maybeRunPangramOnComment(commentId: string, context: ResolverContext) {
   if (!pangramIsConfigured()) return;
 

--- a/packages/lesswrong/server/callbacks/postCallbackFunctions.tsx
+++ b/packages/lesswrong/server/callbacks/postCallbackFunctions.tsx
@@ -160,27 +160,31 @@ async function maybeRunPangramOnPost(post: DbPost, context: ResolverContext) {
   if (!pangramIsConfigured()) return;
 
   const eligibility = documentIsEligibleForPangram(post);
-  // Short-circuit reversible ineligible states (draft, rejected) before the
-  // DataLoader roundtrips — hot path for draft-post creation.
   if (!eligibility.eligible && !eligibility.skipStatus) return;
 
-  const [author, revision] = await Promise.all([
-    context.loaders.Users.load(post.userId),
-    getLatestContentsRevision(post, context),
-  ]);
+  const author = await context.loaders.Users.load(post.userId);
   if (!author || !userIsUnreviewedForPangram(author)) return;
-  if (!revision) return;
-  // Avoid re-scoring the same revision when a draft is re-published. Manual rerun still overwrites.
-  if (revision.pangramCheckedAt) return;
 
   if (!eligibility.eligible) {
-    if (eligibility.skipStatus) {
-      await recordPangramSkip(revision._id, eligibility.skipStatus, context);
+    // Preview's `contents_latest` is safe to stamp for terminal states — spam/deleted
+    // posts aren't simultaneously getting a new revision from the same mutation.
+    if (eligibility.skipStatus && post.contents_latest) {
+      await recordPangramSkip(post.contents_latest, eligibility.skipStatus, context);
     }
     return;
   }
 
-  const text = extractPangramInputFromPost(post, revision.html);
+  // On undraft, the passed-in post is a preview built from `{...oldDocument, ...data}`
+  // captured BEFORE `createRevisionsForEditableFields` ran, so `contents_latest` can
+  // still point at the stale draft revision. Re-fetch to pick up the fresh one.
+  const freshPost = await context.Posts.findOne({ _id: post._id });
+  if (!freshPost) return;
+  const revision = await getLatestContentsRevision(freshPost, context);
+  if (!revision) return;
+  // Avoid re-scoring the same revision when a draft is re-published. Manual rerun still overwrites.
+  if (revision.pangramCheckedAt) return;
+
+  const text = extractPangramInputFromPost(freshPost, revision.html);
   await runPangramOnRevision(revision._id, text, context);
 }
 

--- a/packages/lesswrong/server/collections/comments/mutations.ts
+++ b/packages/lesswrong/server/collections/comments/mutations.ts
@@ -4,7 +4,7 @@ import { userIsAllowedToComment } from "@/lib/collections/users/helpers";
 import { isElasticEnabled } from "@/lib/instanceSettings";
 import { accessFilterSingle } from "@/lib/utils/schemaUtils";
 import { userCanDo, userOwns } from "@/lib/vulcan-users/permissions";
-import { addReferrerToComment, assignPostVersion, checkCommentForSpamWithAkismet, checkModGPTOnCommentCreate, checkModGPTOnCommentUpdate, commentsAlignmentEdit, commentsAlignmentNew, commentsEditSoftDeleteCallback, commentsNewNotifications, commentsNewOperations, commentsNewUserApprovedStatus, commentsPublishedNotifications, createShortformPost, handleForumEventMetadataEdit, handleForumEventMetadataNew, handleReplyToAnswer, invalidatePostOnCommentCreate, invalidatePostOnCommentUpdate, lwCommentsNewUpvoteOwnComment, moveToAnswers, newCommentsEmptyCheck, newCommentsPollResponseCheck, newCommentsRateLimit, newCommentTriggerReview, newCommentTriggerPangram, handleDraftState, setTopLevelCommentId, trackCommentRateLimitHit, updatedCommentMaybeTriggerReview, updateDescendentCommentCountsOnCreate, updateDescendentCommentCountsOnEdit, updatePostLastCommentPromotedAt, updateUserNotesOnCommentRejection, validateDeleteOperations } from "@/server/callbacks/commentCallbackFunctions";
+import { addReferrerToComment, assignPostVersion, checkCommentForSpamWithAkismet, checkModGPTOnCommentCreate, checkModGPTOnCommentUpdate, commentsAlignmentEdit, commentsAlignmentNew, commentsEditSoftDeleteCallback, commentsNewNotifications, commentsNewOperations, commentsNewUserApprovedStatus, commentsPublishedNotifications, createShortformPost, editedCommentTriggerPangram, handleForumEventMetadataEdit, handleForumEventMetadataNew, handleReplyToAnswer, invalidatePostOnCommentCreate, invalidatePostOnCommentUpdate, lwCommentsNewUpvoteOwnComment, moveToAnswers, newCommentsEmptyCheck, newCommentsPollResponseCheck, newCommentsRateLimit, newCommentTriggerReview, newCommentTriggerPangram, handleDraftState, setTopLevelCommentId, trackCommentRateLimitHit, updatedCommentMaybeTriggerReview, updateDescendentCommentCountsOnCreate, updateDescendentCommentCountsOnEdit, updatePostLastCommentPromotedAt, updateUserNotesOnCommentRejection, validateDeleteOperations } from "@/server/callbacks/commentCallbackFunctions";
 import { updateCountOfReferencesOnOtherCollectionsAfterCreate, updateCountOfReferencesOnOtherCollectionsAfterUpdate } from "@/server/callbacks/countOfReferenceCallbacks";
 import { upsertPolls } from "@/server/callbacks/forumEventCallbacks";
 import { sendAlignmentSubmissionApprovalNotifications } from "@/server/callbacks/sharedCallbackFunctions";
@@ -179,6 +179,7 @@ export async function updateComment({ selector, data }: UpdateCommentInput, cont
   await updateCountOfReferencesOnOtherCollectionsAfterUpdate('Comments', updatedDocument, oldDocument);
 
   await updatedCommentMaybeTriggerReview(updateCallbackProperties);
+  await editedCommentTriggerPangram(updatedDocument, oldDocument, context);
   await updateUserNotesOnCommentRejection(updateCallbackProperties);
   await checkModGPTOnCommentUpdate(updateCallbackProperties);  
 


### PR DESCRIPTION
## Summary

Two follow-up bugs to the recent Pangram integration, caught after deploy:

- **Snoozed user published a post** → revision was created but had no Pangram fields. Root cause: `undraftedPostTriggerPangram` passes the preview document built from `{...oldDocument, ...data}`, which is captured *before* `createRevisionsForEditableFields` runs. On undraft-with-content-changes, the preview's `contents_latest` still points at the stale draft revision, so Pangram either wrote to the wrong row or short-circuited on a pre-existing `pangramCheckedAt`. Fix: re-fetch the post on the eligible path. Terminal skip path keeps using the preview (terminal posts aren't simultaneously getting a new revision).

- **New user edited a comment** → new revision had no Pangram fields. Root cause: there was no update-path trigger — Pangram only fired on comment create. Fix: add `editedCommentTriggerPangram`, wired into `updateComment`. It short-circuits when `contents_latest` is unchanged (so status-only edits like retraction are free), and delegates to the existing refetch-based `maybeRunPangramOnComment`.

## Test plan

- [ ] As a snoozed user, publish a draft post with >200 words; confirm `pangramStatus` transitions from pending → scored.
- [ ] As an unreviewed user, edit a previously-scored comment's body; confirm the new revision gets its own Pangram score.
- [ ] Status-only comment edits (retraction, tag change) don't re-trigger Pangram.
- [ ] Existing create-path auto-run still works for new posts by unreviewed users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1214242933797460) by [Unito](https://www.unito.io)
