### PR TITLE
Drop the legacy postId JWT field (PR 2 of YjsDocuments collectionName split)

### DIFF
--- a/fly/hocuspocusServer/src/auth.ts
+++ b/fly/hocuspocusServer/src/auth.ts
@@ -2,18 +2,6 @@ import jwt from 'jsonwebtoken';
 
 type AccessLevel = 'none' | 'read' | 'comment' | 'edit';
 
-interface RawAuthPayload {
-  userId: string;
-  displayName: string;
-  // postId is the pre-migration field; collectionName/documentId are the new
-  // ones. Tokens minted during the rollout window may carry only postId.
-  postId?: string;
-  collectionName?: string;
-  documentId?: string;
-  accessLevel: AccessLevel;
-  exp: number;
-}
-
 export interface AuthPayload {
   userId: string;
   displayName: string;
@@ -25,24 +13,15 @@ export interface AuthPayload {
 
 export async function verifyAuthToken(token: string): Promise<AuthPayload> {
   // Must match HOCUSPOCUS_JWT_SECRET used in the main app's postResolvers.ts.
-  const payload = jwt.verify(token, process.env.HOCUSPOCUS_JWT_SECRET!) as RawAuthPayload;
+  const payload = jwt.verify(token, process.env.HOCUSPOCUS_JWT_SECRET!) as AuthPayload;
 
   if (payload.exp < Date.now() / 1000) {
     throw new Error('Token expired');
   }
 
-  const collectionName = payload.collectionName ?? 'Posts';
-  const documentId = payload.documentId ?? payload.postId;
-  if (!documentId) {
-    throw new Error('Token missing documentId/postId');
+  if (!payload.collectionName || !payload.documentId) {
+    throw new Error('Token missing collectionName/documentId');
   }
 
-  return {
-    userId: payload.userId,
-    displayName: payload.displayName,
-    collectionName,
-    documentId,
-    accessLevel: payload.accessLevel,
-    exp: payload.exp,
-  };
+  return payload;
 }

--- a/packages/lesswrong/server/resolvers/postResolvers.ts
+++ b/packages/lesswrong/server/resolvers/postResolvers.ts
@@ -454,9 +454,6 @@ export const postGqlQueries = {
         displayName: currentUser?.displayName ?? 'Anonymous',
         collectionName,
         documentId,
-        // A Hocuspocus server still on the pre-migration build reads postId from
-        // the JWT, not documentId; remove once that build is fully rolled out.
-        postId: documentId,
         accessLevel,
       },
       process.env.HOCUSPOCUS_JWT_SECRET!,


### PR DESCRIPTION
Written by Claude:
----
[PR 1](https://github.com/ForumMagnum/ForumMagnum/pull/12544) dual-carried postId in the Hocuspocus JWT so a fly server still on the pre-migration build could read it. With PR 1 fully rolled out, every fly instance reads collectionName/documentId, so the postId claim and the auth.ts postId -> ('Posts', postId) fallback are dead.

- postResolvers HocuspocusAuth: stop signing postId into the JWT.
- fly auth.ts: require collectionName/documentId; drop the postId fallback and the now-redundant RawAuthPayload (it collapses into AuthPayload).

Deploy gate: merge/deploy only once >=1h has passed since PR 1's app prod deploy, so no postId-only token minted by the pre-PR-1 app is still valid (tokens have a 1h TTL). During PR 2's own rollout, PR-1 tokens carry both fields, so a PR-1 fly reads them and a PR-2 fly reads documentId.

The GraphQL postId *argument* is deliberately untouched here (old browser bundles still send it); its removal is the separate, bundle-lifetime-gated follow-up.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1215283839927681) by [Unito](https://www.unito.io)
