### PR TITLE
Fix bug with URL-encoded slugs in tag route pages

### DIFF
--- a/app/compare/w/[slug]/page.tsx
+++ b/app/compare/w/[slug]/page.tsx
@@ -17,7 +17,8 @@ export const generateMetadata = getTagPageMetadataFunction<{ slug: string }>(({ 
 export default async function Page({ params }: {
   params: Promise<{ slug: string }>
 }) {
-  const { slug } = await params;
+  const { slug: rawSlug } = await params;
+  const slug = decodeURIComponent(rawSlug);
   return <RouteRoot>
     <TagCompareRevisions slug={slug} />
   </RouteRoot>;

--- a/app/revisions/w/[slug]/page.tsx
+++ b/app/revisions/w/[slug]/page.tsx
@@ -18,7 +18,8 @@ export const generateMetadata = getTagPageMetadataFunction<{ slug: string }>(({ 
 export default async function Page({ params }: {
   params: Promise<{ slug: string }>
 }) {
-  const { slug } = await params;
+  const { slug: rawSlug } = await params;
+  const slug = decodeURIComponent(rawSlug);
   return <RouteRoot subtitle={TagPageSubtitle}>
     <TagPageRevisionSelect slug={slug} />
   </RouteRoot>;

--- a/app/w/[slug]/discussion/page.tsx
+++ b/app/w/[slug]/discussion/page.tsx
@@ -18,9 +18,9 @@ assertRouteAttributes("/w/[slug]/discussion", {
 export default async function Page({ params }: {
   params: Promise<{ slug: string }>
 }) {
-  const { slug } = await params;
+  const { slug: rawSlug } = await params;
+  const slug = decodeURIComponent(rawSlug);
   return <RouteRoot subtitle={TagPageSubtitle}>
     <TagDiscussionPage slug={slug} />
   </RouteRoot>;
 }
-

--- a/app/w/[slug]/edit/page.tsx
+++ b/app/w/[slug]/edit/page.tsx
@@ -18,7 +18,8 @@ export const generateMetadata = getTagPageMetadataFunction<{ slug: string }>(({ 
 export default async function Page({ params }: {
   params: Promise<{ slug: string }>
 }) {
-  const { slug } = await params;
+  const { slug: rawSlug } = await params;
+  const slug = decodeURIComponent(rawSlug);
   return <RouteRoot subtitle={TagPageSubtitle}>
     <EditTagPage slug={slug} />
   </RouteRoot>;

--- a/app/w/[slug]/history/page.tsx
+++ b/app/w/[slug]/history/page.tsx
@@ -18,7 +18,8 @@ export const generateMetadata = getTagPageMetadataFunction<{ slug: string }>(({ 
 export default async function Page({ params }: {
   params: Promise<{ slug: string }>
 }) {
-  const { slug } = await params;
+  const { slug: rawSlug } = await params;
+  const slug = decodeURIComponent(rawSlug);
   
   return <RouteRoot subtitle={TagHistoryPageSubtitle}>
     <TagHistoryPage slug={slug} />

--- a/app/w/[slug]/page.tsx
+++ b/app/w/[slug]/page.tsx
@@ -22,7 +22,8 @@ export default async function Page({ params, searchParams }: {
   params: Promise<{ slug: string }>
   searchParams: Promise<{ startPath?: string }>
 }) {
-  const [{ slug }, searchParamValues] = await Promise.all([params, searchParams]);
+  const [{ slug: rawSlug }, searchParamValues] = await Promise.all([params, searchParams]);
+  const slug = decodeURIComponent(rawSlug);
 
   // This needs to be an `in` because startPath will be an empty string,
   // for legacy Arbital compatibility reasons.

--- a/packages/lesswrong/server/pageMetadata/tagPageMetadata.ts
+++ b/packages/lesswrong/server/pageMetadata/tagPageMetadata.ts
@@ -33,7 +33,10 @@ export function getTagPageMetadataFunction<Params>(paramsToTagSlugConverter: (pa
   return async function generateMetadata({ params, searchParams }: { params: Promise<Params>, searchParams: Promise<{ commentId?: string }> }): Promise<Metadata> {
     const [paramValues, searchParamsValues, defaultMetadata] = await Promise.all([params, searchParams, getDefaultMetadata()]);
 
-    const slug = paramsToTagSlugConverter(paramValues);
+    // Next.js percent-encodes special characters in server component params
+    // (e.g. `:` becomes `%3A`); decode so slugs like
+    // `rationality:-from-ai-to-zombies` are looked up correctly.
+    const slug = decodeURIComponent(paramsToTagSlugConverter(paramValues));
     const commentId = searchParamsValues.commentId;
 
     const resolverContext = await getResolverContextForGenerateMetadata(searchParamsValues);


### PR DESCRIPTION
> Next.js server components receive URL params with special characters already percent-encoded (e.g. `:` becomes `%3A`), so tag pages whose slugs contain a colon (like `rationality:-from-ai-to-zombies`) would receive the encoded form, fail to match the DB record, and render a 404 RedlinkTagPage instead of the real page.
> 
> Fix: apply decodeURIComponent to the slug in:
> - getTagPageMetadataFunction (covers all generateMetadata exports)
> - each tag route Page component
> 
> Affected routes: /w/[slug], /w/[slug]/history, /w/[slug]/discussion, /w/[slug]/edit, /compare/w/[slug], /revisions/w/[slug]
> 
> Fixes #12450
> 
> Preview: https://baserates-test-git-beautiful-allen-kpS8n-lesswrong.vercel.app/w/rationality:-from-ai-to-zombies

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1214449201548045) by [Unito](https://www.unito.io)
