### PR TITLE
Move comment Pangram badge into meta-row flex flow

### DIFF
--- a/packages/lesswrong/components/comments/CommentsItem/CommentsItemMeta.tsx
+++ b/packages/lesswrong/components/comments/CommentsItem/CommentsItemMeta.tsx
@@ -298,6 +298,10 @@ export const CommentsItemMeta = ({
 
       {post && <CommentOutdatedWarning comment={comment} post={post}/>}
 
+      {userIsAdminOrMod(currentUser) && (
+        <PangramBadge contents={comment.contents} collectionName="Comments" documentId={comment._id} />
+      )}
+
       {comment.nominatedForReview &&
         <Link
           to={`/nominations/${comment.nominatedForReview}`}
@@ -336,9 +340,6 @@ export const CommentsItemMeta = ({
       <CommentPollVote comment={comment} />
 
       <span className={classes.rightSection}>
-        {userIsAdminOrMod(currentUser) && (
-          <PangramBadge contents={comment.contents} collectionName="Comments" documentId={comment._id} />
-        )}
         {rightSectionElements}
         {isFriendlyUI &&
           <CommentLinkWrapper>


### PR DESCRIPTION
## Summary
- The comment-row [`PangramBadge`](packages/lesswrong/components/comments/CommentsItem/CommentsItemMeta.tsx) previously sat in the absolutely-positioned `rightSection`. Because the badge body grows leftward and can be ~150px wide when it shows the AI / AI-assisted / Human breakdown, it overlapped the username/date area on the left side of the row.
- Moved the badge into the meta row's flex flow, just after `CommentOutdatedWarning`. The row already uses `flexWrap: "wrap"` with a `rowGap`, so on narrower widths the badge now wraps to a new line instead of overlapping.
- Mod-only gating (`userIsAdminOrMod`) and click-to-rerun behavior are unchanged.

## Test plan
- [ ] As a mod, view a comment thread on the EA Forum and confirm the Pangram badge appears in-row near the karma/reacts and outdated-warning, without overlapping the username/date
- [ ] Resize the viewport narrow enough that the meta row wraps; confirm the badge wraps cleanly rather than colliding with other elements
- [ ] Click the badge to rerun Pangram and confirm the result updates in place
- [ ] As a non-mod logged-in user, confirm the badge is not visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1214633072155594) by [Unito](https://www.unito.io)
