### PR TITLE
Exclude headings in spoiler/collapsible sections from ToC

### DIFF
--- a/packages/lesswrong/lib/tableOfContents.ts
+++ b/packages/lesswrong/lib/tableOfContents.ts
@@ -114,6 +114,11 @@ export function extractTableOfContents({
     if (!(element instanceof window.HTMLElement)) {
       continue;
     }
+    // Skip headings inside spoiler/collapsible sections or code blocks;
+    // those are hidden content and should not appear in the ToC.
+    if (element.closest('.spoilers, .spoiler, pre')) {
+      continue;
+    }
     let tagName = element.tagName.toLowerCase();
     if (tagIsHeadingIfWholeParagraph(tagName) && !tagIsWholeParagraph({ element, window })) {
       continue;


### PR DESCRIPTION
> Headings inside .spoilers/.spoiler containers (the Lexical SpoilerNode) or inside `<pre>` elements were being picked up by querySelectorAll in extractTableOfContents and appearing in the table of contents, even though that content is hidden/collapsed.
> 
> Fix: call `element.closest('.spoilers, .spoiler, pre')` before adding a heading to the ToC list, and skip it if it's inside one of those containers.
> 
> Reported in #forum_magnum_product: https://lworg.slack.com/archives/CJY3ZKP62/p1775611112908809
> 
> Preview: https://baserates-test-git-claude-beautiful-allen-xlRhE-lesswrong.vercel.app
> Deep link: https://baserates-test-git-claude-beautiful-allen-xlRhE-lesswrong.vercel.app/posts/bJ2haLkcGeLtTWaD5/welcome-to-lesswrong

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1214450236005400) by [Unito](https://www.unito.io)
