### PR TITLE
Don't throw when no user is found to create a notification

### DIFF
--- a/packages/lesswrong/server/notificationCallbacksHelpers.tsx
+++ b/packages/lesswrong/server/notificationCallbacksHelpers.tsx
@@ -182,7 +182,12 @@ export const createNotification = async ({
   context: ResolverContext,
 }) => {
   let user = await Users.findOne({ _id:userId });
-  if (!user) throw Error(`Wasn't able to find user to create notification for with id: ${userId}`)
+  if (!user) {
+    // eslint-disable-next-line no-console
+    console.error(`Wasn't able to find user to create notification for with id: ${userId}`)
+    return;
+  }
+
   const userSettingField = getNotificationTypeByName(notificationType).userSettingField;
   const notificationTypeSettings = (userSettingField && user[userSettingField])
     ? legacyToNewNotificationTypeSettings(user[userSettingField])


### PR DESCRIPTION
We had some subscriptions in the database for a user who was hard-deleted at some point (not sure why). This meant that a user they subscribed to was unable to create quick takes because sending notifications threw an error.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1214584224565882) by [Unito](https://www.unito.io)
