### PR TITLE
Fix quote-block freezing when selection spans into existing quote

### DIFF
--- a/packages/lesswrong/components/lexical/plugins/ToolbarPlugin/utils.ts
+++ b/packages/lesswrong/components/lexical/plugins/ToolbarPlugin/utils.ts
@@ -274,7 +274,23 @@ function $wrapOrUnwrapQuote(selection: ReturnType<typeof $getSelection>): void {
     return a.isBefore(b) ? -1 : 1;
   });
 
-  $wrapInQuote(sortedElements);
+  // Only wrap elements whose direct parent is not already a ContainerQuoteNode
+  // (i.e. not inside an existing shadow root). A selection that straddles a
+  // quote boundary produces topLevelElements from two different root contexts:
+  // root-level blocks AND paragraphs inside the existing ContainerQuoteNode.
+  // Passing both to $wrapInQuote would move nodes across shadow-root
+  // boundaries and create nested shadow roots, which Lexical's reconciler does
+  // not support — causing the editor to freeze.
+  const wrapTargets = sortedElements.filter((el) => {
+    const parent = el.getParent();
+    return parent !== null && !$isContainerQuoteNode(parent);
+  });
+
+  if (wrapTargets.length === 0) {
+    return;
+  }
+
+  $wrapInQuote(wrapTargets);
 }
 
 export const formatParagraph = (editor: LexicalEditor) => {


### PR DESCRIPTION
> When a user highlights text that crosses a ContainerQuoteNode boundary (e.g. a selection that starts outside an existing blockquote and extends into it), $wrapOrUnwrapQuote would collect topLevelElements that included both root-level nodes AND paragraphs that live inside the existing ContainerQuoteNode shadow root. Calling $wrapInQuote on that mixed set moved nodes across shadow-root boundaries and — in the nested-shadow-root case — caused Lexical's reconciler to enter an infinite loop, freezing the editor.
> 
> Fix: after sorting topLevelElements, filter out any element whose direct parent is already a ContainerQuoteNode (i.e. elements that are inside an existing shadow root). Only root-level elements are wrapped in the new ContainerQuoteNode. This preserves existing behaviour for normal wrap/ unwrap and prevents the freeze for cross-boundary selections.
> 
> Bug reported by Ben Pace in #m_bugs-channel 2026-04-17.
> 
> Preview: https://baserates-test-git-claude-beautiful-allen-z2xn3-lesswrong.vercel.app
> Bugs thread: https://lworg.slack.com/archives/CJUN2UAFN/p1776463192564299

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1214450236005391) by [Unito](https://www.unito.io)
