### PR TITLE
Update LLM disclosure alert copy

### DIFF
--- a/packages/lesswrong/components/posts/NewPostAIPolicy.tsx
+++ b/packages/lesswrong/components/posts/NewPostAIPolicy.tsx
@@ -161,7 +161,7 @@ export const NewPostAIPolicy = ({postId, editContentsRef, classes}: {
         <ForumIcon icon="InfoCircle" className={classes.info} />
         <div className={classes.content}>
           <div>
-            Drafted with an LLM? Our{" "}
+            Likely that more than 10% of your post was drafted by an LLM? Our{" "}
             <Link to={POLICY_LINK}>AI usage policy</Link>{" "}
             requires disclosure at the top of your post.
           </div>


### PR DESCRIPTION
## Summary
- Update the post editor LLM disclosure alert to refer to posts likely drafted more than 10% by an LLM

## Testing
- Not run; copy-only change

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1214790793230299) by [Unito](https://www.unito.io)
