### PR TITLE
Make Pangram window highlights dark-mode readable

### DIFF
--- a/packages/lesswrong/components/sunshineDashboard/helpers.ts
+++ b/packages/lesswrong/components/sunshineDashboard/helpers.ts
@@ -404,11 +404,15 @@ function findElementsInRange(
  *   38% → ~52% of hue range → yellow-orange
  *   10% → ~20% of hue range → yellow-green
  *    1% → ~4% of hue range → green
+ *
+ * In dark mode we drop lightness so the (now-light) document text stays
+ * readable on top of the highlight, while keeping the hue gradient so
+ * red/green still mean what they did in light mode.
  */
 function scoreToColour(score: number): string {
   const adjustedRatio = Math.pow(Math.max(0, Math.min(1, score)), 0.7);
   const hue = 120 - (adjustedRatio * 120);
-  return `hsl(${hue}, 100%, 85%)`;
+  return `light-dark(hsl(${hue}, 100%, 85%), hsl(${hue}, 55%, 25%))`;
 }
 
 /**

--- a/packages/lesswrong/components/sunshineDashboard/helpers.ts
+++ b/packages/lesswrong/components/sunshineDashboard/helpers.ts
@@ -404,10 +404,6 @@ function findElementsInRange(
  *   38% → ~52% of hue range → yellow-orange
  *   10% → ~20% of hue range → yellow-green
  *    1% → ~4% of hue range → green
- *
- * In dark mode we drop lightness so the (now-light) document text stays
- * readable on top of the highlight, while keeping the hue gradient so
- * red/green still mean what they did in light mode.
  */
 function scoreToColour(score: number): string {
   const adjustedRatio = Math.pow(Math.max(0, Math.min(1, score)), 0.7);


### PR DESCRIPTION
## Summary
- `scoreToColour` (used by `highlightHtmlWithPangramWindowScores`, which renders Pangram windowed scores in `LLMScoreDialog` and the new `/admin/pangram` page) returned a fixed light pastel `hsl(hue, 100%, 85%)`. In dark mode the document text flips to light, so light text on a light-pastel highlight was hard to read.
- Wrap the returned color in `light-dark(...)` with a darker variant `hsl(hue, 55%, 25%)` for dark mode. Same hue gradient — red = high AI likelihood, green = low — just darker enough to keep contrast against light text.

## Test plan
- [x] In light mode, open the LLM Score dialog on a post/comment with Pangram windows and confirm the highlights look unchanged.
- [x] Switch to dark mode, repeat, and confirm the highlights are dark with readable text on top.
- [ ] Once #12504 lands, repeat both checks on `/admin/pangram`.

Made with [Cursor](https://cursor.com)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1214627241824363) by [Unito](https://www.unito.io)
