### PR TITLE
Research sandbox: fix turn-completion, supervised dev server, cold-resume

### DIFF
--- a/app/api/research/agent/captureResearchAgentAnalytics.ts
+++ b/app/api/research/agent/captureResearchAgentAnalytics.ts
@@ -14,6 +14,7 @@ interface ResearchAgentApiEventProps {
   conversationId?: string;
   projectId?: string;
   documentId?: string;
+  sandboxId?: string;
   userId?: string;
   status: ResearchAgentApiStatus;
   /** For `unauthorized`: discriminator from `verifySandboxCallbackToken`. */
@@ -21,8 +22,14 @@ interface ResearchAgentApiEventProps {
   /** For `forbidden`: short tag describing which check failed. */
   reason?: string;
   errorCategory?: string;
-  /** Set on success to describe what actually happened (e.g. "inserted", "replaced"). */
+  /** Categorical outcome of the operation (e.g. "inserted", "deleted", "persisted"). */
   operationResult?: string;
+  /** Whether a turn was running, on the heartbeat route. */
+  turnRunning?: boolean;
+  /** Size of a returned collection (conversations, documents, transcript turns). */
+  count?: number;
+  /** Character length of returned/affected content. */
+  charCount?: number;
 }
 
 function categorizeError(error: unknown): string {

--- a/app/api/research/agent/conversations/[conversationId]/transcript/route.ts
+++ b/app/api/research/agent/conversations/[conversationId]/transcript/route.ts
@@ -75,7 +75,7 @@ export async function GET(
       status: "success",
       conversationId,
       projectId: payload.projectId,
-      operationResult: `turns=${turns.length}`,
+      count: turns.length,
     });
 
     return NextResponse.json({

--- a/app/api/research/agent/documents/[documentId]/route.ts
+++ b/app/api/research/agent/documents/[documentId]/route.ts
@@ -141,7 +141,7 @@ export async function GET(
       conversationId: payload.conversationId,
       projectId: payload.projectId,
       documentId,
-      operationResult: `chars=${markdown.length}`,
+      charCount: markdown.length,
     });
 
     return NextResponse.json({

--- a/app/api/research/agent/projects/[projectId]/conversations/route.ts
+++ b/app/api/research/agent/projects/[projectId]/conversations/route.ts
@@ -50,7 +50,7 @@ export async function GET(
       status: "success",
       conversationId: payload.conversationId,
       projectId,
-      operationResult: `conversations=${conversations.length}`,
+      count: conversations.length,
     });
 
     return NextResponse.json({

--- a/app/api/research/agent/projects/[projectId]/documents/route.ts
+++ b/app/api/research/agent/projects/[projectId]/documents/route.ts
@@ -57,7 +57,7 @@ export async function GET(
       status: "success",
       conversationId: payload.conversationId,
       projectId,
-      operationResult: `documents=${documents.length}`,
+      count: documents.length,
     });
 
     return NextResponse.json({

--- a/app/api/research/agent/sandboxes/[sandboxId]/heartbeat/route.ts
+++ b/app/api/research/agent/sandboxes/[sandboxId]/heartbeat/route.ts
@@ -107,7 +107,9 @@ export async function POST(
       route: ROUTE,
       status: "success",
       projectId: payload.projectId,
-      operationResult: `turnRunning=${turnRunning}`,
+      conversationId,
+      sandboxId,
+      turnRunning,
     });
     return NextResponse.json({ ok: true });
   } catch (error) {

--- a/packages/lesswrong/components/research/ChatPane.tsx
+++ b/packages/lesswrong/components/research/ChatPane.tsx
@@ -3,6 +3,7 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { gql } from '@/lib/generated/gql-codegen';
 import { useMutation, useApolloClient } from '@apollo/client/react';
+import { isSandboxWarmingError } from './sandboxWarming';
 import { pollForConversationTitle, ProjectSidebarQuery } from './projectSidebarQuery';
 import classNames from 'classnames';
 import { defineStyles } from '../hooks/defineStyles';
@@ -201,10 +202,14 @@ const ChatPane = ({
         refresh();
       }
     } catch (err) {
-      // eslint-disable-next-line no-console
-      console.error('[research] chat send failed', err);
-      flash({ messageString: 'Failed to send message — try again.', type: 'error' });
       clearOptimistic();
+      if (isSandboxWarmingError(err)) {
+        flash({ messageString: 'The sandbox is still starting up — try again in a moment.' });
+      } else {
+        // eslint-disable-next-line no-console
+        console.error('[research] chat send failed', err);
+        flash({ messageString: 'Failed to send message — try again.', type: 'error' });
+      }
       throw err;
     } finally {
       setSending(false);

--- a/packages/lesswrong/components/research/lexical/QueryInputPlugin.tsx
+++ b/packages/lesswrong/components/research/lexical/QueryInputPlugin.tsx
@@ -46,6 +46,7 @@ import {
   QueryInputContentNode,
 } from './QueryInputContentNode';
 import { useResearchEditorEnvironment, type ResearchEditorEnvironment } from './ResearchEditorContext';
+import { isSandboxWarmingError } from '../sandboxWarming';
 import { useMessages } from '@/components/common/withMessages';
 import { type WithMessagesFunctions } from '@/components/layout/FlashMessages';
 
@@ -153,9 +154,13 @@ async function fireQuery({
     // The AgentBlock is already in the doc with the correct conversationId,
     // so a successful mutation needs no further client-side action.
   } catch (err) {
-    // eslint-disable-next-line no-console
-    console.error('[research] /query failed to fire', err);
-    flash({ messageString: 'Failed to send query — try again.', type: 'error' });
+    if (isSandboxWarmingError(err)) {
+      flash({ messageString: 'The sandbox is still starting up — try again in a moment.' });
+    } else {
+      // eslint-disable-next-line no-console
+      console.error('[research] /query failed to fire', err);
+      flash({ messageString: 'Failed to send query — try again.', type: 'error' });
+    }
     editor.update(() => {
       const agentBlock = $getNodeByKey(agentBlockKey);
       if (!$isAgentBlockNode(agentBlock)) return;

--- a/packages/lesswrong/components/research/sandboxWarming.ts
+++ b/packages/lesswrong/components/research/sandboxWarming.ts
@@ -1,0 +1,14 @@
+import { CombinedGraphQLErrors } from '@apollo/client';
+
+/**
+ * True for the transient "sandbox still starting" rejection a research mutation
+ * throws while a sandbox is resuming. The resume keeps progressing server-side,
+ * so the prompt is preserved and a retry succeeds — this is a "try again in a
+ * moment", not a real failure.
+ */
+export function isSandboxWarmingError(err: unknown): boolean {
+  return (
+    err instanceof CombinedGraphQLErrors &&
+    err.errors.some((e) => e.extensions?.code === 'SANDBOX_WARMING')
+  );
+}

--- a/packages/lesswrong/server/research/sandbox/sandboxManager.ts
+++ b/packages/lesswrong/server/research/sandbox/sandboxManager.ts
@@ -30,6 +30,7 @@ import { sleep } from "@/lib/utils/asyncUtils";
 import { mintSupervisorCallbackToken } from "../../../../../app/api/research/agent/researchAgentAuth";
 import { decryptUserSecret } from "@/server/research/userSecretsCrypto";
 import { getSiteUrlFromHeaders } from "@/server/utils/getSiteUrl";
+import { serverCaptureEvent } from "@/server/analytics/serverAnalyticsWriter";
 import { getPlatformAssets } from "./platformAssets";
 import {
   AGENT_CWD,
@@ -45,8 +46,6 @@ import {
 const SUPERVISOR_PORT = 9280;
 
 const AUTH_PROXY_PORT = 9281;
-
-const DEV_PORT = 9282;
 
 /**
  * Per-session Vercel `timeout`. This is the idle dead-man's switch: activity
@@ -187,7 +186,6 @@ async function launchSupervisor(sandbox: Sandbox, env: SupervisorLaunchEnv): Pro
     BACKEND_BASE_URL: env.backendBaseUrl,
     SUPERVISOR_PORT: String(SUPERVISOR_PORT),
     AUTH_PROXY_PORT: String(AUTH_PROXY_PORT),
-    DEV_PORT: String(DEV_PORT),
     DEV_PROXY_SECRET: env.devProxySecret,
     USER_ID: env.userId,
     PROJECT_ID: env.projectId,
@@ -208,8 +206,23 @@ async function launchSupervisor(sandbox: Sandbox, env: SupervisorLaunchEnv): Pro
   await waitForSupervisorReady(supervisorUrlForSandbox(sandbox));
 }
 
+/**
+ * Thrown when a sandbox is provisioning but its supervisor hasn't come up within
+ * the readiness window. Distinct from a hard provisioning failure: the resume
+ * keeps progressing after we give up, so the caller can surface a "still
+ * starting, retry" state and a retry will find it warm.
+ */
+export class SandboxWarmingError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "SandboxWarmingError";
+  }
+}
+
+const SUPERVISOR_READY_TIMEOUT_MS = 30_000;
+
 async function waitForSupervisorReady(endpointUrl: string): Promise<void> {
-  const deadline = Date.now() + 30_000;
+  const deadline = Date.now() + SUPERVISOR_READY_TIMEOUT_MS;
   let lastErr: unknown = null;
   while (Date.now() < deadline) {
     try {
@@ -221,8 +234,8 @@ async function waitForSupervisorReady(endpointUrl: string): Promise<void> {
     }
     await sleep(500);
   }
-  throw new Error(
-    `supervisor not ready within 30s: ${(lastErr as Error)?.message ?? "unknown"}`,
+  throw new SandboxWarmingError(
+    `supervisor not ready within ${SUPERVISOR_READY_TIMEOUT_MS / 1000}s: ${(lastErr as Error)?.message ?? "unknown"}`,
   );
 }
 
@@ -267,6 +280,16 @@ async function resolveSnapshotSource(
   return { snapshotId: baseline.vercelSnapshotId };
 }
 
+function captureSandboxProvision(props: {
+  conversationId: string;
+  projectId: string;
+  path: "warm" | "create" | "resume";
+  durationMs: number;
+  ready: boolean;
+}): void {
+  serverCaptureEvent("researchSandboxProvision", props);
+}
+
 /**
  * Resolve (provisioning lazily on first use) the persistent sandbox for a
  * conversation, with its supervisor confirmed up. Safe to call on every turn.
@@ -282,6 +305,7 @@ export async function getOrCreateSandbox(
     throw new Error(`getOrCreateSandbox: conversation ${conversationId} not found`);
   }
 
+  const provisionStartedAt = Date.now();
   const sandboxName = sandboxNameForConversation(conversationId);
   const existingRow = await ResearchSandboxSessions.findOne({ conversationId });
 
@@ -292,6 +316,17 @@ export async function getOrCreateSandbox(
   if (existingRow) {
     const running = await getRunningSandbox(conversationId);
     if (running) {
+      // A running sandbox doesn't guarantee a ready supervisor — e.g. a retry
+      // after a resume whose supervisor was still booting. Confirm /health so a
+      // not-yet-ready supervisor surfaces as warming, not a generic dispatch error.
+      await waitForSupervisorReady(supervisorUrlForSandbox(running));
+      captureSandboxProvision({
+        conversationId,
+        projectId: conversation.projectId,
+        path: "warm",
+        durationMs: Date.now() - provisionStartedAt,
+        ready: true,
+      });
       return {
         conversationId,
         sandboxName,
@@ -324,11 +359,25 @@ export async function getOrCreateSandbox(
   const { snapshotId } = snapshotSource;
   const supervisorSecret = existingRow?.supervisorSecret ?? randomSecret();
   const devProxySecret = existingRow?.devProxySecret ?? randomSecret();
-  if (existingRow && !existingRow.devProxySecret) {
-    await ResearchSandboxSessions.rawUpdateOne(
-      { _id: existingRow._id },
-      { $set: { devProxySecret } },
-    );
+  // Persist the per-conversation secrets before launching the supervisor: a
+  // readiness timeout in launchSupervisor must not lose the secret the supervisor
+  // booted with, or a retry would mint a new one and fail to authenticate to the
+  // still-running supervisor.
+  if (existingRow) {
+    if (!existingRow.devProxySecret) {
+      await ResearchSandboxSessions.rawUpdateOne(
+        { _id: existingRow._id },
+        { $set: { devProxySecret } },
+      );
+    }
+  } else {
+    await ResearchSandboxSessions.rawInsert({
+      _id: randomId(),
+      conversationId,
+      supervisorSecret,
+      devProxySecret,
+      createdAt: new Date(),
+    });
   }
 
   const callbackToken = mintSupervisorCallbackToken({
@@ -359,17 +408,6 @@ export async function getOrCreateSandbox(
     wasFreshlyCreated = true;
     await overlayPlatformFiles(sandbox);
     await launchSupervisor(sandbox, launchEnv);
-    // Insert the row only for a brand-new conversation. A rebuild (expired
-    // snapshot) re-enters this path with the row already present.
-    if (!existingRow) {
-      await ResearchSandboxSessions.rawInsert({
-        _id: randomId(),
-        conversationId,
-        supervisorSecret,
-        devProxySecret,
-        createdAt: new Date(),
-      });
-    }
   };
 
   // `getOrCreate` covers all three branches: resume an existing sandbox,
@@ -380,21 +418,51 @@ export async function getOrCreateSandbox(
   // passed explicitly because the SDK omits the `resume` query param entirely
   // when it's left undefined, and the backend in that case hands back a
   // stopped-session handle rather than starting a new session.
-  const sandbox = await Sandbox.getOrCreate({
-    name: sandboxName,
-    // The SDK types `getOrCreate`'s `source` as git/tarball only, but at
-    // runtime it forwards `source` to `Sandbox.create` unchanged, which does
-    // accept a snapshot source. Cast until the SDK widens the type.
-    source: { type: "snapshot", snapshotId } as unknown as NonNullable<Parameters<typeof Sandbox.getOrCreate>[0]>["source"],
-    ports: [SUPERVISOR_PORT, AUTH_PROXY_PORT],
-    timeout: SESSION_TIMEOUT_MS,
-    resources: { vcpus: 2 },
-    persistent: true,
-    snapshotExpiration: SNAPSHOT_EXPIRATION_MS,
-    keepLastSnapshots: { count: KEEP_LAST_SNAPSHOTS_COUNT },
-    resume: true,
-    onCreate,
-    onResume,
+  let sandbox: Sandbox;
+  try {
+    // `getOrCreate` covers all three branches: resume an existing sandbox,
+    // create a fresh one when none exists, and rebuild (delete + create) when
+    // the existing sandbox's snapshot has expired. `source` is consumed only on
+    // the create path — `Sandbox.get` ignores it — so a warm resume can't
+    // clobber the snapshot we're trying to recover from. `resume: true` is
+    // passed explicitly because the SDK omits the `resume` query param entirely
+    // when it's left undefined, and the backend in that case hands back a
+    // stopped-session handle rather than starting a new session.
+    sandbox = await Sandbox.getOrCreate({
+      name: sandboxName,
+      // The SDK types `getOrCreate`'s `source` as git/tarball only, but at
+      // runtime it forwards `source` to `Sandbox.create` unchanged, which does
+      // accept a snapshot source. Cast until the SDK widens the type.
+      source: { type: "snapshot", snapshotId } as unknown as NonNullable<Parameters<typeof Sandbox.getOrCreate>[0]>["source"],
+      ports: [SUPERVISOR_PORT, AUTH_PROXY_PORT],
+      timeout: SESSION_TIMEOUT_MS,
+      resources: { vcpus: 4 },
+      persistent: true,
+      snapshotExpiration: SNAPSHOT_EXPIRATION_MS,
+      keepLastSnapshots: { count: KEEP_LAST_SNAPSHOTS_COUNT },
+      resume: true,
+      onCreate,
+      onResume,
+    });
+  } catch (err) {
+    if (err instanceof SandboxWarmingError) {
+      captureSandboxProvision({
+        conversationId,
+        projectId: conversation.projectId,
+        path: wasFreshlyCreated ? "create" : "resume",
+        durationMs: Date.now() - provisionStartedAt,
+        ready: false,
+      });
+    }
+    throw err;
+  }
+
+  captureSandboxProvision({
+    conversationId,
+    projectId: conversation.projectId,
+    path: wasFreshlyCreated ? "create" : "resume",
+    durationMs: Date.now() - provisionStartedAt,
+    ready: true,
   });
 
   return {

--- a/packages/lesswrong/server/research/sandbox/supervisor/agentInstructions.md
+++ b/packages/lesswrong/server/research/sandbox/supervisor/agentInstructions.md
@@ -404,64 +404,78 @@ Two situations you'll find yourself in:
   Orient, then get straight to work on the existing code — don't re-clone or
   reinstall.
 
-### Keeping work alive across turns: `init.sh`
+### Keeping work alive across turns: `init.sh` and `dev-server.sh`
 
 The sandbox doesn't run continuously — it's stopped after idle periods (and
 recycled periodically regardless) and resumed on the next turn. On resume the
-**filesystem is restored but running processes are not**, so a dev server (or
-anything else long-running) you started by hand in one turn can be gone by a
-later turn. `init.sh` is the supervisor's hook to re-establish that live state:
-**you write `/vercel/sandbox/init.sh`**, and the supervisor runs it on every
-boot/resume, before your turn — so you set it up once instead of restarting
-things by hand each turn.
+**filesystem is restored but running processes are not**. Two files you write
+re-establish the live state on every boot, so you set things up once instead of
+restarting them by hand each turn:
 
-**Work out its contents collaboratively.** A repo's dev command, build steps,
+- **`/vercel/sandbox/init.sh`** — per-boot *setup*. The supervisor runs it to
+  completion before your turn. Put cheap, idempotent setup here: fast-forward the
+  checkout, reconcile dependencies, any build step the toolchain doesn't run
+  itself. It must **finish and exit** — don't start a long-running server from it.
+- **`/vercel/sandbox/dev-server.sh`** — the *foreground* command that runs your
+  app's dev server. The supervisor runs this as a managed process: it starts it
+  after `init.sh`, restarts it if it exits, and captures its output to
+  `/vercel/sandbox/dev.log`. Write a plain foreground command — **no `&`, no
+  `nohup`, no `setsid`** — ideally `exec`-ing the server so signals reach it.
+
+**Work out their contents collaboratively.** A repo's dev command, build steps,
 required services, or env vars often aren't obvious from the tree, so don't
-guess — figure out the full per-boot sequence and **confirm it with the user**
-before relying on it. It's usually some variation of:
+guess — figure out the per-boot sequence and **confirm it with the user** before
+relying on it.
 
-1. **Fast-forward the checkout** — `git -C <dir> pull --ff-only`.
-2. **Reconcile dependencies** — e.g. `npm install`. Include this almost always:
-   an environment you were spawned from already has *some* installed
-   dependencies, but if the pull changed the lockfile they need updating. (It's a
-   near-no-op when nothing changed.)
-3. **Optional post-install/build** — only if the repo's own toolchain doesn't
-   already handle it via a post-install hook.
-4. **Start the dev server**, detached, on `$PORT`.
+A few rules:
 
-How to write each part:
+- **Bind `$PORT`** (injected into both scripts; currently 9282) for the dev
+  server — that's the one port the preview proxy fronts; a server on any other
+  port won't be reachable.
+- **Stripped environment.** These scripts get only `PORT` and a PATH that finds
+  `research-tool` — not your Claude token, the supervisor's secrets, or your
+  turn's env. Anything your app needs at boot, the scripts must establish
+  themselves (e.g. load a `.env` you wrote during setup).
+- **Don't run the dev server (or any long-lived service) yourself inside a turn**
+  — not with `&`, `nohup`, or a background task. Processes you start in a turn are
+  tied to that turn and won't reliably outlive it. Let the platform run it via
+  `dev-server.sh` and use the controls below.
+- **Treat in-turn background tasks as turn-scoped** — fine for "kick off a build
+  while I work and check it before the turn ends," not for anything that must
+  survive to a later turn.
 
-- **Stripped environment.** `init.sh` gets only `PORT` (the dev-server port) and
-  a PATH that finds `research-tool` — not your Claude token, the supervisor's
-  secrets, or your turn's env. So anything your app needs at boot, `init.sh` must
-  establish itself (e.g. load a `.env` you wrote during setup).
-- **Detached long-running processes.** The supervisor runs `init.sh` as a
-  subprocess and reaps it (under a ~5-minute timeout, enough for a dependency
-  reconcile), so steps 1–3 run to completion but the dev server in step 4 must be
-  detached with `nohup setsid … &` or it's killed when the script returns.
-- **Bind `$PORT`** (currently 9282) for the dev server — that's the one port the
-  preview proxy fronts; a server on any other port won't be reachable.
+Controlling the dev server:
 
-Example `init.sh` for a cloned Node project at `/vercel/sandbox/app`:
+```
+research-tool dev start      # (re)start supervision and bring it up
+research-tool dev stop       # stop it and leave it stopped
+research-tool dev restart    # restart it (e.g. after a change the app can't hot-reload)
+```
+
+Check on it with ordinary tools — `curl localhost:$PORT`, `tail /vercel/sandbox/dev.log`.
+
+Example files for a cloned Node project at `/vercel/sandbox/app`:
 
 ```sh
+# /vercel/sandbox/init.sh — setup only; runs to completion.
 #!/usr/bin/env sh
 repo=/vercel/sandbox/app
-# 1. Fast-forward to the latest commit (cheap; tolerate being offline).
-git -C "$repo" pull --ff-only || true
-# 2. Reconcile dependencies in case the pull changed the lockfile.
-( cd "$repo" && npm install )
-# 3. Optional: a build/post-install step the toolchain doesn't run itself.
-# ( cd "$repo" && npm run build )
-# 4. Start the dev server detached, bound to the proxied port.
-nohup setsid sh -c 'cd /vercel/sandbox/app && npm run dev -- --port "$PORT"' \
-  >/vercel/sandbox/dev.log 2>&1 &
+git -C "$repo" pull --ff-only || true          # fast-forward (tolerate offline)
+( cd "$repo" && npm install )                   # reconcile deps if the lockfile moved
+# ( cd "$repo" && npm run build )               # only if the toolchain needs it
+```
+
+```sh
+# /vercel/sandbox/dev-server.sh — foreground; the platform supervises it.
+#!/usr/bin/env sh
+cd /vercel/sandbox/app
+exec npm run dev -- --port "$PORT"
 ```
 
 The user opens an authenticated preview link from the UI; you don't manage the
-proxy or hand out URLs. Because `init.sh` doesn't block your turn, just after a
-resume the dev server may take a few seconds to bind and the preview reads "no
-dev server detected yet" until it does — that's normal, not a failure.
+proxy or hand out URLs. Just after a resume the dev server may take a few seconds
+to bind and the preview reads "no dev server detected yet" until it does — that's
+normal, not a failure.
 
 ### Git and GitHub
 

--- a/packages/lesswrong/server/research/sandbox/supervisor/authProxy.ts
+++ b/packages/lesswrong/server/research/sandbox/supervisor/authProxy.ts
@@ -24,7 +24,7 @@ import {
 import { Socket } from "node:net";
 import { Duplex } from "node:stream";
 import { DEVAUTH_SCOPE, validateSupervisorToken } from "./auth";
-import { DevServerHandle } from "./devServer";
+import { DevServerHandle, DEV_PORT } from "./devServer";
 
 /** Cookie the auth-proxy sets and checks; host-only, so scoped to the subdomain. */
 const COOKIE_NAME = "research_devauth";
@@ -32,8 +32,6 @@ const COOKIE_NAME = "research_devauth";
 export interface AuthProxyConfig {
   /** Public port to listen on (`AUTH_PROXY_PORT`). */
   port: number;
-  /** localhost port the dev server binds. */
-  devPort: number;
   /** Shared HMAC secret (`DEV_PROXY_SECRET`). */
   proxySecret: string;
   /** Sandbox name — the token's `sandboxId` claim must match it. */
@@ -150,7 +148,7 @@ async function handleRequest(
   config.onActivity();
 
   if (await config.devServer.isListening()) {
-    proxyHttp(req, res, config.devPort);
+    proxyHttp(req, res, DEV_PORT);
   } else {
     send(res, 503, NOT_DETECTED_PAGE, "text/html");
   }
@@ -178,7 +176,7 @@ export function startAuthProxy(config: AuthProxyConfig): Server {
       return;
     }
     config.onActivity();
-    proxyUpgrade(req, socket, head, config.devPort);
+    proxyUpgrade(req, socket, head, DEV_PORT);
   });
 
   server.listen(config.port, "0.0.0.0", () => {

--- a/packages/lesswrong/server/research/sandbox/supervisor/conversationHub.ts
+++ b/packages/lesswrong/server/research/sandbox/supervisor/conversationHub.ts
@@ -23,6 +23,13 @@ interface ConversationEntry {
   state: ConversationState;
   runner: ClaudeRunnerHandle | null;
   claudeSessionId?: string;
+  /**
+   * Monotonic id of the most recently dispatched turn. A runner's callbacks
+   * carry the id they were started with; once a newer turn supersedes them
+   * (the prior turn finished but its process is still alive), the stale
+   * callbacks check this and become no-ops instead of mutating the entry.
+   */
+  activeTurnId: number;
 }
 
 export interface DispatchInput {
@@ -53,12 +60,13 @@ export function createConversationHub(config: ConversationHubConfig) {
       conversationId,
       state: { conversationId, status: "idle" },
       runner: null,
+      activeTurnId: 0,
     };
     conversations.set(conversationId, entry);
     return entry;
   }
 
-  function emit(entry: ConversationEntry, line: ParsedJsonlLine) {
+  function emit(entry: ConversationEntry, line: ParsedJsonlLine, turnId: number) {
     const persistKind = mapKindForPersistence(line.kind);
     if (persistKind) {
       config.postPersister.enqueue(entry.conversationId, {
@@ -68,6 +76,14 @@ export function createConversationHub(config: ConversationHubConfig) {
         claudeSessionId: line.sessionId ?? undefined,
         supervisorEmittedAt: new Date(now()).toISOString(),
       });
+    }
+
+    // The `result` line is the turn's terminal signal — emitted once when the
+    // turn is done, independent of whether the process then exits (a backgrounded
+    // child can keep it alive). Completion is tracked here, not at process exit.
+    // Guarded so a superseded runner's late output can't complete a newer turn.
+    if (line.kind === "result" && entry.activeTurnId === turnId && entry.state.status === "running") {
+      entry.state = { ...entry.state, status: "completed", endedAt: now() };
     }
 
     if (line.sessionId && !entry.claudeSessionId) {
@@ -82,6 +98,13 @@ export function createConversationHub(config: ConversationHubConfig) {
     const entry = getOrInit(input.conversationId);
     if (entry.runner && entry.state.status === "running") {
       return { accepted: false, reason: "already running" };
+    }
+    if (entry.runner) {
+      // The previous turn reached a terminal status but its process is still
+      // alive (a backgrounded child is holding it open). Starting the next turn
+      // is safe; the runner reference is replaced below.
+      // eslint-disable-next-line no-console
+      console.warn(`[hub] conv=${input.conversationId} starting turn with a live prior runner (status=${entry.state.status})`);
     }
 
     if (input.claudeSessionId && input.bootstrapJsonl && input.bootstrapJsonl.length > 0) {
@@ -100,6 +123,8 @@ export function createConversationHub(config: ConversationHubConfig) {
       }
     }
 
+    const turnId = entry.activeTurnId + 1;
+    entry.activeTurnId = turnId;
     entry.state = { conversationId: input.conversationId, status: "running", startedAt: now() };
     entry.claudeSessionId = input.claudeSessionId ?? entry.claudeSessionId;
 
@@ -109,18 +134,20 @@ export function createConversationHub(config: ConversationHubConfig) {
       claudeSessionId: input.claudeSessionId,
       cwd: runnerOpts?.cwd,
       env: runnerOpts?.env,
-      onLine: (line) => emit(entry, line),
+      onLine: (line) => emit(entry, line, turnId),
       onExit: ({ code }) => {
-        entry.state = {
-          ...entry.state,
-          status:
-            entry.state.status === "cancelled"
-              ? "cancelled"
-              : code === 0
-              ? "completed"
-              : "errored",
-          endedAt: now(),
-        };
+        // A runner superseded by a newer turn must not touch the entry.
+        if (entry.activeTurnId !== turnId) return;
+        // Backstop for turns that exit without ever emitting a `result` (crash,
+        // kill). A turn already moved to a terminal status by `emit` (the normal
+        // case) or by `cancel` is left untouched.
+        if (entry.state.status === "running") {
+          entry.state = {
+            ...entry.state,
+            status: code === 0 ? "completed" : "errored",
+            endedAt: now(),
+          };
+        }
         entry.runner = null;
       },
       onError: (err) => {
@@ -139,12 +166,16 @@ export function createConversationHub(config: ConversationHubConfig) {
   async function cancel(conversationId: string): Promise<void> {
     const entry = conversations.get(conversationId);
     if (!entry || !entry.runner) return;
+    // Only an in-progress turn can be cancelled. A completed turn whose process
+    // is still alive (a backgrounded child) must not be torn down here.
+    if (entry.state.status !== "running") return;
+    const cancelledRunner = entry.runner;
     entry.state = { ...entry.state, status: "cancelled" };
-    entry.runner.cancel("SIGTERM");
-    // SIGKILL fallback if still running after grace period
+    cancelledRunner.cancel("SIGTERM");
+    // SIGKILL fallback if still running after grace period — but only if this is
+    // still the same runner, so a turn dispatched in the meantime isn't killed.
     setTimeout(() => {
-      const still = conversations.get(conversationId);
-      if (still?.runner) still.runner.cancel("SIGKILL");
+      if (entry.runner === cancelledRunner) cancelledRunner.cancel("SIGKILL");
     }, 5_000);
   }
 

--- a/packages/lesswrong/server/research/sandbox/supervisor/devServer.ts
+++ b/packages/lesswrong/server/research/sandbox/supervisor/devServer.ts
@@ -1,4 +1,24 @@
 import { Socket } from "node:net";
+import { homedir } from "node:os";
+import * as path from "node:path";
+
+/** Port the agent's dev server binds (exported to its scripts as `$PORT`) and the auth-proxy fronts. */
+export const DEV_PORT = 9282;
+
+/** PATH that finds the overlaid `research-tool` binary, prepended to the inherited PATH. */
+export function researchBinPath(): string {
+  return `${path.join(homedir(), ".research", "bin")}:${process.env.PATH ?? ""}`;
+}
+
+/** Environment the supervisor hands the agent's boot scripts (`init.sh`, `dev-server.sh`). */
+export function buildScriptBootEnv(): NodeJS.ProcessEnv {
+  return {
+    NODE_ENV: process.env.NODE_ENV,
+    PORT: String(DEV_PORT),
+    PATH: researchBinPath(),
+    HOME: homedir(),
+  };
+}
 
 export interface DevServerHandle {
   /** True when something is accepting TCP connections on the dev port. */

--- a/packages/lesswrong/server/research/sandbox/supervisor/devServerManager.ts
+++ b/packages/lesswrong/server/research/sandbox/supervisor/devServerManager.ts
@@ -1,0 +1,288 @@
+/**
+ * Supervisor-owned dev-server lifecycle.
+ *
+ * The agent declares how to start its app's dev server in
+ * `/vercel/sandbox/dev-server.sh` — a plain foreground command (ideally
+ * `exec`-ing the server). The supervisor runs that script as a child it owns,
+ * restarts it if it exits, captures its output to a log the agent can read, and
+ * exposes start/stop/restart so the agent never has to background the process
+ * itself.
+ *
+ * If no `dev-server.sh` is present (e.g. an environment whose `init.sh` still
+ * launches the server itself), the manager stays idle and leaves that
+ * arrangement untouched.
+ */
+import { createServer, Server } from "node:http";
+import { spawn, ChildProcess } from "node:child_process";
+import { existsSync, openSync, closeSync, readFileSync } from "node:fs";
+import { AGENT_CWD } from "../sandboxLayout";
+import { startDevPortProbe, DevServerHandle, DEV_PORT, buildScriptBootEnv } from "./devServer";
+
+const DEV_SCRIPT_PATH = `${AGENT_CWD}/dev-server.sh`;
+const DEV_LOG_PATH = `${AGENT_CWD}/dev.log`;
+
+/** Local-only port for the dev-server control surface. */
+export const DEV_CONTROL_PORT = 9283;
+
+/** Backoff between automatic restarts; index clamps to the last entry. */
+const BACKOFF_MS = [1_000, 2_000, 5_000, 10_000];
+/** A run that lasts at least this long is treated as healthy (resets backoff). */
+const HEALTHY_RUN_MS = 30_000;
+/** Crash-loop window and the restart count within it that pauses supervision. */
+const CRASH_WINDOW_MS = 60_000;
+const CRASH_LIMIT = 5;
+/** Grace period after SIGTERM before SIGKILL when stopping/restarting. */
+const STOP_GRACE_MS = 5_000;
+
+export interface DevServerManager extends DevServerHandle {
+  /** Resume supervision and ensure the server is running. */
+  start(): void;
+  /** Suspend supervision and stop the server until an explicit `start`. */
+  stop(): void;
+  /** Restart the server, keeping supervision on. */
+  restart(): void;
+  /** Whether a `dev-server.sh` exists for the manager to supervise. */
+  hasScript(): boolean;
+}
+
+/** Emits a one-line system event to the transcript (e.g. crash-loop notices). */
+type SurfaceFn = (text: string) => void;
+
+function signalGroup(pid: number, signal: NodeJS.Signals): void {
+  // The child is spawned `detached`, so it leads its own process group; the
+  // negative pid signals the whole tree even when the script doesn't `exec`.
+  try {
+    process.kill(-pid, signal);
+  } catch {
+    try {
+      process.kill(pid, signal);
+    } catch {
+      /* already gone */
+    }
+  }
+}
+
+function tailFile(filePath: string, lines = 20): string {
+  try {
+    return readFileSync(filePath, "utf8").split("\n").slice(-lines).join("\n").trim();
+  } catch {
+    return "";
+  }
+}
+
+function closeFdSafely(fd: number): void {
+  try {
+    closeSync(fd);
+  } catch {
+    /* already closed */
+  }
+}
+
+export function createDevServerManager(surface: SurfaceFn): DevServerManager {
+  const probe = startDevPortProbe(DEV_PORT);
+  const childEnv = buildScriptBootEnv();
+
+  let child: ChildProcess | null = null;
+  /** Whether we want the server up. start/restart set true; stop sets false. */
+  let desiredRunning = false;
+  /** True between issuing a kill and seeing its exit, so the exit isn't crash-counted. */
+  let killing = false;
+  let killGraceTimer: NodeJS.Timeout | null = null;
+  let restartTimer: NodeJS.Timeout | null = null;
+  let consecutiveFailures = 0;
+  let launchedAt = 0;
+  /** Launch timestamps within the crash window, for loop detection. */
+  const recentStarts: number[] = [];
+
+  function hasScript(): boolean {
+    return existsSync(DEV_SCRIPT_PATH);
+  }
+
+  function clearRestartTimer(): void {
+    if (restartTimer) {
+      clearTimeout(restartTimer);
+      restartTimer = null;
+    }
+  }
+
+  function launch(): void {
+    if (child || killing) return;
+    if (!hasScript()) return;
+
+    let fd: number;
+    try {
+      // Truncate per launch so the log reflects the current run.
+      fd = openSync(DEV_LOG_PATH, "w");
+    } catch (err) {
+      surface(`dev server: could not open ${DEV_LOG_PATH}: ${(err as Error).message}`);
+      return;
+    }
+
+    launchedAt = Date.now();
+    recentStarts.push(launchedAt);
+
+    let proc: ChildProcess;
+    try {
+      proc = spawn("sh", [DEV_SCRIPT_PATH], {
+        cwd: AGENT_CWD,
+        env: childEnv,
+        stdio: ["ignore", fd, fd],
+        detached: true,
+      });
+    } catch (err) {
+      surface(`dev server failed to start: ${(err as Error).message}`);
+      closeFdSafely(fd);
+      return;
+    }
+    closeFdSafely(fd);
+    child = proc;
+
+    proc.on("error", (err) => {
+      surface(`dev server failed to start: ${err.message}`);
+    });
+    proc.on("exit", (code, signal) => onChildExit(proc, code, signal));
+  }
+
+  function onChildExit(proc: ChildProcess, code: number | null, signal: NodeJS.Signals | null): void {
+    if (child !== proc) return;
+    child = null;
+    if (killGraceTimer) {
+      clearTimeout(killGraceTimer);
+      killGraceTimer = null;
+    }
+    if (killing) {
+      // Intentional kill (stop/restart): not a crash. Let reconcile decide the
+      // next step (relaunch if we still want it up, e.g. a restart).
+      killing = false;
+      reconcile();
+      return;
+    }
+    // Exited on its own. If we no longer want it up, leave it down.
+    if (!desiredRunning) return;
+    scheduleRestartAfterCrash(code, signal);
+  }
+
+  function scheduleRestartAfterCrash(code: number | null, signal: NodeJS.Signals | null): void {
+    // A run that lasted long enough to be healthy earns a fresh crash budget, so
+    // a stable stretch isn't tripped by crashes from before it.
+    if (Date.now() - launchedAt > HEALTHY_RUN_MS) {
+      consecutiveFailures = 0;
+      recentStarts.length = 0;
+    }
+
+    const cutoff = Date.now() - CRASH_WINDOW_MS;
+    while (recentStarts.length > 0 && recentStarts[0] < cutoff) recentStarts.shift();
+    if (recentStarts.length >= CRASH_LIMIT) {
+      desiredRunning = false;
+      const how = signal ? `signal ${signal}` : `code ${code}`;
+      const log = tailFile(DEV_LOG_PATH);
+      surface(
+        `Dev server is crash-looping (exited ${how} ${recentStarts.length} times in ` +
+          `${CRASH_WINDOW_MS / 1000}s); supervision paused. Fix dev-server.sh and run ` +
+          "`research-tool dev start`." +
+          (log ? `\nRecent dev.log:\n${log}` : ""),
+      );
+      return;
+    }
+
+    const delay = BACKOFF_MS[Math.min(consecutiveFailures, BACKOFF_MS.length - 1)];
+    consecutiveFailures += 1;
+    clearRestartTimer();
+    restartTimer = setTimeout(() => {
+      restartTimer = null;
+      reconcile();
+    }, delay);
+    restartTimer.unref?.();
+  }
+
+  function beginKill(): void {
+    if (!child || child.pid == null) return;
+    killing = true;
+    const pid = child.pid;
+    signalGroup(pid, "SIGTERM");
+    killGraceTimer = setTimeout(() => signalGroup(pid, "SIGKILL"), STOP_GRACE_MS);
+    killGraceTimer.unref?.();
+  }
+
+  /** Drive the child toward `desiredRunning`. Waits for any in-flight kill's exit. */
+  function reconcile(): void {
+    if (killing) return;
+    if (desiredRunning) {
+      if (!child) launch();
+    } else if (child) {
+      beginKill();
+    }
+  }
+
+  function start(): void {
+    desiredRunning = true;
+    consecutiveFailures = 0;
+    recentStarts.length = 0;
+    clearRestartTimer();
+    reconcile();
+  }
+
+  function stop(): void {
+    desiredRunning = false;
+    clearRestartTimer();
+    reconcile();
+  }
+
+  function restart(): void {
+    desiredRunning = true;
+    consecutiveFailures = 0;
+    recentStarts.length = 0;
+    clearRestartTimer();
+    // Kill the current child; its exit reconciles back to a fresh launch.
+    if (child) beginKill();
+    else reconcile();
+  }
+
+  return { isListening: probe.isListening, hasScript, start, stop, restart };
+}
+
+/**
+ * Local-only HTTP control surface for the dev server. Bound to 127.0.0.1 on a
+ * port that is *not* in the sandbox's public port list, so it needs no auth —
+ * only the in-sandbox agent (via `research-tool dev …`) and the supervisor can
+ * reach it.
+ */
+export function startDevControlServer(manager: DevServerManager): Server {
+  const server = createServer((req, res) => {
+    const method = req.method ?? "GET";
+    const requestPath = (req.url ?? "/").split("?")[0];
+    if (method !== "POST") {
+      res.statusCode = 405;
+      res.end();
+      return;
+    }
+    const action =
+      requestPath === "/start"
+        ? "start"
+        : requestPath === "/stop"
+        ? "stop"
+        : requestPath === "/restart"
+        ? "restart"
+        : null;
+    if (!action) {
+      res.statusCode = 404;
+      res.end();
+      return;
+    }
+    try {
+      if (action === "start") manager.start();
+      else if (action === "stop") manager.stop();
+      else manager.restart();
+      res.statusCode = 200;
+      res.setHeader("Content-Type", "application/json");
+      // `managed: false` means no dev-server.sh — the controls did nothing.
+      res.end(JSON.stringify({ ok: true, action, managed: manager.hasScript() }));
+    } catch (err) {
+      res.statusCode = 500;
+      res.setHeader("Content-Type", "application/json");
+      res.end(JSON.stringify({ ok: false, error: (err as Error).message }));
+    }
+  });
+  server.listen(DEV_CONTROL_PORT, "127.0.0.1");
+  return server;
+}

--- a/packages/lesswrong/server/research/sandbox/supervisor/index.ts
+++ b/packages/lesswrong/server/research/sandbox/supervisor/index.ts
@@ -16,7 +16,6 @@
  *  - BACKEND_BASE_URL     — origin to POST to (events, heartbeats)
  *  - SUPERVISOR_PORT      — port to listen on (9280)
  *  - AUTH_PROXY_PORT      — auth-proxy public port (9281)
- *  - DEV_PORT             — fixed dev-server port, exported to init.sh as PORT (9282)
  *  - DEV_PROXY_SECRET     — HMAC key for dev-preview tokens
  *  - USER_ID, PROJECT_ID  — for context / heartbeat metadata
  *  - CONVERSATION_ID      — this sandbox's conversation (scopes queue recovery)
@@ -34,13 +33,12 @@ import { createConversationHub } from "./conversationHub";
 import { createPostPersister, PostPersister } from "./postPersister";
 import { startSupervisor, SupervisorDeps } from "./server";
 import { startHeartbeat } from "./heartbeat";
-import { startDevPortProbe } from "./devServer";
+import { createDevServerManager, startDevControlServer, DEV_CONTROL_PORT } from "./devServerManager";
+import { buildScriptBootEnv, researchBinPath } from "./devServer";
 import { startAuthProxy } from "./authProxy";
+import { AGENT_CWD } from "../sandboxLayout";
 
 const CLAUDE_MD_PATH = path.join(homedir(), ".claude", "CLAUDE.md");
-
-/** Where the in-sandbox agent runs `claude`. */
-const AGENT_CWD = "/vercel/sandbox";
 
 // init.sh runs non-blocking (it doesn't gate boot or the agent's turn), so this
 // is only a hung-process reaper, not a latency budget. Allow several minutes so a
@@ -73,7 +71,6 @@ interface SupervisorEnv {
   backendBaseUrl: string;
   port: number;
   authProxyPort: number;
-  devPort: number;
   devProxySecret: string;
   userId: string;
   projectId: string;
@@ -95,7 +92,6 @@ function readEnv(): SupervisorEnv {
     backendBaseUrl: required("BACKEND_BASE_URL"),
     port: Number(process.env.SUPERVISOR_PORT ?? "9280"),
     authProxyPort: Number(process.env.AUTH_PROXY_PORT ?? "9281"),
-    devPort: Number(process.env.DEV_PORT ?? "9282"),
     devProxySecret: required("DEV_PROXY_SECRET"),
     userId: required("USER_ID"),
     projectId: required("PROJECT_ID"),
@@ -106,14 +102,22 @@ function readEnv(): SupervisorEnv {
   };
 }
 
-function runInitScript(env: SupervisorEnv, surfaceSystem: (text: string) => void): void {
-  if (!fs.existsSync(env.initScriptPath)) return;
-  const initEnv: NodeJS.ProcessEnv = {
-    NODE_ENV: process.env.NODE_ENV,
-    PORT: String(env.devPort),
-    PATH: `${path.join(homedir(), ".research", "bin")}:${process.env.PATH ?? ""}`,
-    HOME: homedir(),
+function runInitScript(
+  env: SupervisorEnv,
+  surfaceSystem: (text: string) => void,
+  onComplete: () => void,
+): void {
+  let completed = false;
+  const finish = () => {
+    if (completed) return;
+    completed = true;
+    onComplete();
   };
+  if (!fs.existsSync(env.initScriptPath)) {
+    finish();
+    return;
+  }
+  const initEnv: NodeJS.ProcessEnv = buildScriptBootEnv();
   const child = spawn("sh", [env.initScriptPath], {
     cwd: AGENT_CWD,
     env: initEnv,
@@ -134,14 +138,15 @@ function runInitScript(env: SupervisorEnv, surfaceSystem: (text: string) => void
   child.on("error", (err) => {
     clearTimeout(timer);
     surfaceSystem(`init.sh failed to start: ${err.message}`);
+    finish();
   });
   child.on("close", (code, signal) => {
     clearTimeout(timer);
     // Surface a system event only on a genuine failure (non-zero exit or a
     // timeout kill). `init.sh` runs on *every* resume and benign steps (git pull
-    // progress, dep/deprecation warnings, dev-server banners) write to stderr
-    // without failing — surfacing those would spam the transcript on every boot.
-    // Include the stderr tail when we do surface, since that's where the cause is.
+    // progress, dep/deprecation warnings) write to stderr without failing —
+    // surfacing those would spam the transcript on every boot. Include the
+    // stderr tail when we do surface, since that's where the cause is.
     if (code !== 0 || signal) {
       const trimmed = stderr.trim();
       surfaceSystem(
@@ -149,6 +154,7 @@ function runInitScript(env: SupervisorEnv, surfaceSystem: (text: string) => void
           (trimmed ? `\n${trimmed}` : ""),
       );
     }
+    finish();
   });
 }
 
@@ -248,12 +254,14 @@ export async function bootSupervisor() {
             // Put `~/.research/bin` (where the overlay drops the research-tool
             // binary) ahead of the system PATH so the agent can invoke
             // `research-tool ...` directly from Bash.
-            PATH: `${path.join(homedir(), ".research", "bin")}:${process.env.PATH ?? ""}`,
+            PATH: researchBinPath(),
             // research-tool's required env. The token is the *agent-scoped*
             // sandbox-callback bearer the backend mints per dispatch.
             RESEARCH_BACKEND_BASE_URL: env.backendBaseUrl,
             RESEARCH_BACKEND_TOKEN: req.agentBackendToken,
             RESEARCH_PROJECT_ID: env.projectId,
+            // Lets `research-tool dev …` reach the local dev-server controller.
+            RESEARCH_DEV_CONTROL_URL: `http://127.0.0.1:${DEV_CONTROL_PORT}`,
           },
         },
       );
@@ -272,22 +280,27 @@ export async function bootSupervisor() {
 
   const server = startSupervisor(deps, env.port);
 
-  // The always-on auth-proxy fronts the localhost dev server. The supervisor
-  // does not spawn the dev server — `init.sh` does — so the proxy just probes
-  // the fixed dev port per request. Proxied requests bump `lastDevActivityAt`
-  // so dev-server use counts as activity for the idle policy.
+  // The supervisor owns the dev server: it runs the agent's `dev-server.sh`,
+  // restarts it on exit, and exposes start/stop/restart. The always-on
+  // auth-proxy fronts it and probes the fixed dev port per request; proxied
+  // requests bump `lastDevActivityAt` so dev-server use counts as activity for
+  // the idle policy.
   let lastDevActivityAt = 0;
-  const devProbe = startDevPortProbe(env.devPort);
+  const devServer = createDevServerManager(surfaceSystem);
   const authProxy: Server = startAuthProxy({
     port: env.authProxyPort,
-    devPort: env.devPort,
     proxySecret: env.devProxySecret,
     sandboxId: env.sandboxId,
-    devServer: devProbe,
+    devServer,
     onActivity: () => { lastDevActivityAt = Date.now(); },
   });
+  const devControl: Server = startDevControlServer(devServer);
 
-  runInitScript(env, surfaceSystem);
+  // Run per-boot setup to completion, then bring the dev server up. (A fresh
+  // environment has the server in `dev-server.sh`; an older one may still start
+  // it from `init.sh`, in which case `dev-server.sh` is absent and the manager
+  // stays idle.)
+  runInitScript(env, surfaceSystem, () => devServer.start());
 
   selfHealDanglingTurn(env, postPersister, () =>
     hub.snapshot().conversations.some((c) => c.status === "running"),
@@ -305,6 +318,8 @@ export async function bootSupervisor() {
     heartbeat.stop();
     server.close();
     authProxy.close();
+    devControl.close();
+    devServer.stop();
     await postPersister.drain();
     process.exit(0);
   };

--- a/packages/lesswrong/server/research/sandbox/supervisor/researchTool/researchTool.cjs
+++ b/packages/lesswrong/server/research/sandbox/supervisor/researchTool/researchTool.cjs
@@ -248,6 +248,36 @@ async function cmdCreateDoc(args) {
   printJson(result);
 }
 
+async function cmdDev(args) {
+  const action = args.positional[0];
+  if (!["start", "stop", "restart"].includes(action)) {
+    fail(1, "dev requires an action: start | stop | restart");
+  }
+  const base = (process.env.RESEARCH_DEV_CONTROL_URL || "http://127.0.0.1:9283").replace(/\/$/, "");
+  let res;
+  try {
+    res = await fetch(`${base}/${action}`, { method: "POST" });
+  } catch (err) {
+    fail(3, `Could not reach the dev-server controller: ${err && err.message ? err.message : String(err)}`);
+  }
+  const text = await res.text();
+  let parsed;
+  try {
+    parsed = text.length > 0 ? JSON.parse(text) : null;
+  } catch (err) {
+    parsed = { raw: text };
+  }
+  if (!res.ok) {
+    fail(res.status >= 500 ? 3 : 4, (parsed && parsed.error) || `HTTP ${res.status}`);
+  }
+  if (parsed && parsed.managed === false) {
+    process.stderr.write(
+      "research-tool: note — no dev-server.sh present, so there is no supervisor-managed dev server (this environment may start one from init.sh).\n",
+    );
+  }
+  printJson(parsed || { ok: true, action });
+}
+
 async function cmdFetchConversation(args) {
   const conversationId = args.positional[0];
   if (!conversationId) fail(1, "fetch-conversation requires <conversationId>");
@@ -278,6 +308,7 @@ async function cmdHelp() {
     "  list-documents",
     "  list-conversations",
     "  fetch-conversation <conversationId> [--with-thinking] [--with-tool-payloads]",
+    "  dev       start | stop | restart    (control the supervised dev server)",
     "",
     "Required env: RESEARCH_BACKEND_BASE_URL, RESEARCH_BACKEND_TOKEN, RESEARCH_PROJECT_ID",
   ].join("\n");
@@ -287,16 +318,20 @@ async function cmdHelp() {
 // --- main dispatcher -----------------------------------------------------
 
 async function main() {
-  for (const name of REQUIRED_ENV) {
-    // Ensure required env is present early — fast-fail before parsing args.
-    if (!process.env[name]) {
-      fail(1, `Missing required env var: ${name}`);
-    }
-  }
-
   const argv = process.argv.slice(2);
   const command = argv[0];
   const rest = parseArgs(argv.slice(1));
+
+  // `dev` and the help screens talk to the local dev controller (or nothing),
+  // so they don't need the backend env; everything else fast-fails without it.
+  const needsBackendEnv = !["dev", "help", "--help", "-h", undefined].includes(command);
+  if (needsBackendEnv) {
+    for (const name of REQUIRED_ENV) {
+      if (!process.env[name]) {
+        fail(1, `Missing required env var: ${name}`);
+      }
+    }
+  }
 
   switch (command) {
     case undefined:
@@ -322,6 +357,9 @@ async function main() {
       return;
     case "fetch-conversation":
       await cmdFetchConversation(rest);
+      return;
+    case "dev":
+      await cmdDev(rest);
       return;
     default:
       fail(1, `Unknown command: ${command}. Run \`research-tool help\` for usage.`);

--- a/packages/lesswrong/server/resolvers/researchResolvers.ts
+++ b/packages/lesswrong/server/resolvers/researchResolvers.ts
@@ -8,9 +8,11 @@ import {
   getOrCreateSandbox,
   getRunningSandbox,
   sandboxNameForConversation,
+  SandboxWarmingError,
   supervisorUrlForSandbox,
   type ProvisionedSandbox,
 } from "@/server/research/sandbox/sandboxManager";
+import { GraphQLError } from "graphql";
 import { isPlainRecord } from "@/components/research/conversationEventFormat";
 import { accessFilterSingle } from "@/lib/utils/schemaUtils";
 import { userIsAdmin } from "@/lib/vulcan-users/permissions";
@@ -380,8 +382,6 @@ export const researchResolversMutations = {
       context,
     });
 
-    await ResearchConversations.rawUpdateOne({ _id: conv._id }, { $set: { lastActivityAt: new Date() } });
-
     await dispatchToSandbox({
       context,
       conversationId: conv._id,
@@ -392,6 +392,9 @@ export const researchResolversMutations = {
         ? { claudeSessionId: conv.claudeSessionId, priorEvents }
         : undefined,
     });
+
+    // Only after a successful dispatch, so a failed turn leaves no advanced timestamp.
+    await ResearchConversations.rawUpdateOne({ _id: conv._id }, { $set: { lastActivityAt: new Date() } });
 
     return { conversationId: conv._id, data: { _id: conv._id } };
   },
@@ -426,7 +429,7 @@ export const researchResolversMutations = {
    */
   async mintDevPreviewUrl(_root: void, args: { conversationId: string }, context: ResolverContext) {
     const conv = await loadConversationOrThrow(args.conversationId, context);
-    const provisioned = await getOrCreateSandbox(conv._id, context);
+    const provisioned = await provisionSandboxOrWarming(conv._id, context);
     if (!provisioned.devProxySecret) {
       throw new Error("The sandbox was provisioned without a dev proxy secret.");
     }
@@ -503,6 +506,29 @@ function sessionIdFromPayload(payload: unknown): string | null {
 }
 
 /**
+ * Provision (or resume) a conversation's sandbox, translating a transient
+ * "supervisor not ready yet" into a retryable `SANDBOX_WARMING` GraphQL error
+ * the client surfaces softly (and which is kept out of Sentry). Used by every
+ * resolver that brings a sandbox up.
+ */
+async function provisionSandboxOrWarming(
+  conversationId: string,
+  context: ResolverContext,
+): Promise<ProvisionedSandbox> {
+  try {
+    return await getOrCreateSandbox(conversationId, context);
+  } catch (err) {
+    if (err instanceof SandboxWarmingError) {
+      throw new GraphQLError(
+        "The sandbox is still starting up. Please try again in a moment.",
+        { extensions: { code: "SANDBOX_WARMING", noSentryCapture: true } },
+      );
+    }
+    throw err;
+  }
+}
+
+/**
  * Provision (or resume) the conversation's persistent sandbox and dispatch one
  * turn to its supervisor. `resumeContext` is supplied when continuing an
  * existing conversation; it lets a rebuilt sandbox have its Claude session
@@ -517,7 +543,7 @@ async function dispatchToSandbox(args: {
   resumeContext?: { claudeSessionId: string; priorEvents: DbResearchConversationEvent[] };
   sessionOnDisk?: { claudeSessionId: string };
 }): Promise<void> {
-  const provisioned = await getOrCreateSandbox(args.conversationId, args.context);
+  const provisioned = await provisionSandboxOrWarming(args.conversationId, args.context);
 
   if (args.sessionOnDisk && provisioned.isFirstProvision) {
     await dispatchTurnViaSupervisor({


### PR DESCRIPTION
Written by Claude
---------------------
Fixes across the /research agent sandbox system:

- Turn liveness: track completion from the Claude `result` line rather than process exit, so a turn whose process lingers (a backgrounded child) no longer pins the conversation as "running" — which had caused spurious 409s on continue, sandboxes that never idle-stopped, and blocked env saves. Stale runner callbacks are guarded by a per-turn id; cancel only acts on a running turn and won't SIGKILL a later turn.

- Dev server: the supervisor now owns the dev server, running the agent's dev-server.sh as a supervised process (restart-on-exit with backoff + a crash-loop cap, log capture, child reaping) and exposing start/stop/restart via `research-tool dev`. init.sh is demoted to setup-only; legacy init.sh-served environments still work and report `managed:false`.

- Cold resume: surface a supervisor-not-ready timeout as a retryable, Sentry-suppressed SANDBOX_WARMING error instead of a hard failure (handled on chat and /query); make the continue path idempotent; persist sandbox secrets before launch and verify /health on the warm path so retries stay coherent.

- Analytics: attribute heartbeats per sandbox/conversation, replace stringified metadata with structured fields, and add resume-timing instrumentation.

- Resources: double sandbox vCPUs.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1215404297857068) by [Unito](https://www.unito.io)
