### PR TITLE
Fix code block gutter line numbers desyncing on long-token wrap

### DIFF
--- a/packages/lesswrong/themes/stylePiping.ts
+++ b/packages/lesswrong/themes/stylePiping.ts
@@ -502,6 +502,9 @@ const baseBodyStyles = (theme: ThemeType) => ({
     overflowX: 'auto',
     position: 'relative',
     tabSize: 2,
+    // Explicit pre + normal overflow-wrap overrides parent word-break:break-word, keeping gutter line numbers in sync.
+    whiteSpace: 'pre',
+    overflowWrap: 'normal',
   },
   '& pre.code-block::before, & pre[data-highlight-language]::before': {
     content: 'attr(data-gutter)',


### PR DESCRIPTION
> The parent baseBodyStyles sets word-break:break-word (which browsers treat as overflow-wrap:break-word). This can force line breaks inside pre.code-block for very long unbroken tokens (long URLs, minified strings) even though `<pre>` defaults to white-space:pre. When a visual line wraps, the absolute-positioned gutter numbers go out of sync with the rendered rows.
> 
> Fix: explicitly set white-space:pre and overflow-wrap:normal on pre.code-block and pre[data-highlight-language] to pin no-wrap behaviour regardless of inherited overflow-wrap.
> 
> Preview: https://baserates-test-git-claude-beautiful-allen-uujt7-lesswrong.vercel.app
> Bug thread: https://lworg.slack.com/archives/CJUN2UAFN/p1777079883153219
> 
> https://claude.ai/code/session_017VKVvdjpyHDqzvnoaLTUEZ

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1214450214267756) by [Unito](https://www.unito.io)
