### PR TITLE
Fix syntax-highlight colors in inverted-color direct messages

### DIFF
--- a/packages/lesswrong/components/messaging/MessageItem.tsx
+++ b/packages/lesswrong/components/messaging/MessageItem.tsx
@@ -22,6 +22,7 @@ import { SideItemsSidebar } from '../contents/SideItems';
 import { commentBodyStyles, postBodyStyles } from '@/themes/stylePiping';
 import { defineStyles } from '@/components/hooks/defineStyles';
 import { useStyles } from '@/components/hooks/useStyles';
+import { invertHexColor, invertIfDarkMode } from '@/themes/colorUtil';
 
 const styles = defineStyles('MessageItem', (theme: ThemeType) => ({
   hoverWrapper: {
@@ -75,13 +76,10 @@ const styles = defineStyles('MessageItem', (theme: ThemeType) => ({
   },
   highlighted: {},
   backgroundIsCurrent: {
-    backgroundColor: theme.palette.grey[700],
-    color: theme.palette.inverseGreyAlpha(.87),
-    '& *, & $messageBody *, & $messageBody li::marker': {
-      color: theme.palette.inverseGreyAlpha(.87),
-    },
+    backgroundColor: theme.dark ? invertHexColor('#616161') : '#616161',
+    colorScheme: theme.dark ? "light" : "dark",
     "&$highlighted": {
-      backgroundColor: theme.palette.grey[500],
+      backgroundColor: theme.dark ? invertHexColor('#9e9e9e') : '#9e9e9e',
     },
     marginLeft:12,
   },
@@ -89,7 +87,7 @@ const styles = defineStyles('MessageItem', (theme: ThemeType) => ({
     marginBottom: 4,
   },
   whiteMeta: {
-    color: theme.palette.inverseGreyAlpha(.93),
+    color: theme.palette.greyAlpha(.93),
   },
   messageBody: {
     ...postBodyStyles(theme),


### PR DESCRIPTION
In MessageItem, messages sent by the other person are dark-on-light, while messages sent by the current user are light-on-dark (or vise-versa in dark mode). The version that's inverted relative to the selected theme was handled with a hacky CSS `*` descendent selector, overriding the color on (almost) all elements. However code blocks came out looking bad, because they have some built in syntax highlighting that specifies text colors, and those text colors, while dark-mode-aware, assumed that the dark-modiness of the code block was the same as the page as a whole.

Remove this hack, replacing it with `colorScheme: theme.dark ? "light" : "dark"`. This is possible with our styles/theming as they are now (the whole color palette uses CSS `light-dark`), and naturally inverts the colors for all descendent elements, including using dark-mode syntax highlight colors where appropriate.


<img width="1052" height="950" alt="Screenshot 2026-05-25 at 23 13 18" src="https://github.com/user-attachments/assets/abf7c465-33ea-425d-8451-74128b2c6d36" />

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1215124775693211) by [Unito](https://www.unito.io)
