### PR TITLE
Fix orphaned (missing postId) comments

### DIFF
--- a/packages/lesswrong/server/collections/comments/mutations.ts
+++ b/packages/lesswrong/server/collections/comments/mutations.ts
@@ -1,6 +1,7 @@
 import schema from "@/lib/collections/comments/newSchema";
 import { userIsAllowedToComment } from "@/lib/collections/users/helpers";
 import { isElasticEnabled } from "@/lib/instanceSettings";
+import { captureException } from "@/lib/sentryWrapper";
 import { sanitizeRejectionReason } from "@/lib/utils/sanitize";
 import { accessFilterSingle } from "@/lib/utils/schemaUtils";
 import { userCanDo, userOwns } from "@/lib/vulcan-users/permissions";
@@ -18,8 +19,43 @@ import { getLegacyCreateCallbackProps, getLegacyUpdateCallbackProps, insertAndRe
 import gql from "graphql-tag";
 import cloneDeep from "lodash/cloneDeep";
 
+/**
+ * When creating a comment which is a reply (ie, has `parentCommentId`), use the parent comment
+ * to fill in postId and tagId if missing, and if not missing, ensure they're consistent between
+ * the mutation options and the parent comment.
+ */
+async function applyParentCommentContext(
+  data: CreateCommentDataInput,
+  context: ResolverContext,
+  currentUser: DbUser | null,
+) {
+  if (!data.parentCommentId) return;
+
+  const parentComment = await context.loaders.Comments.load(data.parentCommentId);
+  if (!parentComment) return;
+
+  const conflictingFields = [
+    data.postId && parentComment.postId && data.postId !== parentComment.postId ? "postId" : null,
+    data.tagId && parentComment.tagId && data.tagId !== parentComment.tagId ? "tagId" : null,
+  ].filter((field): field is string => !!field);
+
+  if (conflictingFields.length) {
+    captureException(new Error(
+      `Comment reply submitted with conflicting parent context: fields=${conflictingFields.join(",")}, ` +
+      `parentCommentId=${parentComment._id}, userId=${currentUser?._id ?? "none"}, ` +
+      `submittedPostId=${data.postId ?? "null"}, parentPostId=${parentComment.postId ?? "null"}, ` +
+      `submittedTagId=${data.tagId ?? "null"}, parentTagId=${parentComment.tagId ?? "null"}`
+    ));
+  }
+
+  data.postId = parentComment.postId ?? null;
+  data.tagId = parentComment.tagId ?? null;
+}
+
 async function newCheck(user: DbUser | null, document: CreateCommentDataInput | null, context: ResolverContext) {
   if (!user || !document) return false;
+
+  await applyParentCommentContext(document, context, user);
   
   newCommentsEmptyCheck(document);
   await newCommentsRateLimit(document, user, context);
@@ -51,6 +87,8 @@ async function editCheck(user: DbUser | null, document: DbComment | null, contex
 
 export async function createComment({ data }: CreateCommentInput, context: ResolverContext) {
   const { currentUser } = context;
+
+  await applyParentCommentContext(data, context, currentUser);
 
   // rejectedReason is rendered raw on the public /moderation page; sanitize on
   // every write so a compromised mod account can't produce stored XSS.

--- a/packages/lesswrong/server/migrations/20260526T080000.backfill_reply_comment_context.ts
+++ b/packages/lesswrong/server/migrations/20260526T080000.backfill_reply_comment_context.ts
@@ -1,0 +1,86 @@
+interface CommentContextFields {
+  _id: string,
+  parentCommentId: string | null,
+  postId: string | null,
+  tagId: string | null,
+}
+
+interface CommentContext {
+  postId: string | null,
+  tagId: string | null,
+}
+
+async function fetchCommentContext(db: MigrationContext["db"], commentId: string) {
+  return await db.oneOrNone<CommentContextFields>(`
+    SELECT "_id", "parentCommentId", "postId", "tagId"
+    FROM "Comments"
+    WHERE "_id" = $(commentId)
+  `, { commentId });
+}
+
+async function getInheritedCommentContext(
+  db: MigrationContext["db"],
+  comment: CommentContextFields,
+  commentsById: Map<string, CommentContextFields>,
+): Promise<CommentContext | null> {
+  const visitedCommentIds = new Set<string>([comment._id]);
+  let parentCommentId = comment.parentCommentId;
+
+  while (parentCommentId) {
+    if (visitedCommentIds.has(parentCommentId)) return null;
+
+    visitedCommentIds.add(parentCommentId);
+    const parentComment = commentsById.get(parentCommentId) ?? await fetchCommentContext(db, parentCommentId);
+    if (!parentComment) return null;
+
+    commentsById.set(parentComment._id, parentComment);
+
+    if (parentComment.postId || parentComment.tagId) {
+      return {
+        postId: parentComment.postId,
+        tagId: parentComment.tagId,
+      };
+    }
+
+    parentCommentId = parentComment.parentCommentId;
+  }
+
+  return null;
+}
+
+export const up = async ({db}: MigrationContext) => {
+  const comments = await db.any<CommentContextFields>(`
+    SELECT "_id", "parentCommentId", "postId", "tagId"
+    FROM "Comments"
+    WHERE "parentCommentId" IS NOT NULL
+      AND "postId" IS NULL
+      AND "tagId" IS NULL
+  `);
+
+  const commentsById = new Map(comments.map((comment) => [comment._id, comment]));
+
+  for (const comment of comments) {
+    const inheritedContext = await getInheritedCommentContext(db, comment, commentsById);
+    if (!inheritedContext) continue;
+
+    await db.none(`
+      UPDATE "Comments"
+      SET
+        "postId" = $(postId),
+        "tagId" = $(tagId)
+      WHERE "_id" = $(commentId)
+    `, {
+      commentId: comment._id,
+      postId: inheritedContext.postId,
+      tagId: inheritedContext.tagId,
+    });
+
+    commentsById.set(comment._id, {
+      ...comment,
+      ...inheritedContext,
+    });
+  }
+}
+
+export const down = async ({db}: MigrationContext) => {
+}


### PR DESCRIPTION
It's possible to submit a reply-comment mutation with a valid parentCommentId, but missing the postId. There is a buggy form somewhere in supermod that does this. Fix this by making the create mutator fill in postId (or tagId) from the parent comment, if a parentCommentId is provided. If both a postId and parentCommentId are provided, and the postId from the parent doesn't match, uses the from the parent and logs an error to Sentry.

Also adds a mutation to fix some comments where this previously happened. When run on the dev DB, 13 comments were fixed this way.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1215127408673219) by [Unito](https://www.unito.io)
