### PR TITLE
Tables use smaller sans-serif font for better data density

### DIFF
--- a/packages/lesswrong/components/editor/LexicalEditor.tsx
+++ b/packages/lesswrong/components/editor/LexicalEditor.tsx
@@ -231,6 +231,8 @@ const lexicalStyles = defineStyles('LexicalPostEditor', (theme: ThemeType) => ({
       width: 'auto',
       margin: '1em 0',
       border: `1px solid ${theme.palette.grey[300]}`,
+      fontSize: '0.875em',
+      fontFamily: theme.typography.commentStyle.fontFamily,
     },
     '& th, & td': {
       border: `1px solid ${theme.palette.grey[300]}`,

--- a/packages/lesswrong/themes/stylePiping.ts
+++ b/packages/lesswrong/themes/stylePiping.ts
@@ -197,6 +197,8 @@ const tableStyles = (theme: ThemeType) => ({
   height: "100%",
   textAlign: "left",
   width: '100%',
+  fontSize: '0.875em',
+  fontFamily: theme.typography.commentStyle.fontFamily,
 });
 
 const tableCellStyles = (theme: ThemeType) => ({


### PR DESCRIPTION
> Tables in rendered posts, comments, and the Lexical editor now render at 0.875em in the sans-serif font stack instead of inheriting the post body's larger serif font. The two-line change (fontSize + fontFamily on the table element) covers CKEditor tables, Lexical editor tables, and all rendered post/comment content via stylePiping.ts.
> 
> Requested by Oliver in #forum_magnum_product:
> https://lworg.slack.com/archives/CJY3ZKP62/p1776562529760839 Preview: https://baserates-test-git-claude-beautiful-allen-ih1np-lesswrong.vercel.app

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1214450116326135) by [Unito](https://www.unito.io)
