### PR TITLE
Update new post AI disclosure guidance

### DIFF
--- a/packages/lesswrong/components/common/ForumIcon.tsx
+++ b/packages/lesswrong/components/common/ForumIcon.tsx
@@ -42,6 +42,7 @@ import ChatBubbleLeftRightIcon from "@heroicons/react/24/outline/ChatBubbleLeftR
 import ChatBubbleLeftRightFilledIcon from "@heroicons/react/24/solid/ChatBubbleLeftRightIcon";
 import LightbulbIcon from "@heroicons/react/24/outline/LightBulbIcon";
 import WarningIcon from "@heroicons/react/24/solid/ExclamationTriangleIcon";
+import WarningOutlineIcon from "@heroicons/react/24/outline/ExclamationTriangleIcon";
 import ReportIcon from "@heroicons/react/24/outline/ExclamationCircleIcon";
 import ListBulletIcon from "@heroicons/react/24/outline/ListBulletIcon";
 import TagIcon from "@heroicons/react/24/outline/TagIcon";
@@ -216,6 +217,7 @@ export type ForumIconName =
   "ChatBubbleLeftRightFilled" |
   "Shortform" |
   "Warning" |
+  "WarningOutline" |
   "Report" |
   "ListBullet" |
   "Eye" |
@@ -348,6 +350,7 @@ const ICONS: ForumOptions<Record<ForumIconName, IconComponent>> = {
     ChatBubbleLeftRightFilled: MuiForumIcon,
     Shortform: MuiNotesIcon,
     Warning: MuiWarningIcon,
+    WarningOutline: WarningOutlineIcon,
     ListBullet: ListBulletIcon,
     Report: MuiReportIcon,
     Tag: MuiTagIcon,
@@ -479,6 +482,7 @@ const ICONS: ForumOptions<Record<ForumIconName, IconComponent>> = {
     ChatBubbleLeftRightFilled: ChatBubbleLeftRightFilledIcon,
     Shortform: LightbulbIcon,
     Warning: WarningIcon,
+    WarningOutline: WarningOutlineIcon,
     ListBullet: ListBulletIcon,
     Report: ReportIcon,
     Tag: TagIcon,

--- a/packages/lesswrong/components/posts/NewPostAIPolicy.tsx
+++ b/packages/lesswrong/components/posts/NewPostAIPolicy.tsx
@@ -63,26 +63,26 @@ const styles = (theme: ThemeType) => ({
 });
 
 const disclosureHtml = `
-<p>Please <strong>edit the below</strong> so that your disclosure is accurate:</p>
+<p>The following are examples. Please <strong>edit the below</strong> so that your disclosure is accurate:</p>
 <ul>
   <li>
-    This post is the raw output of an LLM.
+    <em>This post is the raw output of an LLM.</em>
   </li>
   <li>
-    I wrote this post myself, then asked an LLM to copy-edit it before posting.
+    <em>I used AI to assist in writing this post, and it’s likely that >30% is AI-generated text.</em>
   </li>
   <li>
-    I used an LLM to help draft this post, but I’ve edited/rewritten it extensively
-    and endorse it.
+    <em>I used an LLM to help draft this post and it likely contains >10% AI-generated text, but I’ve edited/rewritten it extensively
+    and endorse it.</em>
   </li>
 </ul>
 `;
 
-const disclosureMarkdown = `Please **edit the below** so that your disclosure is accurate:
- - This post is the raw output of an LLM.
- - I wrote this post myself, then asked an LLM to copy-edit it before posting.
- - I used an LLM to help draft this post, but I’ve edited/rewritten it extensively
-   and endorse it.
+const disclosureMarkdown = `The following are examples. Please **edit the below** so that your disclosure is accurate:
+ - *This post is the raw output of an LLM.*
+ - *I used AI to assist in writing this post, and it’s likely that >30% is AI-generated text.*
+ - *I used an LLM to help draft this post and it likely contains >10% AI-generated text, but I’ve edited/rewritten it extensively
+    and endorse it.*
 
 `;
 

--- a/packages/lesswrong/components/posts/NewPostHowToGuides.tsx
+++ b/packages/lesswrong/components/posts/NewPostHowToGuides.tsx
@@ -74,6 +74,11 @@ const guides: HowToGuide[] = [
     label: "Guide to norms on the Forum",
     url: "/posts/yND9aGJgobm5dEXqF/guide-to-norms-on-the-forum",
   },
+  {
+    icon: "WarningOutline",
+    label: "LLM-use policy",
+    url: "/posts/bxA9fsY9Psgarcq6e/new-ea-forum-llm-use-policy",
+  },
 ];
 
 export const NewPostHowToGuides = ({classes}: {
@@ -95,7 +100,13 @@ export const NewPostHowToGuides = ({classes}: {
           <ForumIcon icon="Close" />
         </div>
         {guides.map(({icon, label, url}) =>
-          <Link to={url} className={classes.howToGuide} key={label}>
+          <Link
+            to={url}
+            className={classes.howToGuide}
+            key={label}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
             <ForumIcon icon={icon} /> {label}
           </Link>
         )}
@@ -109,5 +120,4 @@ export default registerComponent(
   NewPostHowToGuides,
   {styles},
 );
-
 


### PR DESCRIPTION
Summary:
- Update AI disclosure examples and italicize inserted examples
- Add LLM-use policy to the new post guide links
- Open guide links in a new tab

<img width="970" height="340" alt="Screenshot 2026-05-14 at 3 45 03 PM" src="https://github.com/user-attachments/assets/f952a294-eabf-4ef8-b718-9189252423e5" />

<img width="970" height="371" alt="Screenshot 2026-05-14 at 3 45 21 PM" src="https://github.com/user-attachments/assets/08b4ed6e-b8fd-4b3d-ad8c-76b229af8c79" />

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1214825839115339) by [Unito](https://www.unito.io)
