### PR TITLE
fix imports of google doc footnotes with lists in them

### DIFF
--- a/packages/lesswrong/server/editor/googleDocUtils.ts
+++ b/packages/lesswrong/server/editor/googleDocUtils.ts
@@ -181,14 +181,6 @@ function googleDocConvertFootnotes(html: string): string {
       firstFootnoteSpan.text(firstFootnoteSpan.text().replace(/^[\s\u00A0]+/, ''));
     }
 
-    // Replace bullets in footnotes with regular <p> elements and move them up a level
-    const listParent = footnoteContent.find('li').parent('ul, ol');
-    listParent.children('li').each((_, liElement) => {
-      const liContent = $(liElement).html();
-      $(`<p>${liContent}</p>`).insertBefore(listParent);
-    });
-    listParent.remove();
-
     const newFootnoteBackLink = $('<span class="footnote-back-link" data-footnote-back-link="" data-footnote-id="' + id + '"><sup><strong><a href="#fnref' + id + '">^</a></strong></sup></span>');
 
     const newFootnoteContent = $('<div class="footnote-content" data-footnote-content=""></div>');
@@ -738,9 +730,12 @@ export async function convertImportedGoogleDoc({
     googleDocStripComments,
     googleDocCropImages,
     googleDocTextFormatting,
+    // Nested-bullet conversion runs before footnote conversion so that lists inside
+    // footnotes (which Google Docs emits as a flat sequence of <ul>s indented via CSS)
+    // are collapsed into genuinely nested lists before the footnote converter relocates them.
+    googleDocConvertNestedBullets, // Must come before removeEmptyBodyParagraphs because paragraph breaks are used to determine when to break up a nested list of bullets
     googleDocConvertLinks,
     googleDocRemoveRedirects,
-    googleDocConvertNestedBullets, // Must come before removeEmptyBodyParagraphs because paragraph breaks are used to determine when to break up a nested list of bullets
     removeEmptyBodyParagraphs,
     async (html: string) => await dataToCkEditor(html, "html"),
   ];

--- a/packages/lesswrong/unitTests/googleDocImport.tests.ts
+++ b/packages/lesswrong/unitTests/googleDocImport.tests.ts
@@ -147,6 +147,40 @@ describe("convertImportedGoogleDoc", () => {
     expect(htmlOutput).not.toContain('<div class="footnote-content" data-footnote-content=""><p><span>First paragraph</span></p><p><span></span></p><p><span>Second paragraph</span></p></div>');
   });
 
+  it("preserves nested lists inside footnotes without duplicating items", async () => {
+    // The third footnote in the source Google Doc uses Google Docs' CSS-based nested-list
+    // representation: two adjacent <ul>s, one at indent level 0 and one at level 1.
+    // A previous bug flattened these to <p>s and duplicated each <p> once per list.
+    const htmlInput = `
+      <html>
+        <body>
+          <p><span>Body</span><sup><a href="#ftnt1" id="ftnt_ref1">[1]</a></sup></p>
+          <hr />
+          <div>
+            <p><a href="#ftnt_ref1" id="ftnt1">[1]</a><span>&nbsp;Lead-in:</span></p>
+            <ul class="lst-kix_abc-0 start"><li><span>Top A</span></li><li><span>Top B</span></li></ul>
+            <ul class="lst-kix_abc-1 start"><li><span>Sub A</span></li><li><span>Sub B</span></li></ul>
+          </div>
+        </body>
+      </html>
+    `;
+    const zipBuffer = await createGoogleDocZip({
+      "index.html": htmlInput.replace(/\s+</g, '<'),
+    });
+
+    const htmlOutput = await convertImportedGoogleDoc({ zipBuffer, postId: 'dummy' });
+
+    // The footnote content should contain the items exactly once each
+    expect(htmlOutput.match(/<span>Top A<\/span>/g) ?? []).toHaveLength(1);
+    expect(htmlOutput.match(/<span>Top B<\/span>/g) ?? []).toHaveLength(1);
+    expect(htmlOutput.match(/<span>Sub A<\/span>/g) ?? []).toHaveLength(1);
+    expect(htmlOutput.match(/<span>Sub B<\/span>/g) ?? []).toHaveLength(1);
+
+    // The list structure should be preserved (with the second ul nested inside the last <li> of the first)
+    expect(htmlOutput).toContain('class="footnote-content" data-footnote-content');
+    expect(htmlOutput).toMatch(/<ul><li><span>Top A<\/span><\/li><li><span>Top B<\/span><ul><li><span>Sub A<\/span><\/li><li><span>Sub B<\/span><\/li><\/ul><\/li><\/ul>/);
+  });
+
   it("collapses each run of blank Google Docs spacer paragraphs by one", async () => {
     const htmlInput = `
       <html>


### PR DESCRIPTION
Fixes two problems inside of imported footnotes:
1. we no longer pointlessly flatten lists into paragraphs
2. we no longer incorrectly duplicate lists if they happen to have nested list items

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1214334816436733) by [Unito](https://www.unito.io)
