### PR TITLE
Add async Akismet bio triage

### DIFF
--- a/packages/lesswrong/server/akismet.ts
+++ b/packages/lesswrong/server/akismet.ts
@@ -27,12 +27,23 @@ const getAkismetClient = () => {
   return akismetClient;
 }
 
+async function getLatestLoginEventData(userId: string, context: ResolverContext) {
+  const { LWEvents } = context;
+  const events = await LWEvents.find({userId, name: 'login'}, {sort: {createdAt: -1}, limit: 1}).fetch()
+  const latestLogin = events?.[0];
+  return {
+    ip: latestLogin?.properties?.ip,
+    userAgent: latestLogin?.properties?.userAgent,
+    referrer: latestLogin?.properties?.referrer,
+  }
+}
+
 async function constructAkismetReport({document, type="post", context}: {
   document: AnyBecauseTodo
   type: string
   context: ResolverContext
 }) {
-  const { Users, Posts, LWEvents } = context;
+  const { Users, Posts } = context;
   const author = await Users.findOne(document.userId)
   if (!author) throw Error("Couldn't find author for Akismet report")
   let post = document
@@ -40,10 +51,7 @@ async function constructAkismetReport({document, type="post", context}: {
     post = await Posts.findOne(document.postId)
   }
   const link = (post && postGetPageUrl(post)) || ""  // Don't get link if we create a comment without a post
-  const events = await LWEvents.find({userId: author._id, name: 'login'}, {sort: {createdAt: -1}, limit: 1}).fetch()
-  const ip = events && events[0] && events[0].properties && events[0].properties.ip
-  const userAgent = events && events[0] && events[0].properties && events[0].properties.userAgent
-  const referrer = events && events[0] && events[0].properties && events[0].properties.referrer
+  const { ip, userAgent, referrer } = await getLatestLoginEventData(author._id, context)
 
   const content = type === "post"
     ? (await getLatestContentsRevision(document, context))?.html
@@ -62,6 +70,27 @@ async function constructAkismetReport({document, type="post", context}: {
   }
 }
 
+async function constructAkismetBioReport(user: DbUser, context: ResolverContext) {
+  const { ip, userAgent, referrer } = await getLatestLoginEventData(user._id, context)
+  if (!ip) {
+    // eslint-disable-next-line no-console
+    console.log(`Skipping Akismet bio spam check for user ${user._id}: no login IP found.`);
+    return null;
+  }
+
+  const profilePath = user.slug ? `/users/${user.slug}` : "";
+  return {
+    user_ip: ip,
+    user_agent: userAgent,
+    referrer,
+    permalink: akismetURLSetting.get() + profilePath,
+    comment_type: 'signup',
+    comment_author: user.displayName,
+    comment_content: user.biography?.html,
+    is_test: isDevelopment,
+  }
+}
+
 export async function checkForAkismetSpam({document, type, context}: AnyBecauseTodo) {
   try {
     if (document?.contents?.html?.indexOf("spam-test-string-123") >= 0) {
@@ -77,6 +106,28 @@ export async function checkForAkismetSpam({document, type, context}: AnyBecauseT
   } catch (e) {
     // eslint-disable-next-line no-console
     console.error("Akismet spam checker crashed. Classifying as not spam.", e)
+    return false
+  }
+}
+
+export async function checkUserBioForAkismetSpam(user: DbUser, context: ResolverContext) {
+  try {
+    if ((user.biography?.html?.indexOf("spam-test-string-123") ?? -1) >= 0) {
+      // eslint-disable-next-line no-console
+      console.log(`User ${user._id} bio contained Akismet spam filter test string; marking as spam.`);
+      return true;
+    }
+
+    const akismetReport = await constructAkismetBioReport(user, context);
+    if (!akismetReport) return false;
+
+    const spam = await getAkismetClient().checkSpam(akismetReport);
+    // eslint-disable-next-line no-console
+    console.log("Checked user bio for spam: ", { userId: user._id, spam });
+    return spam;
+  } catch (e) {
+    // eslint-disable-next-line no-console
+    console.error("Akismet bio spam checker crashed. Classifying as not spam.", e)
     return false
   }
 }

--- a/packages/lesswrong/server/collections/users/mutations.ts
+++ b/packages/lesswrong/server/collections/users/mutations.ts
@@ -8,6 +8,7 @@ import { approveUnreviewedSubmissions, changeDisplayNameRateLimit, clearKarmaCha
 import { createInitialRevisionsForEditableFields, reuploadImagesIfEditableFieldsChanged, uploadImagesInEditableFields, notifyUsersOfNewPingbackMentions, createRevisionsForEditableFields, updateRevisionsDocumentIds } from "@/server/editor/make_editable_callbacks";
 import { logFieldChanges } from "@/server/fieldChanges";
 import { elasticSyncDocument } from "@/server/search/elastic/elasticCallbacks";
+import { maybeFlagUserBioForSpamWithAkismet } from "@/server/users/akismetBio";
 import { runSlugCreateBeforeCallback, runSlugUpdateBeforeCallback } from "@/server/utils/slugUtil";
 import { getCreatableGraphQLFields, getUpdatableGraphQLFields } from "@/server/vulcan-lib/apollo-server/graphqlTemplates";
 import { makeGqlCreateMutation, makeGqlUpdateMutation } from "@/server/vulcan-lib/apollo-server/helpers";
@@ -15,6 +16,7 @@ import { getLegacyCreateCallbackProps, getLegacyUpdateCallbackProps, insertAndRe
 import { dataToModifier, modifierToData } from "@/server/vulcan-lib/validation";
 import gql from "graphql-tag";
 import cloneDeep from "lodash/cloneDeep";
+import { captureException } from "@sentry/core";
 
 function newCheck() {
   return true;
@@ -135,6 +137,7 @@ export async function updateUser({ selector, data }: { data: UpdateUserDataInput
   await updateCountOfReferencesOnOtherCollectionsAfterUpdate('Users', updatedDocument, oldDocument);
 
   updateUserMayTriggerReview(updateCallbackProperties);
+  void maybeFlagUserBioForSpamWithAkismet(updatedDocument, oldDocument, context).catch(captureException);
   await userEditDeleteContentCallbacksAsync(updateCallbackProperties);
 
   await newSubforumMemberNotifyMods(updatedDocument, oldDocument, context);

--- a/packages/lesswrong/server/users/akismetBio.ts
+++ b/packages/lesswrong/server/users/akismetBio.ts
@@ -1,0 +1,45 @@
+import { getSignatureWithNote } from "@/lib/collections/users/helpers";
+import { akismetKeySetting } from "../databaseSettings";
+import { checkUserBioForAkismetSpam } from "../akismet";
+
+const AKISMET_BIO_FLAG_NOTE = "Profile bio was flagged as possible spam by Akismet. Review bio links before approving.";
+
+export async function maybeFlagUserBioForSpamWithAkismet(updatedUser: DbUser, oldUser: DbUser, context: ResolverContext) {
+  const newBioHtml = updatedUser.biography?.html ?? "";
+  const oldBioHtml = oldUser.biography?.html ?? "";
+
+  if (
+    newBioHtml === oldBioHtml ||
+    !newBioHtml.trim() ||
+    updatedUser.reviewedByUserId ||
+    !akismetKeySetting.get()
+  ) {
+    return;
+  }
+
+  const spam = await checkUserBioForAkismetSpam(updatedUser, context);
+  if (!spam) return;
+
+  const latestUser = await context.Users.findOne({_id: updatedUser._id});
+  if (
+    !latestUser ||
+    latestUser.reviewedByUserId ||
+    latestUser.biography?.html !== newBioHtml
+  ) {
+    return;
+  }
+
+  const oldNotes = latestUser.sunshineNotes ?? "";
+  await context.Users.rawUpdateOne({
+    _id: updatedUser._id,
+    reviewedByUserId: null,
+    "biography.html": newBioHtml,
+    sunshineNotes: oldNotes,
+  }, {
+    $set: {
+      needsReview: true,
+      sunshineFlagged: true,
+      sunshineNotes: `${getSignatureWithNote("Akismet", AKISMET_BIO_FLAG_NOTE)}${oldNotes}`,
+    },
+  });
+}

--- a/packages/lesswrong/unitTests/akismetBio.tests.ts
+++ b/packages/lesswrong/unitTests/akismetBio.tests.ts
@@ -1,0 +1,184 @@
+const mockAkismetClient = {
+  verifyKey: jest.fn(() => new Promise(() => {})),
+  checkSpam: jest.fn(),
+  submitHam: jest.fn(),
+  submitSpam: jest.fn(),
+};
+
+jest.mock('akismet-api', () => ({
+  __esModule: true,
+  default: {
+    client: jest.fn(() => mockAkismetClient),
+  },
+}));
+
+import { akismetKeySetting, akismetURLSetting } from "../server/databaseSettings";
+import { maybeFlagUserBioForSpamWithAkismet } from "../server/users/akismetBio";
+
+const spamBioHtml = '<p>Please visit <a href="https://spam.example">my site</a></p>';
+
+function makeBiography(html: string): NonNullable<DbUser["biography"]> {
+  return { html } as NonNullable<DbUser["biography"]>;
+}
+
+function makeUser(overrides: Partial<DbUser> = {}): DbUser {
+  return {
+    _id: "user1",
+    slug: "user-one",
+    displayName: "User One",
+    reviewedByUserId: null,
+    biography: makeBiography(spamBioHtml),
+    sunshineNotes: "",
+    ...overrides,
+  } as DbUser;
+}
+
+function makeContext({loginEvent, latestUser}: {
+  loginEvent?: AnyBecauseTodo,
+  latestUser?: DbUser|null,
+} = {}) {
+  const event = loginEvent === undefined
+    ? {
+      properties: {
+        ip: "1.2.3.4",
+        userAgent: "test user agent",
+        referrer: "https://google.example",
+      },
+    }
+    : loginEvent;
+  const fetch = jest.fn().mockResolvedValue(event ? [event] : []);
+  const find = jest.fn(() => ({fetch}));
+  const findOne = jest.fn().mockResolvedValue(latestUser ?? makeUser());
+  const rawUpdateOne = jest.fn().mockResolvedValue(1);
+
+  return {
+    context: {
+      LWEvents: { find },
+      Users: { findOne, rawUpdateOne },
+    } as unknown as ResolverContext,
+    find,
+    fetch,
+    findOne,
+    rawUpdateOne,
+  };
+}
+
+describe("maybeFlagUserBioForSpamWithAkismet", () => {
+  beforeEach(() => {
+    jest.restoreAllMocks();
+    mockAkismetClient.checkSpam.mockReset();
+    mockAkismetClient.verifyKey.mockClear();
+    mockAkismetClient.submitHam.mockClear();
+    mockAkismetClient.submitSpam.mockClear();
+
+    jest.spyOn(console, "log").mockImplementation(() => {});
+    jest.spyOn(akismetKeySetting, "get").mockReturnValue("akismet-key");
+    jest.spyOn(akismetURLSetting, "get").mockReturnValue("https://forum.example");
+  });
+
+  it("flags unreviewed users when Akismet marks a changed bio as spam", async () => {
+    mockAkismetClient.checkSpam.mockResolvedValue(true);
+    const oldUser = makeUser({ biography: makeBiography("") });
+    const updatedUser = makeUser();
+    const latestUser = makeUser({ sunshineNotes: "Existing note\n" });
+    const { context, rawUpdateOne } = makeContext({ latestUser });
+
+    await maybeFlagUserBioForSpamWithAkismet(updatedUser, oldUser, context);
+
+    expect(mockAkismetClient.checkSpam).toHaveBeenCalledWith(expect.objectContaining({
+      user_ip: "1.2.3.4",
+      user_agent: "test user agent",
+      referrer: "https://google.example",
+      permalink: "https://forum.example/users/user-one",
+      comment_type: "signup",
+      comment_author: "User One",
+      comment_content: spamBioHtml,
+    }));
+    const akismetPayload = mockAkismetClient.checkSpam.mock.calls[0][0];
+    expect(akismetPayload).not.toHaveProperty("comment_author_email");
+    expect(akismetPayload).not.toHaveProperty("comment_author_url");
+
+    expect(rawUpdateOne).toHaveBeenCalledWith({
+      _id: "user1",
+      reviewedByUserId: null,
+      "biography.html": spamBioHtml,
+      sunshineNotes: "Existing note\n",
+    }, {
+      $set: expect.objectContaining({
+        needsReview: true,
+        sunshineFlagged: true,
+        sunshineNotes: expect.stringContaining("Akismet: Profile bio was flagged as possible spam by Akismet. Review bio links before approving.\nExisting note\n"),
+      }),
+    });
+  });
+
+  it("does not flag users when Akismet returns ham", async () => {
+    mockAkismetClient.checkSpam.mockResolvedValue(false);
+    const oldUser = makeUser({ biography: makeBiography("") });
+    const { context, rawUpdateOne } = makeContext();
+
+    await maybeFlagUserBioForSpamWithAkismet(makeUser(), oldUser, context);
+
+    expect(mockAkismetClient.checkSpam).toHaveBeenCalledTimes(1);
+    expect(rawUpdateOne).not.toHaveBeenCalled();
+  });
+
+  it("does not call Akismet for reviewed users", async () => {
+    const oldUser = makeUser({ biography: makeBiography("") });
+    const reviewedUser = makeUser({ reviewedByUserId: "mod1" });
+    const { context, find, rawUpdateOne } = makeContext();
+
+    await maybeFlagUserBioForSpamWithAkismet(reviewedUser, oldUser, context);
+
+    expect(find).not.toHaveBeenCalled();
+    expect(mockAkismetClient.checkSpam).not.toHaveBeenCalled();
+    expect(rawUpdateOne).not.toHaveBeenCalled();
+  });
+
+  it("does not call Akismet when the bio is unchanged or empty", async () => {
+    const unchangedUser = makeUser();
+    const emptyBioUser = makeUser({ biography: makeBiography("   ") });
+    const { context, find, rawUpdateOne } = makeContext();
+
+    await maybeFlagUserBioForSpamWithAkismet(unchangedUser, makeUser(), context);
+    await maybeFlagUserBioForSpamWithAkismet(emptyBioUser, makeUser({ biography: makeBiography("") }), context);
+
+    expect(find).not.toHaveBeenCalled();
+    expect(mockAkismetClient.checkSpam).not.toHaveBeenCalled();
+    expect(rawUpdateOne).not.toHaveBeenCalled();
+  });
+
+  it("does not call Akismet when the Akismet key is missing", async () => {
+    jest.spyOn(akismetKeySetting, "get").mockReturnValue(null);
+    const oldUser = makeUser({ biography: makeBiography("") });
+    const { context, find, rawUpdateOne } = makeContext();
+
+    await maybeFlagUserBioForSpamWithAkismet(makeUser(), oldUser, context);
+
+    expect(find).not.toHaveBeenCalled();
+    expect(mockAkismetClient.checkSpam).not.toHaveBeenCalled();
+    expect(rawUpdateOne).not.toHaveBeenCalled();
+  });
+
+  it("does not call Akismet when no login IP is available", async () => {
+    const oldUser = makeUser({ biography: makeBiography("") });
+    const { context, rawUpdateOne } = makeContext({ loginEvent: null });
+
+    await maybeFlagUserBioForSpamWithAkismet(makeUser(), oldUser, context);
+
+    expect(mockAkismetClient.checkSpam).not.toHaveBeenCalled();
+    expect(rawUpdateOne).not.toHaveBeenCalled();
+  });
+
+  it("fails open when Akismet throws", async () => {
+    jest.spyOn(console, "error").mockImplementation(() => {});
+    mockAkismetClient.checkSpam.mockRejectedValue(new Error("Akismet unavailable"));
+    const oldUser = makeUser({ biography: makeBiography("") });
+    const { context, rawUpdateOne } = makeContext();
+
+    await maybeFlagUserBioForSpamWithAkismet(makeUser(), oldUser, context);
+
+    expect(mockAkismetClient.checkSpam).toHaveBeenCalledTimes(1);
+    expect(rawUpdateOne).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add an async Akismet check for changed profile bios on unreviewed users
- flag likely-spam bios for moderator review using existing moderation fields
- avoid new DB fields, migrations, UI changes, or bio ham/spam training

## Tests
- yarn unit --runTestsByPath packages/lesswrong/unitTests/akismetBio.tests.ts
- yarn tsc --noEmit

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1214591305368725) by [Unito](https://www.unito.io)
