### PR TITLE
Better error handling for link-previews of invalid URLs

### DIFF
--- a/packages/lesswrong/components/linkPreview/HoverPreviewLink.tsx
+++ b/packages/lesswrong/components/linkPreview/HoverPreviewLink.tsx
@@ -151,7 +151,7 @@ const HoverPreviewLink = ({ href, id, rel, noPrefetch, contentStyleType, classNa
       {children}
     </a>
   } catch (err) {
-    console.error(err, href) // eslint-disable-line
+    console.warn(`Invalid URL for link preview: ${href}`) // eslint-disable-line
     return <a href={href} id={id} rel={rel} className={className}>
       {children}
     </a>

--- a/packages/lesswrong/server/resolvers/linkPreviewResolver.ts
+++ b/packages/lesswrong/server/resolvers/linkPreviewResolver.ts
@@ -957,7 +957,21 @@ async function resolveCrossSitePreview({ url, forceRefetch, includeDebug }: {
   forceRefetch: boolean;
   includeDebug: boolean;
 }): Promise<LinkPreviewResult> {
-  const normalizedUrl = normalizePreviewUrl(url);
+  let normalizedUrl: string
+  try {
+    normalizedUrl = normalizePreviewUrl(url);
+  } catch(e) {
+    return {
+      title: null,
+      imageUrl: null,
+      html: null,
+      error: "Invalid URL",
+      status: "error",
+      cacheVersion: LINK_PREVIEW_CACHE_VERSION,
+      fetchedAt: null,
+      nextRefreshAt: null,
+    };
+  }
   const now = new Date();
 
   const cachedResult = await getCachedPreview(normalizedUrl, includeDebug);


### PR DESCRIPTION
Posts sometimes have links to malformed (ie not-a-URL) destinations, eg http://lesswrong.com/posts/fXnpnrazqwpJmbadu/ai-25-inflection-point has one. Add error handling to the graphql resolver and the HoverPreviewLink component, to downgrade this from a loud error in Sentry to a console warning.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1214448698319251) by [Unito](https://www.unito.io)
