### PR TITLE
prevent entire summary form from getting dragged

### DIFF
--- a/packages/lesswrong/components/form-components/sortableList.tsx
+++ b/packages/lesswrong/components/form-components/sortableList.tsx
@@ -1,18 +1,53 @@
 import React, { useCallback } from 'react';
 import type { ReactNode } from 'react';
-import { DndContext, PointerSensor, useSensor, useSensors, closestCenter, DragEndEvent, KeyboardSensor, Modifiers, MouseSensor } from '@dnd-kit/core';
+import { DndContext, PointerSensor, useSensor, useSensors, closestCenter, DragEndEvent, KeyboardSensor, Modifiers, MouseSensor, DraggableAttributes, DraggableSyntheticListeners } from '@dnd-kit/core';
 import { arrayMove, SortableContext, rectSortingStrategy, verticalListSortingStrategy, horizontalListSortingStrategy, useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 import without from 'lodash/without';
 
 /**
+ * Props that the caller can attach to whichever element should act as the
+ * drag handle. Spread them onto a single element (e.g. an icon) to scope
+ * drag activation to that element instead of the whole item.
+ */
+export interface DragHandleProps {
+  ref: (node: HTMLElement | null) => void;
+  attributes: DraggableAttributes;
+  listeners: DraggableSyntheticListeners;
+}
+
+interface RenderItemArgsBase {
+  contents: string;
+  removeItem: (id: string) => void;
+}
+
+interface RenderItemArgsWithHandle extends RenderItemArgsBase {
+  dragHandleProps: DragHandleProps;
+}
+
+type MakeSortableListComponentArgs =
+  | {
+      RenderItem: (args: RenderItemArgsBase) => ReactNode;
+      customDragHandle?: never;
+    }
+  | {
+      RenderItem: (args: RenderItemArgsWithHandle) => ReactNode;
+      customDragHandle: true;
+    };
+
+/**
  * Create a sortable list component that wraps some arbitrary render
  * function. `RenderItem` receives the item's `contents` (usually an id) and a
  * function that allows the item to remove itself from the list.
+ *
+ * By default, the entire item wrapper is the drag activator. Pass
+ * `customDragHandle: true` to suppress that and instead receive a
+ * `dragHandleProps` bag in `RenderItem`; spread it onto whatever element you
+ * want to act as the handle. This is the right choice when the item contains
+ * text, form fields, or other interactive content that would otherwise be
+ * hijacked by the drag listeners.
  */
-export function makeSortableListComponent({ RenderItem }: {
-  RenderItem: (args: { contents: string, removeItem: (id: string) => void }) => ReactNode;
-}) {
+export function makeSortableListComponent(args: MakeSortableListComponentArgs) {
   const SortableItem = ({ id, removeItem }: {
     id: string;
     removeItem: (id: string) => void;
@@ -21,6 +56,7 @@ export function makeSortableListComponent({ RenderItem }: {
       attributes,
       listeners,
       setNodeRef,
+      setActivatorNodeRef,
       transform,
       transition,
       isDragging,
@@ -29,12 +65,23 @@ export function makeSortableListComponent({ RenderItem }: {
     const style: React.CSSProperties = {
       transform: CSS.Transform.toString(transform),
       transition,
-      cursor: 'grab',
+      cursor: args.customDragHandle ? undefined : 'grab',
       opacity: isDragging ? 0.7 : 1,
     };
 
+    if (args.customDragHandle) {
+      const dragHandleProps: DragHandleProps = {
+        ref: setActivatorNodeRef,
+        attributes,
+        listeners,
+      };
+      return <span ref={setNodeRef} style={style}>
+        <args.RenderItem contents={id} removeItem={removeItem} dragHandleProps={dragHandleProps} />
+      </span>;
+    }
+
     return <span ref={setNodeRef} style={style} {...attributes} {...listeners}>
-      <RenderItem contents={id} removeItem={removeItem} />
+      <args.RenderItem contents={id} removeItem={removeItem} />
     </span>;
   };
 

--- a/packages/lesswrong/components/tagging/SummariesEditForm.tsx
+++ b/packages/lesswrong/components/tagging/SummariesEditForm.tsx
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 import { MouseSensor, PointerSensor, useSensor, useSensors } from "@dnd-kit/core";
 import { defineStyles, useStyles } from "@/components/hooks/useStyles";
 import classNames from "classnames";
-import { makeSortableListComponent } from "../form-components/sortableList";
+import { DragHandleProps, makeSortableListComponent } from "../form-components/sortableList";
 import { useMutation } from "@apollo/client/react";
 import { useQuery } from "@/lib/crud/useQuery"
 import { gql } from "@/lib/generated/gql-codegen";
@@ -162,7 +162,7 @@ const styles = defineStyles("SummariesEditForm", (theme: ThemeType) => ({
     color: theme.palette.grey[500],
   },
   dragHandle: {
-    cursor: 'pointer',
+    cursor: 'grab',
     transform: 'rotate(-90deg)',
     flexShrink: 0,
     alignSelf: 'start',
@@ -247,10 +247,15 @@ const NewSummaryEditor = ({ parentDocumentId, collectionName, refetchSummaries, 
   </div>
 }
 
-export const SortableRowHandle = ({children}: { children?: React.ReactNode }) => {
+export const SortableRowHandle = ({ dragHandleProps }: { dragHandleProps: DragHandleProps }) => {
   const classes = useStyles(styles);
 
-  return <span className={classes.dragHandle}>
+  return <span
+    ref={dragHandleProps.ref}
+    {...dragHandleProps.attributes}
+    {...dragHandleProps.listeners}
+    className={classes.dragHandle}
+  >
     <LWTooltip title="Drag to reorder" placement='left'>
       <ForumIcon icon="DragIndicator" className={classes.dragIndicatorIcon} />
     </LWTooltip>
@@ -314,10 +319,11 @@ const SummariesEditForm = ({ parentDocumentId, collectionName }: SummariesEditFo
   // We need to do this inside of the component to get the summary by id, to pass through to SummaryEditorRow
   // Our sortable list wrapper currently only deal with arrays of strings, and it doesn't seem worth refactoring right now.
   const SortableSummaryRowList = makeSortableListComponent({
-    RenderItem: ({contents, removeItem}) => {
+    customDragHandle: true,
+    RenderItem: ({ contents, dragHandleProps }) => {
       const classes = useStyles(styles);
       return <li className={classes.sortableListItem}>
-        <SortableRowHandle />
+        <SortableRowHandle dragHandleProps={dragHandleProps} />
         <SummaryEditorRow summary={summariesById[contents]} refetch={refetch} />
       </li>
     }


### PR DESCRIPTION
Make it so that `makeSortableListComponent` optionally lets you control what part of the rendered sortable item acts as the drag handle from the callsite, and use that to fix summaries.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1215123377442006) by [Unito](https://www.unito.io)
