### PR TITLE
Filter rejected content from shared queries and clean up notifications

### DIFF
--- a/packages/lesswrong/lib/collections/posts/helpers.ts
+++ b/packages/lesswrong/lib/collections/posts/helpers.ts
@@ -424,8 +424,8 @@ export const isRecombeeRecommendablePost = (post: Pick<DbPost, keyof PostsBase &
   );
 };
 
-export const postIsPublic = (post: Pick<DbPost, '_id' | 'draft' | 'status'>) => {
-  return !post.draft && post.status === postStatuses.STATUS_APPROVED
+export const postIsPublic = (post: Pick<DbPost, '_id' | 'draft' | 'status' | 'rejected'>) => {
+  return !post.draft && post.status === postStatuses.STATUS_APPROVED && !post.rejected
 };
 
 export type PostParticipantInfo = Pick<PostsDetails, "userId"|"debate"|"coauthorUserIds">;

--- a/packages/lesswrong/lib/collections/posts/views.ts
+++ b/packages/lesswrong/lib/collections/posts/views.ts
@@ -428,7 +428,6 @@ function userPosts(terms: PostsViewTerms) {
       shortform: viewFieldAllowAny,
       groupId: null, // TODO: fix vulcan so it doesn't do deep merges on viewFieldAllowAny
       $or: [{userId: terms.userId}, {coauthorUserIds: terms.userId}],
-      rejected: null
     },
     options: {
       limit: 5,

--- a/packages/lesswrong/server/callbacks/commentCallbackFunctions.tsx
+++ b/packages/lesswrong/server/callbacks/commentCallbackFunctions.tsx
@@ -1231,6 +1231,8 @@ export async function removeCommentNotificationsOnHidden(comment: DbComment, old
   const { Notifications } = context;
   if (!commentIsNotPublicForAnyReason(oldComment) && commentIsNotPublicForAnyReason(comment)) {
     const notifications = await Notifications.find({ documentId: comment._id }).fetch();
-    notifications.forEach(notification => void updateNotification({ data: { deleted: true }, selector: { _id: notification._id } }, context));
+    await Promise.all(notifications.map(notification =>
+      updateNotification({ data: { deleted: true }, selector: { _id: notification._id } }, context)
+    ));
   }
 }

--- a/packages/lesswrong/server/callbacks/commentCallbackFunctions.tsx
+++ b/packages/lesswrong/server/callbacks/commentCallbackFunctions.tsx
@@ -28,6 +28,7 @@ import { postGetPageUrl } from "@/lib/collections/posts/helpers";
 import { wrapAndSendEmail } from "../emails/renderEmail";
 import { subscriptionTypes } from "@/lib/collections/subscriptions/helpers";
 import { swrInvalidatePostRoute } from "../cache/swr";
+import { updateNotification } from "../collections/notifications/mutations";
 import { getAdminTeamAccount } from "../utils/adminTeamAccount";
 import _ from "underscore";
 import moment from "moment";
@@ -1223,5 +1224,13 @@ export async function commentsEditSoftDeleteCallback(comment: DbComment, oldComm
 export async function commentsPublishedNotifications(comment: DbComment, oldComment: DbComment, context: ResolverContext) {
   if (commentIsNotPublicForAnyReason(oldComment) && !commentIsNotPublicForAnyReason(comment)) {
     void utils.sendNewCommentNotifications(comment, context)
+  }
+}
+
+export async function removeCommentNotificationsOnHidden(comment: DbComment, oldComment: DbComment, context: ResolverContext) {
+  const { Notifications } = context;
+  if (!commentIsNotPublicForAnyReason(oldComment) && commentIsNotPublicForAnyReason(comment)) {
+    const notifications = await Notifications.find({ documentId: comment._id }).fetch();
+    notifications.forEach(notification => void updateNotification({ data: { deleted: true }, selector: { _id: notification._id } }, context));
   }
 }

--- a/packages/lesswrong/server/callbacks/postCallbackFunctions.tsx
+++ b/packages/lesswrong/server/callbacks/postCallbackFunctions.tsx
@@ -1029,12 +1029,15 @@ export async function sendNewPublishedDialogueMessageNotifications(newPost: DbPo
   }
 }
 
-export async function removeRedraftNotifications(newPost: Pick<DbPost, '_id' | 'draft' | 'status'>, oldPost: DbPost, context: ResolverContext) {
+export async function removeRedraftNotifications(newPost: Pick<DbPost, '_id' | 'draft' | 'status' | 'rejected'>, oldPost: DbPost, context: ResolverContext) {
   const { Notifications, TagRels } = context;
 
-  if (!postIsPublic(newPost) && postIsPublic(oldPost)) {
+  const wasPublic = postIsPublic(oldPost) && !oldPost.rejected;
+  const isPublic = postIsPublic(newPost) && !newPost.rejected;
+
+  if (wasPublic && !isPublic) {
       //eslint-disable-next-line no-console
-    console.info("Post redrafted, removing notifications");
+    console.info("Post no longer public, removing notifications");
 
     // delete post notifications
     const postNotifications = await Notifications.find({documentId: newPost._id}).fetch()

--- a/packages/lesswrong/server/callbacks/postCallbackFunctions.tsx
+++ b/packages/lesswrong/server/callbacks/postCallbackFunctions.tsx
@@ -1032,10 +1032,7 @@ export async function sendNewPublishedDialogueMessageNotifications(newPost: DbPo
 export async function removeRedraftNotifications(newPost: Pick<DbPost, '_id' | 'draft' | 'status' | 'rejected'>, oldPost: DbPost, context: ResolverContext) {
   const { Notifications, TagRels } = context;
 
-  const wasPublic = postIsPublic(oldPost) && !oldPost.rejected;
-  const isPublic = postIsPublic(newPost) && !newPost.rejected;
-
-  if (wasPublic && !isPublic) {
+  if (!postIsPublic(newPost) && postIsPublic(oldPost)) {
       //eslint-disable-next-line no-console
     console.info("Post no longer public, removing notifications");
 

--- a/packages/lesswrong/server/collections/comments/mutations.ts
+++ b/packages/lesswrong/server/collections/comments/mutations.ts
@@ -4,7 +4,7 @@ import { userIsAllowedToComment } from "@/lib/collections/users/helpers";
 import { isElasticEnabled } from "@/lib/instanceSettings";
 import { accessFilterSingle } from "@/lib/utils/schemaUtils";
 import { userCanDo, userOwns } from "@/lib/vulcan-users/permissions";
-import { addReferrerToComment, assignPostVersion, checkCommentForSpamWithAkismet, checkModGPTOnCommentCreate, checkModGPTOnCommentUpdate, commentsAlignmentEdit, commentsAlignmentNew, commentsEditSoftDeleteCallback, commentsNewNotifications, commentsNewOperations, commentsNewUserApprovedStatus, commentsPublishedNotifications, createShortformPost, editedCommentTriggerPangram, handleForumEventMetadataEdit, handleForumEventMetadataNew, handleReplyToAnswer, invalidatePostOnCommentCreate, invalidatePostOnCommentUpdate, lwCommentsNewUpvoteOwnComment, moveToAnswers, newCommentsEmptyCheck, newCommentsPollResponseCheck, newCommentsRateLimit, newCommentTriggerReview, newCommentTriggerPangram, handleDraftState, setTopLevelCommentId, trackCommentRateLimitHit, updatedCommentMaybeTriggerReview, updateDescendentCommentCountsOnCreate, updateDescendentCommentCountsOnEdit, updatePostLastCommentPromotedAt, updateUserNotesOnCommentRejection, validateDeleteOperations } from "@/server/callbacks/commentCallbackFunctions";
+import { addReferrerToComment, assignPostVersion, checkCommentForSpamWithAkismet, checkModGPTOnCommentCreate, checkModGPTOnCommentUpdate, commentsAlignmentEdit, commentsAlignmentNew, commentsEditSoftDeleteCallback, commentsNewNotifications, commentsNewOperations, commentsNewUserApprovedStatus, commentsPublishedNotifications, createShortformPost, editedCommentTriggerPangram, handleForumEventMetadataEdit, handleForumEventMetadataNew, handleReplyToAnswer, invalidatePostOnCommentCreate, invalidatePostOnCommentUpdate, lwCommentsNewUpvoteOwnComment, moveToAnswers, newCommentsEmptyCheck, newCommentsPollResponseCheck, newCommentsRateLimit, newCommentTriggerReview, newCommentTriggerPangram, handleDraftState, removeCommentNotificationsOnHidden, setTopLevelCommentId, trackCommentRateLimitHit, updatedCommentMaybeTriggerReview, updateDescendentCommentCountsOnCreate, updateDescendentCommentCountsOnEdit, updatePostLastCommentPromotedAt, updateUserNotesOnCommentRejection, validateDeleteOperations } from "@/server/callbacks/commentCallbackFunctions";
 import { updateCountOfReferencesOnOtherCollectionsAfterCreate, updateCountOfReferencesOnOtherCollectionsAfterUpdate } from "@/server/callbacks/countOfReferenceCallbacks";
 import { upsertPolls } from "@/server/callbacks/forumEventCallbacks";
 import { sendAlignmentSubmissionApprovalNotifications } from "@/server/callbacks/sharedCallbackFunctions";
@@ -187,6 +187,7 @@ export async function updateComment({ selector, data }: UpdateCommentInput, cont
   // There really has to be a currentUser here.
   await commentsEditSoftDeleteCallback(updatedDocument, oldDocument, currentUser!, context);
   await commentsPublishedNotifications(updatedDocument, oldDocument, context);
+  await removeCommentNotificationsOnHidden(updatedDocument, oldDocument, context);
   await sendAlignmentSubmissionApprovalNotifications(updatedDocument, oldDocument);  
 
   await reuploadImagesIfEditableFieldsChanged({

--- a/packages/lesswrong/server/permissions/accessFilters.ts
+++ b/packages/lesswrong/server/permissions/accessFilters.ts
@@ -43,6 +43,9 @@ const clientIdCheckAccess: CheckAccessFunction<'ClientIds'> = async (currentUser
 }
 
 const commentCheckAccess: CheckAccessFunction<'Comments'> = async (currentUser, document, context): Promise<boolean> => {
+  // Rejected comments are intentionally accessible by direct fetch (parallel to
+  // postCheckAccess), so users can audit moderation decisions via the moderation
+  // log. Default views still hide rejected comments from feeds.
   if (!document.draft) {
     return true;
   }

--- a/packages/lesswrong/server/repos/CommentsRepo.ts
+++ b/packages/lesswrong/server/repos/CommentsRepo.ts
@@ -56,6 +56,7 @@ class CommentsRepo extends AbstractRepo<"Comments"> {
           ROW_NUMBER() OVER (PARTITION BY comment_with_rownumber."postId" ORDER BY comment_with_rownumber."postedAt" DESC) as rn
         FROM "Comments" comment_with_rownumber
         WHERE comment_with_rownumber."postId" IN ($1:csv)
+        AND comment_with_rownumber."rejected" IS NOT TRUE
         AND (
           ${filterWhereClause}
         )
@@ -88,6 +89,7 @@ class CommentsRepo extends AbstractRepo<"Comments"> {
           LIMIT $1
       ) v
       ON c._id = v."documentId"
+      WHERE c."rejected" IS NOT TRUE
       ORDER BY v.most_recent_react DESC;
     `, [limit]);
   }
@@ -144,7 +146,8 @@ class CommentsRepo extends AbstractRepo<"Comments"> {
           "retracted" IS NOT TRUE AND
           "deleted" IS NOT TRUE AND
           "deletedPublic" IS NOT TRUE AND
-          "needsReview" IS NOT TRUE
+          "needsReview" IS NOT TRUE AND
+          "rejected" IS NOT TRUE
           ${afCommentsFilter}
         ORDER BY "postId", "baseScore" DESC
       ) q
@@ -235,6 +238,7 @@ class CommentsRepo extends AbstractRepo<"Comments"> {
     return this.getRawDb().any(`
       -- CommentsRepo.getSearchDocuments
       ${this.getSearchDocumentQuery()}
+      WHERE COALESCE(c."rejected", FALSE) IS FALSE
       ORDER BY c."createdAt" DESC
       LIMIT $1
       OFFSET $2
@@ -244,7 +248,7 @@ class CommentsRepo extends AbstractRepo<"Comments"> {
   async countSearchDocuments(): Promise<number> {
     const {count} = await this.getRawDb().one(`
       -- CommentsRepo.countSearchDocuents
-      SELECT COUNT(*) FROM "Comments"
+      SELECT COUNT(*) FROM "Comments" WHERE COALESCE("rejected", FALSE) IS FALSE
     `);
     return count;
   }
@@ -262,6 +266,7 @@ class CommentsRepo extends AbstractRepo<"Comments"> {
         AND ($2 IS NULL OR c."postedAt" >= $2)
         AND c."postedAt" <= $3
         AND c."deleted" IS NOT TRUE
+        AND c."rejected" IS NOT TRUE
       GROUP BY
         window_start_key
       ORDER BY
@@ -313,6 +318,7 @@ class CommentsRepo extends AbstractRepo<"Comments"> {
           AND "retracted" IS NOT TRUE
           AND "deletedPublic" IS NOT TRUE
           AND "moderatorHat" IS NOT TRUE
+          AND "rejected" IS NOT TRUE
           AND ${shortformCondition}
           AND "postedAt" > $1
           AND "postedAt" < $2

--- a/packages/lesswrong/server/repos/CommentsRepo.ts
+++ b/packages/lesswrong/server/repos/CommentsRepo.ts
@@ -81,15 +81,15 @@ class CommentsRepo extends AbstractRepo<"Comments"> {
       SELECT c.*
       FROM "Comments" c
       JOIN (
-          SELECT "documentId", MIN("votedAt") AS most_recent_react
-          FROM "Votes"
-          WHERE "collectionName" = 'Comments' AND "extendedVoteType"->'reacts' != '[]'::jsonb
-          GROUP BY "documentId"
+          SELECT v."documentId", MIN(v."votedAt") AS most_recent_react
+          FROM "Votes" v
+          JOIN "Comments" target ON target."_id" = v."documentId" AND target."rejected" IS NOT TRUE
+          WHERE v."collectionName" = 'Comments' AND v."extendedVoteType"->'reacts' != '[]'::jsonb
+          GROUP BY v."documentId"
           ORDER BY most_recent_react DESC
           LIMIT $1
       ) v
       ON c._id = v."documentId"
-      WHERE c."rejected" IS NOT TRUE
       ORDER BY v.most_recent_react DESC;
     `, [limit]);
   }
@@ -238,7 +238,7 @@ class CommentsRepo extends AbstractRepo<"Comments"> {
     return this.getRawDb().any(`
       -- CommentsRepo.getSearchDocuments
       ${this.getSearchDocumentQuery()}
-      WHERE COALESCE(c."rejected", FALSE) IS FALSE
+      WHERE c."rejected" IS NOT TRUE
       ORDER BY c."createdAt" DESC
       LIMIT $1
       OFFSET $2
@@ -248,7 +248,7 @@ class CommentsRepo extends AbstractRepo<"Comments"> {
   async countSearchDocuments(): Promise<number> {
     const {count} = await this.getRawDb().one(`
       -- CommentsRepo.countSearchDocuents
-      SELECT COUNT(*) FROM "Comments" WHERE COALESCE("rejected", FALSE) IS FALSE
+      SELECT COUNT(*) FROM "Comments" WHERE "rejected" IS NOT TRUE
     `);
     return count;
   }

--- a/packages/lesswrong/server/repos/CommentsRepo.ts
+++ b/packages/lesswrong/server/repos/CommentsRepo.ts
@@ -56,7 +56,6 @@ class CommentsRepo extends AbstractRepo<"Comments"> {
           ROW_NUMBER() OVER (PARTITION BY comment_with_rownumber."postId" ORDER BY comment_with_rownumber."postedAt" DESC) as rn
         FROM "Comments" comment_with_rownumber
         WHERE comment_with_rownumber."postId" IN ($1:csv)
-        AND comment_with_rownumber."rejected" IS NOT TRUE
         AND (
           ${filterWhereClause}
         )
@@ -81,11 +80,10 @@ class CommentsRepo extends AbstractRepo<"Comments"> {
       SELECT c.*
       FROM "Comments" c
       JOIN (
-          SELECT v."documentId", MIN(v."votedAt") AS most_recent_react
-          FROM "Votes" v
-          JOIN "Comments" target ON target."_id" = v."documentId" AND target."rejected" IS NOT TRUE
-          WHERE v."collectionName" = 'Comments' AND v."extendedVoteType"->'reacts' != '[]'::jsonb
-          GROUP BY v."documentId"
+          SELECT "documentId", MIN("votedAt") AS most_recent_react
+          FROM "Votes"
+          WHERE "collectionName" = 'Comments' AND "extendedVoteType"->'reacts' != '[]'::jsonb
+          GROUP BY "documentId"
           ORDER BY most_recent_react DESC
           LIMIT $1
       ) v

--- a/packages/lesswrong/server/repos/CommentsRepo.ts
+++ b/packages/lesswrong/server/repos/CommentsRepo.ts
@@ -238,7 +238,6 @@ class CommentsRepo extends AbstractRepo<"Comments"> {
     return this.getRawDb().any(`
       -- CommentsRepo.getSearchDocuments
       ${this.getSearchDocumentQuery()}
-      WHERE c."rejected" IS NOT TRUE
       ORDER BY c."createdAt" DESC
       LIMIT $1
       OFFSET $2
@@ -248,7 +247,7 @@ class CommentsRepo extends AbstractRepo<"Comments"> {
   async countSearchDocuments(): Promise<number> {
     const {count} = await this.getRawDb().one(`
       -- CommentsRepo.countSearchDocuents
-      SELECT COUNT(*) FROM "Comments" WHERE "rejected" IS NOT TRUE
+      SELECT COUNT(*) FROM "Comments"
     `);
     return count;
   }

--- a/packages/lesswrong/server/repos/PostsRepo.ts
+++ b/packages/lesswrong/server/repos/PostsRepo.ts
@@ -586,7 +586,6 @@ class PostsRepo extends AbstractRepo<"Posts"> {
     return this.getRawDb().any(`
       -- PostsRepo.getSearchDocuments
       ${this.getSearchDocumentQuery()}
-      WHERE p."rejected" IS NOT TRUE
       ORDER BY p."createdAt" DESC
       LIMIT $1
       OFFSET $2
@@ -596,7 +595,7 @@ class PostsRepo extends AbstractRepo<"Posts"> {
   async countSearchDocuments(): Promise<number> {
     const {count} = await this.getRawDb().one(`
       -- PostsRepo.countSearchDocuments
-      SELECT COUNT(*) FROM "Posts" WHERE "rejected" IS NOT TRUE
+      SELECT COUNT(*) FROM "Posts"
     `);
     return count;
   }

--- a/packages/lesswrong/server/repos/PostsRepo.ts
+++ b/packages/lesswrong/server/repos/PostsRepo.ts
@@ -1283,7 +1283,7 @@ class PostsRepo extends AbstractRepo<"Posts"> {
         SELECT "_id", UNNEST("coauthorStatuses")->>'userId' "coauthorId"
         FROM "Posts"
       ) q ON p."_id" = q."_id"
-      JOIN "Comments" c ON p."_id" = c."postId" AND NOT c."draft" AND NOT c."deleted"
+      JOIN "Comments" c ON p."_id" = c."postId" AND NOT c."draft" AND NOT c."deleted" AND c."rejected" IS NOT TRUE
       WHERE
         (p."userId" = $1 OR q."coauthorId" = $1)
         AND ${getViewablePostsSelector("p")}

--- a/packages/lesswrong/server/repos/PostsRepo.ts
+++ b/packages/lesswrong/server/repos/PostsRepo.ts
@@ -586,6 +586,7 @@ class PostsRepo extends AbstractRepo<"Posts"> {
     return this.getRawDb().any(`
       -- PostsRepo.getSearchDocuments
       ${this.getSearchDocumentQuery()}
+      WHERE COALESCE(p."rejected", FALSE) IS FALSE
       ORDER BY p."createdAt" DESC
       LIMIT $1
       OFFSET $2
@@ -595,7 +596,7 @@ class PostsRepo extends AbstractRepo<"Posts"> {
   async countSearchDocuments(): Promise<number> {
     const {count} = await this.getRawDb().one(`
       -- PostsRepo.countSearchDocuments
-      SELECT COUNT(*) FROM "Posts"
+      SELECT COUNT(*) FROM "Posts" WHERE COALESCE("rejected", FALSE) IS FALSE
     `);
     return count;
   }

--- a/packages/lesswrong/server/repos/PostsRepo.ts
+++ b/packages/lesswrong/server/repos/PostsRepo.ts
@@ -586,7 +586,7 @@ class PostsRepo extends AbstractRepo<"Posts"> {
     return this.getRawDb().any(`
       -- PostsRepo.getSearchDocuments
       ${this.getSearchDocumentQuery()}
-      WHERE COALESCE(p."rejected", FALSE) IS FALSE
+      WHERE p."rejected" IS NOT TRUE
       ORDER BY p."createdAt" DESC
       LIMIT $1
       OFFSET $2
@@ -596,7 +596,7 @@ class PostsRepo extends AbstractRepo<"Posts"> {
   async countSearchDocuments(): Promise<number> {
     const {count} = await this.getRawDb().one(`
       -- PostsRepo.countSearchDocuments
-      SELECT COUNT(*) FROM "Posts" WHERE COALESCE("rejected", FALSE) IS FALSE
+      SELECT COUNT(*) FROM "Posts" WHERE "rejected" IS NOT TRUE
     `);
     return count;
   }

--- a/packages/lesswrong/server/repos/helpers.ts
+++ b/packages/lesswrong/server/repos/helpers.ts
@@ -26,6 +26,7 @@ export const getViewablePostsSelector = (postsTableAlias?: string) => {
     ${aliasPrefix}"authorIsUnreviewed" = FALSE AND
     ${aliasPrefix}"hiddenRelatedQuestion" = FALSE AND
     ${aliasPrefix}"isEvent" = FALSE AND
+    ${aliasPrefix}"rejected" IS NOT TRUE AND
     ${aliasPrefix}"postedAt" IS NOT NULL
   `;
 };

--- a/packages/lesswrong/server/search/elastic/ElasticConfig.ts
+++ b/packages/lesswrong/server/search/elastic/ElasticConfig.ts
@@ -57,6 +57,16 @@ export type IndexConfig = {
   /**
    * Filters to completely remove entries from the result set, irregardless of their
    * relevancy to the query. This is often used to remove deleted data.
+   *
+   * Convention: ForumMagnum indexes every row regardless of visibility (draft,
+   * deleted, rejected, authorIsUnreviewed, retracted, spam, etc.) and applies
+   * the filtering here at query time. Don't add WHERE clauses to the bulk-export
+   * methods (`getSearchDocuments` / `countSearchDocuments`) or to
+   * `getSearchDocumentById` — the per-document update path (`elasticSyncDocument`
+   * → `ElasticExporter.updateDocument`) always re-indexes the full row, so a
+   * filter applied only at bulk export drifts back to inconsistent the next time
+   * the row is touched. If something must not appear in search, add it to the
+   * relevant `filters` array below.
    */
   filters?: QueryDslQueryContainer[],
   /**


### PR DESCRIPTION
## Summary

Pre-work for enabling the rejection feature on EA Forum. The default Posts and Comments views already filter `rejected: { $ne: true }`, but a number of shared query helpers, paginated resolvers, and notification callbacks bypass the default view and were leaking rejected content (or attributing karma/stats to it). This PR plugs those gaps without changing any visible behavior on either forum today, since both LessWrong and EA Forum already have the rejection schema and rejected content is rare.

The MVP wiring to actually expose the rejection UI on EA Forum (instance setting flip, comment-side `isLWorAF` gate, forum-aware DM template) is intentionally **not** in this PR — it'll come in a follow-up so this hygiene change can land independently.

### Server-side filter helpers
- `getViewablePostsSelector` was missing the rejected filter that the default Posts view has. Used in 18+ queries (sitemap, embeddings, sequences, collections, recommendations, user profile counts, etc.). One-line addition closes all of them at once.
- `userPosts` view had `rejected: null`, which overrode the default filter and surfaced a user's rejected posts on their public profile. Removed; rejected content is auditable via the existing `/moderation` log instead.

### Public paginated resolvers and per-page queries
Each query gained a `"rejected" IS NOT TRUE` filter:
- `CommentsRepo.getPopularComments` — public `PopularComments` resolver, on the homepage rail. The other negative-state checks (`deleted`, `deletedPublic`, `retracted`, `needsReview`) were already there; rejected just joins them.
- `CommentsRepo.getCommentsPerDay` — engagement-chart counts.
- `CommentsRepo.getAuthorshipStats` — Wrapped year-in-review (was inflating both the count and the percentile).
- `PostsRepo.getUsersMostCommentedPostSince` — inactive-user-summary digest email.

### Notification cleanup on rejection
- `postIsPublic` now treats `rejected` as not-public. The other call sites (`sendNewPostNotifications`, `taggedPostNewNotifications`) also benefit: rejected posts no longer trigger publish or tag-subscriber notifications.
- `removeRedraftNotifications` now fires on the public→rejected transition too, marking subscribers' related notifications as `deleted: true`. Previously a published-then-rejected post left subscribers with notifications linking to content they could no longer see.
- New `removeCommentNotificationsOnHidden` does the symmetric thing for comments — fires on the public→non-public transition (rejection, soft-delete, or hidden-pending-review). Wired up in the comment update mutation alongside the existing `commentsPublishedNotifications` (which handles the inverse direction).

### Policy comment
- `commentCheckAccess` now documents that rejected comments are intentionally accessible by direct fetch, parallel to `postCheckAccess`. No behavior change.

### Documentation: ES indexer convention
- Added a paragraph to the `IndexConfig.filters` doc in `ElasticConfig.ts` capturing that ForumMagnum indexes every row regardless of visibility flags and applies filtering at query time. Don't add WHERE clauses to the bulk-export methods — the per-document update path always re-indexes the full row, so a bulk-only filter creates drift between `recreateIndex` and steady-state.

### Considered and reverted on this branch
For full traceability of what we audited and chose not to change:
- **ES bulk-indexer filter** (`fb9c12f`): I had added `WHERE rejected IS NOT TRUE` to `getSearchDocuments` / `countSearchDocuments` for both Posts and Comments. Reverted because the per-document update path (`elasticSyncDocument` → `getSearchDocumentById`) re-indexes every row regardless, so the bulk filter just creates drift. Captured in the `ElasticConfig.ts` doc comment instead.
- **`getCommentsWithReacts` filter** (`6d589f4`): Not used on EA Forum, and the query didn't filter `deleted`/`retracted`/`spam` either, so a rejected-only filter was asymmetric. Pre-existing leak left for a separate audit.
- **`getRecentCommentsOnPosts` filter** (`6d589f4`): Redundant. The caller in `lib/collections/posts/helpers.ts` already merges `getDefaultViewSelector("Comments")` into its filter, which compiles to SQL with full draft/deleted/rejected handling.

## Test plan

- [ ] `yarn lint` (root + CkEditor) and `yarn unit`.
- [ ] `yarn integration` covers `moderation.server.tests.ts` end-to-end rejection flow on Posts and Comments. Verify it still passes.
- [ ] Manual smoke (LessWrong / EA dev DB):
  - [ ] Reject a post: verify the notifications it generated for subscribers are marked deleted, and the post no longer appears in `/allPosts`, the sitemap, the user's profile feed, or the popular feed.
  - [ ] Reject a comment: verify the comment doesn't appear in the `PopularComments` feed, isn't counted in the per-day engagement chart, and that any reply-notifications it generated are marked deleted.
  - [ ] Confirm `/moderation` (`RejectedPostsList` / `RejectedCommentsList`) still surfaces rejected items as before.
  - [ ] Confirm Wrapped stats no longer attribute rejected comments to a user's count/percentile.

## Notes for reviewers

- I didn't update the `getPopularComments` partial index at `commentsDbIndexes.ts:113` to include `rejected`. Rejected has very low selectivity so a planner regression seems unlikely; can be added later if query plans degrade.
- I didn't extract a shared `deleteNotificationsByDocumentId` helper or refactor the pre-existing fire-and-forget `forEach` loop in `removeRedraftNotifications` — kept scope tight; both are reasonable follow-ups.
- I didn't touch the `getEAKarmaChanges` SQL (also missing a rejected filter); per discussion that's not blocking the rejection MVP.
- `getCommentsWithReacts` is missing filters for `deleted`/`retracted`/`spam`, exposing those comments in the public `CommentsWithReacts` feed. Not used on EA Forum so left alone here, but worth a separate fix for LW.
- Schema unchanged; no migrations.

https://claude.ai/code/session_01SMb6Sc161Dth8LUf68DDLF