### PR TITLE
Remove duplicate Pangram badges in sunshine dashboard

### DIFF
--- a/packages/lesswrong/components/sunshineDashboard/SunshineNewUserCommentsList.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineNewUserCommentsList.tsx
@@ -4,7 +4,6 @@ import { isLWorAF } from '../../lib/instanceSettings';
 import CommentsNodeInner from "../comments/CommentsNode";
 import RejectContentButton from "./RejectContentButton";
 import RejectedReasonDisplay from "./RejectedReasonDisplay";
-import PangramBadge from "./PangramBadge";
 
 const styles = (theme: ThemeType) => ({
   root: {
@@ -40,9 +39,6 @@ const SunshineNewUserCommentsList = ({comments, user, classes}: {
   return (
     <div className={classes.root}>
       {(newComments.length > 0) && newComments.map(comment=><div className={classes.comment} key={`sunshine-new-user-${comment._id}`}>
-        <div className={classes.rightAlignedRow}>
-          <PangramBadge contents={comment.contents} collectionName="Comments" documentId={comment._id}/>
-        </div>
         {isLWorAF && <div className={classes.rightAlignedRow}>
           {comment.rejected && <RejectedReasonDisplay reason={comment.rejectedReason}/>}
           <RejectContentButton contentWrapper={{collectionName:"Comments", content:comment}}/>

--- a/packages/lesswrong/components/sunshineDashboard/SunshineReportedItem.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineReportedItem.tsx
@@ -102,18 +102,15 @@ const SunshineReportedItem = ({report, updateReport, classes, currentUser, refet
       <SunshineListItem hover={hover}>
         <SidebarHoverOver hover={hover} anchorEl={anchorEl} >
           <Typography variant="body2">
-            {comment && <>
-              <PangramBadge contents={comment.contents} collectionName="Comments" documentId={comment._id} />
-              <CommentsNodeInner
-                treeOptions={{
-                  condensed: false,
-                  post: comment.post || undefined,
-                  tag: comment.tag || undefined,
-                  showPostTitle: true,
-                }}
-                comment={comment}
-              />
-            </>}
+            {comment && <CommentsNodeInner
+              treeOptions={{
+                condensed: false,
+                post: comment.post || undefined,
+                tag: comment.tag || undefined,
+                showPostTitle: true,
+              }}
+              comment={comment}
+            />}
             {post && !comment && <div>
               <PangramBadge contents={post.contents} collectionName="Posts" documentId={post._id} />
               <PostsTitle post={post}/>


### PR DESCRIPTION
## Summary
- The Pangram badge is now rendered in the comment meta row (admin-gated in `CommentsItemMeta`), so the explicit copies in `SunshineNewUserCommentsList` and the comment branch of `SunshineReportedItem` were showing the badge twice.
- Removes those two explicit renders. The post-side badge in `SunshineReportedItem` stays (the post path doesn't go through `CommentsItemMeta`).
- `SunshineNewCommentsItem` was checked but renders `<CommentBody>` directly (not `CommentsItem`), so its badge is not a duplicate and was left alone.

## Test plan
- [ ] As an admin, view the sunshine sidebar's New Comments / Reported Content / New User Comments lists and confirm exactly one Pangram badge per comment.
- [ ] Confirm the post-side badge still shows in `SunshineReportedItem` for reported posts.
- [ ] Confirm `SunshineNewCommentsItem`'s hover-over still shows the badge above the comment body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1214633509471722) by [Unito](https://www.unito.io)
