### PR TITLE
Fix LaTeX input size after editor opens

### DIFF
--- a/packages/lesswrong/components/editor/lexicalPlugins/math/MathEditorPanel.tsx
+++ b/packages/lesswrong/components/editor/lexicalPlugins/math/MathEditorPanel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useEffect, useRef, useState, useCallback } from 'react';
+import React, { useEffect, useLayoutEffect, useRef, useState, useCallback } from 'react';
 import { createPortal } from 'react-dom';
 import { defineStyles, useStyles } from '../../../hooks/useStyles';
 import { renderEquation } from './loadMathJax';
@@ -140,8 +140,8 @@ function MathEditorPanel({
   }, [equation, isInline, isOpen]);
 
   // Auto-resize textarea
-  useEffect(() => {
-    if (inputRef.current) {
+  useLayoutEffect(() => {
+    if (isOpen && inputRef.current) {
       const textarea = inputRef.current;
       textarea.style.height = 'auto';
       textarea.style.height = `${Math.max(textarea.scrollHeight, 24)}px`;
@@ -151,7 +151,7 @@ function MathEditorPanel({
       const maxLength = Math.max(...lines.map(l => l.length), 20);
       textarea.style.width = `${Math.min((maxLength * 8) + 24, 500)}px`;
     }
-  }, [equation]);
+  }, [equation, isOpen]);
 
   const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
     if (e.key === 'Enter' && !e.shiftKey) {


### PR DESCRIPTION
In the Lexical editor, when editing a LaTeX equation, it auto-resizes the input box on edit. However, when clicking on an existing equation, it got a default size, which was too small, until some edit is made. Make it auto-resize when entering edit mode, similar to the resize that happens on change.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1215124598734446) by [Unito](https://www.unito.io)
