### PR TITLE
Hide editor UI chrome when printing posts

### DIFF
--- a/packages/lesswrong/components/editor/EditorTopBar.tsx
+++ b/packages/lesswrong/components/editor/EditorTopBar.tsx
@@ -18,6 +18,7 @@ const styles = defineStyles("EditorTopBar", (theme: ThemeType) => ({
     padding: 4,
     paddingLeft: 16,
     marginBottom: 16,
+    "@media print": { display: 'none' },
   },
   presenceList: {
     flexGrow: 1,

--- a/packages/lesswrong/components/lexical/plugins/ToolbarPlugin/index.tsx
+++ b/packages/lesswrong/components/lexical/plugins/ToolbarPlugin/index.tsx
@@ -189,6 +189,7 @@ const styles = defineStyles('LexicalToolbarPlugin', (theme: ThemeType) => ({
     top: 0,
     zIndex: 2,
     overflowY: 'hidden' as const,
+    "@media print": { display: 'none' },
   },
   toolbarHidden: {
     display: 'none',

--- a/packages/lesswrong/themes/globalStyles/miscStyles.ts
+++ b/packages/lesswrong/themes/globalStyles/miscStyles.ts
@@ -234,5 +234,10 @@ export const miscStyles = (theme: ThemeType) => ({
     ".rheostat-tooltip": {
       top:-22,
     },
+
+    "@media print": {
+      ".ck-editor__top": { display: 'none' },
+      ".form-submit": { display: 'none' },
+    },
   }
 });


### PR DESCRIPTION
> Adds @media print rules to hide the Lexical toolbar, CK editor toolbar, EditorTopBar (collab mode selector), and form submit buttons so that printing/PDF export from the editor page shows only the post content.
> 
> https://claude.ai/code/session_018eb1UcBEeKwqp7agBHQEf3

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1214450115652257) by [Unito](https://www.unito.io)
