### PR TITLE
Hide content of deleted comments on /moderation page

### DIFF
--- a/app/moderation/ModerationPageContent.tsx
+++ b/app/moderation/ModerationPageContent.tsx
@@ -1089,42 +1089,35 @@ export default function ModerationPageContent(props: Props) {
             </thead>
             <tbody>
               {deletedComments.map((comment) => (
-                <React.Fragment key={comment._id}>
-                  <tr className={classes.tr} onClick={() => toggleRowExpanded(comment._id)}>
-                    <td className={classes.td} data-label="Date">
-                      <span className={classes.date}>
-                        {comment.deletedDate ? new Date(comment.deletedDate).toLocaleDateString() : '—'}
-                      </span>
-                    </td>
-                    <td className={classes.td} data-label="Author">
-                      {comment.user ? (
-                        <a href={userGetProfileUrl(comment.user)} className={classes.link}>
-                          {comment.user.displayName}
-                        </a>
-                      ) : '—'}
-                    </td>
-                    <td className={classes.td} data-label="Post">
-                      {comment.post ? (
-                        <a href={postGetPageUrl(comment.post)} className={classes.titleLink}>
-                          {comment.post.title}
-                        </a>
-                      ) : '—'}
-                    </td>
-                    <td className={classes.td} data-label="Reason">{renderPlainTextReason(comment.deletedReason)}</td>
-                    <td className={classes.td} data-label="Deleted By">
-                      {comment.deletedByUser ? (
-                        <a href={userGetProfileUrl(comment.deletedByUser)} className={classes.link}>
-                          {comment.deletedByUser.displayName}
-                        </a>
-                      ) : '—'}
-                    </td>
-                  </tr>
-                  {expandedRows.has(comment._id) && (
-                    <tr>
-                      <td colSpan={5}>{renderContent(comment.contents)}</td>
-                    </tr>
-                  )}
-                </React.Fragment>
+                <tr key={comment._id} className={classes.trNonExpandable}>
+                  <td className={classes.td} data-label="Date">
+                    <span className={classes.date}>
+                      {comment.deletedDate ? new Date(comment.deletedDate).toLocaleDateString() : '—'}
+                    </span>
+                  </td>
+                  <td className={classes.td} data-label="Author">
+                    {comment.user ? (
+                      <a href={userGetProfileUrl(comment.user)} className={classes.link}>
+                        {comment.user.displayName}
+                      </a>
+                    ) : '—'}
+                  </td>
+                  <td className={classes.td} data-label="Post">
+                    {comment.post ? (
+                      <a href={postGetPageUrl(comment.post)} className={classes.titleLink}>
+                        {comment.post.title}
+                      </a>
+                    ) : '—'}
+                  </td>
+                  <td className={classes.td} data-label="Reason">{renderPlainTextReason(comment.deletedReason)}</td>
+                  <td className={classes.td} data-label="Deleted By">
+                    {comment.deletedByUser ? (
+                      <a href={userGetProfileUrl(comment.deletedByUser)} className={classes.link}>
+                        {comment.deletedByUser.displayName}
+                      </a>
+                    ) : '—'}
+                  </td>
+                </tr>
               ))}
             </tbody>
           </table>

--- a/app/moderation/page.tsx
+++ b/app/moderation/page.tsx
@@ -167,7 +167,6 @@ type DeletedCommentRow = {
   deletedDate: Date | null;
   deletedReason: string | null;
   deletedPublic: boolean | null;
-  contents: any;
   user__id: string | null;
   user_displayName: string | null;
   user_slug: string | null;
@@ -466,7 +465,7 @@ async function fetchDeletedComments(db: SqlClient, limit: number, offset: number
       WITH paginated_comments AS (
         SELECT
           c._id, c."userId", c."postId", c."deletedDate", c."deletedReason",
-          c."deletedPublic", c.contents, c."deletedByUserId"
+          c."deletedPublic", c."deletedByUserId"
         FROM "Comments" c
         WHERE c.deleted = TRUE AND c."deletedPublic" = TRUE
         ORDER BY c."deletedDate" DESC NULLS LAST
@@ -474,7 +473,7 @@ async function fetchDeletedComments(db: SqlClient, limit: number, offset: number
       )
       SELECT
         c._id, c."userId", c."postId", c."deletedDate", c."deletedReason",
-        c."deletedPublic", c.contents,
+        c."deletedPublic",
         u._id as "user__id", u."displayName" as "user_displayName", u.slug as "user_slug",
         du._id as "deletedByUser__id", du."displayName" as "deletedByUser_displayName", du.slug as "deletedByUser_slug",
         p._id as "post__id", p.title as "post_title", p.slug as "post_slug"
@@ -498,7 +497,6 @@ async function fetchDeletedComments(db: SqlClient, limit: number, offset: number
     deletedDate: row.deletedDate ?? null,
     deletedReason: row.deletedReason ?? null,
     deletedPublic: row.deletedPublic ?? null,
-    contents: row.contents,
     user: row.user__id && row.user_slug ? { _id: row.user__id, displayName: row.user_displayName ?? null, slug: row.user_slug } : null,
     deletedByUser: row.deletedByUser__id && row.deletedByUser_slug ? { _id: row.deletedByUser__id, displayName: row.deletedByUser_displayName ?? null, slug: row.deletedByUser_slug } : null,
     post: row.post__id && row.post_slug && row.post_title ? { _id: row.post__id, title: row.post_title, slug: row.post_slug } : null,


### PR DESCRIPTION
## Summary
- The Deleted Comments table on `/moderation` previously had clickable rows that expanded to reveal the full HTML of the deleted comment. This change removes that expansion so the content stays hidden.
- Also stops sending the deleted comment `contents` to the client at all (no longer SELECTed in the SQL query, no longer included in the row mapping or row type), so the content isn't leaked via page source either.
- The visible columns (Date, Author, Post, Reason, Deleted By) are unchanged.

## Test plan
- [ ] Visit `/moderation` and confirm the Deleted Comments table still renders with the same columns.
- [ ] Confirm rows in that table are no longer clickable / no longer expand.
- [ ] View page source and confirm deleted comment HTML is no longer present.

Made with [Cursor](https://cursor.com)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1214626739587825) by [Unito](https://www.unito.io)
