### PR TITLE
Fix research sandbox backend callback URL in deployed environments

### DIFF
--- a/packages/lesswrong/server/research/sandbox/sandboxManager.ts
+++ b/packages/lesswrong/server/research/sandbox/sandboxManager.ts
@@ -29,6 +29,7 @@ import { randomId, randomSecret } from "@/lib/random";
 import { sleep } from "@/lib/utils/asyncUtils";
 import { mintSupervisorCallbackToken } from "../../../../../app/api/research/agent/researchAgentAuth";
 import { decryptUserSecret } from "@/server/research/userSecretsCrypto";
+import { getSiteUrlFromHeaders } from "@/server/utils/getSiteUrl";
 import { getPlatformAssets } from "./platformAssets";
 import {
   AGENT_CWD,
@@ -304,12 +305,13 @@ export async function getOrCreateSandbox(
     }
   }
 
-  // The supervisor POSTs events/heartbeats here. Localhost won't reach a dev
-  // machine from inside a sandbox — point this at a tunnel for local dev.
-  const backendBaseUrl =
-    process.env.RESEARCH_BACKEND_PUBLIC_URL ??
-    process.env.VERCEL_BRANCH_URL ??
-    "http://localhost:3000";
+  // The supervisor POSTs events/heartbeats from inside the sandbox back to our
+  // backend, so it needs a publicly-reachable absolute URL pointing at *this*
+  // deployment. In local dev the backend is only reachable through a tunnel
+  // (RESEARCH_BACKEND_PUBLIC_URL, set by runDevWithResearchSandbox.sh, since the
+  // configured siteUrl is localhost). Otherwise derive it from the firing
+  // request's forwarded headers.
+  const backendBaseUrl = process.env.RESEARCH_BACKEND_PUBLIC_URL ?? getSiteUrlFromHeaders(context.headers);
 
   // The token decrypt and the snapshot-source resolution are independent. The
   // supervisorSecret is generated once and reused for the conversation's life:

--- a/packages/lesswrong/server/utils/getSiteUrl.ts
+++ b/packages/lesswrong/server/utils/getSiteUrl.ts
@@ -2,11 +2,14 @@ import { siteUrlSetting } from "@/lib/instanceSettings";
 import { NextRequest } from "next/server";
 
 export function getSiteUrlFromReq(req: NextRequest): string {
-  const headers = req.headers;
-  const forwardedFor = headers.get('x-forwarded-for');
-  const forwardedHost = headers.get('x-forwarded-host');
-  const forwardedPort = headers.get('x-forwarded-port');
-  const forwardedProto = headers.get("x-forwarded-proto");
+  return getSiteUrlFromHeaders(req.headers);
+}
+
+export function getSiteUrlFromHeaders(headers: Headers | undefined): string {
+  const forwardedFor = headers?.get('x-forwarded-for') ?? null;
+  const forwardedHost = headers?.get('x-forwarded-host') ?? null;
+  const forwardedPort = headers?.get('x-forwarded-port') ?? null;
+  const forwardedProto = headers?.get("x-forwarded-proto") ?? null;
 
   let url: string;
   if (forwardedFor && forwardedHost) {


### PR DESCRIPTION
Written by Claude:
----------
The in-sandbox supervisor POSTs events/heartbeats back to the backend. In deployed environments backendBaseUrl fell back to VERCEL_BRANCH_URL, a bare hostname with no scheme, so fetch() threw ERR_INVALID_URL and no events were ever delivered (AgentBlock stuck on "Waiting for agent response...").

Derive the callback base URL from the firing request's forwarded headers (the same approach as the OAuth redirect_uri) via a new getSiteUrlFromHeaders() helper, so it resolves to the correct host for both production and preview deployments. Local dev still uses the RESEARCH_BACKEND_PUBLIC_URL tunnel.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1215355718264664) by [Unito](https://www.unito.io)
