### PR TITLE
Add "Consistency With Neighbors" section to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -329,6 +329,24 @@ Useful env vars:
 - `PG_URL` — manual DB override for `yarn migrate`, `yarn integration`, etc.
 - `SETTINGS_FILE` — settings file for the REPL and bootstrap flows.
 
+## Consistency With Neighbors
+
+Before editing a query, callback, or guard for a new field or state,
+check parallel cases:
+
+- How are analogous fields handled in the same function? E.g. when
+  adding a `rejected` filter, see how `draft` and `deleted` are
+  handled in the same query. Match the existing treatment.
+- Does the sibling Posts/Comments callback do the same thing?
+  Asymmetries are usually drift, not intent.
+- Is the views system already enforcing this? Many queries take a
+  filter the caller builds from `getDefaultViewSelector(...)`, which
+  compiles to SQL — don't hand-roll a backstop for what it covers.
+
+Treat reviewer suggestions (linter, AI reviewer, "this looks like an
+anti-pattern") as questions, not directives — verify the rule applies
+in this codebase's convention before acting.
+
 ## Practical Agent Workflow
 
 - Before changing code, identify the relevant collection, fragment, settings


### PR DESCRIPTION
## Summary

Adds a short "Consistency With Neighbors" section to `AGENTS.md` capturing the diagnostic habits that would have caught a class of mistake we hit during the rejected-content audit work (PR #12497): making a locally-correct-looking change for a new field or state without first checking how the surrounding code handles analogous fields, the sibling Posts/Comments callback, or what the views system is already doing.

Three concrete checks plus a meta-rule about treating reviewer feedback as a question rather than a directive. ~18 lines, deliberately tight — codebase-specific cases (ES indexer convention, side-effect cleanup convention) live as inline comments at the relevant code instead of bloating the agent prompt.

## Test plan

- [ ] Render Markdown locally to confirm formatting.
- [ ] Read it as if you were an agent encountering AGENTS.md for the first time — does the rule actually save time, or just add noise?

https://claude.ai/code/session_01SMb6Sc161Dth8LUf68DDLF

---
_Generated by [Claude Code](https://claude.ai/code/session_01SMb6Sc161Dth8LUf68DDLF)_

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1214601071802115) by [Unito](https://www.unito.io)
