### PR TITLE
Fix /newPost not working multiple times without a refresh

### DIFF
--- a/packages/lesswrong/components/posts/PostsNewForm.tsx
+++ b/packages/lesswrong/components/posts/PostsNewForm.tsx
@@ -20,6 +20,7 @@ import Loading from "../vulcan-core/Loading";
 import { getMeetupMonthInfo } from '../seasonal/meetupMonth/meetupMonthEventUtils';
 import { getUserDefaultEditor } from '../editor/Editor';
 import { getUserDefaultRichTextEditor } from '@/lib/editor/defaultRichTextEditor';
+import { usePathname } from 'next/navigation';
 
 const PostsEditMutation = gql(`
   mutation createPostPostsNewForm($data: CreatePostDataInput!) {
@@ -171,6 +172,10 @@ function getPostCategory(query: Record<string, string>, questionInQuery: boolean
 }
 
 const PostsNewForm = () => {
+  const pathname = usePathname();
+  return <PostsNewFormInner key={pathname}/>;
+}
+const PostsNewFormInner = () => {
   const { query } = useLocation();
   const [error, setError] = useState<string|null>(null);
   const navigate = useNavigate();


### PR DESCRIPTION
Due to nextjs activity preservation shenanigans, picking "New Post" from the user menu to go to /newPost would create a new post the first time (in a tab) that you went to it, but if you then tried to create a second post in the same tab (without significant navigation in between), it would hang. This probably doesn't affect real users, but I ran into it while debugging with a bug-repro that involved starting a new post each time.


