### PR TITLE
Hide rejected profile top posts

### DIFF
--- a/app/users/[slug]/UserProfileTopPostsSection.tsx
+++ b/app/users/[slug]/UserProfileTopPostsSection.tsx
@@ -398,7 +398,7 @@ export function UserProfileTopPostsSectionQuery({user}: {user: UsersProfile}) {
       selector: hasPinnedPosts
         ? { default: { exactPostIds: pinnedPostIds } }
         : (userId
-          ? { userPosts: { userId, sortedBy: "top", excludeEvents: true, authorIsUnreviewed: null } }
+          ? { userPosts: { userId, sortedBy: "top", excludeEvents: true, authorIsUnreviewed: null, filter: "notRejected" } }
           : undefined
         ),
       limit: TOP_POSTS_LIMIT,
@@ -409,9 +409,10 @@ export function UserProfileTopPostsSectionQuery({user}: {user: UsersProfile}) {
 
   // When using pinned posts, reorder results to match the pinned order.
   const postResults = data?.posts?.results ?? [];
+  const visiblePostResults = postResults.filter(post => !post.rejected);
   const topPosts = hasPinnedPosts
-    ? filterNonnull(pinnedPostIds.map(id => postResults.find(p => p._id === id)))
-    : postResults;
+    ? filterNonnull(pinnedPostIds.map(id => visiblePostResults.find(p => p._id === id)))
+    : visiblePostResults;
 
   return <UserProfileTopPostsSectionInner user={user} topPosts={topPosts} />
 }

--- a/packages/lesswrong/lib/collections/posts/constants.ts
+++ b/packages/lesswrong/lib/collections/posts/constants.ts
@@ -104,6 +104,9 @@ export const filters: Record<string,any> = {
   "includeMetaAndPersonal": {},
   "linkpost": {
     url: {$exists: true},
+  },
+  "notRejected": {
+    rejected: {$ne: true},
   }
 }
 

--- a/packages/lesswrong/lib/collections/posts/views.ts
+++ b/packages/lesswrong/lib/collections/posts/views.ts
@@ -395,6 +395,13 @@ function filterModeToMultiplicativeKarmaModifier(mode: FilterMode): number {
 // Define standalone view functions
 function userPosts(terms: PostsViewTerms) {
   const sortOverride = terms.sortedBy ? {} : {sort: {postedAt: -1}}
+  const filter = terms.filter && filters[terms.filter] ? filters[terms.filter] : {};
+  if (terms.filter && !filters[terms.filter]) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      `Filter '${terms.filter}' not recognized while constructing userPosts view`
+    )
+  }
   return {
     selector: {
       userId: viewFieldAllowAny,
@@ -402,7 +409,8 @@ function userPosts(terms: PostsViewTerms) {
       shortform: viewFieldAllowAny,
       groupId: null, // TODO: fix vulcan so it doesn't do deep merges on viewFieldAllowAny
       $or: [{userId: terms.userId}, {coauthorUserIds: terms.userId}],
-      rejected: null
+      rejected: null,
+      ...filter,
     },
     options: {
       limit: 5,

--- a/packages/lesswrong/unitTests/profileTopPosts.tests.ts
+++ b/packages/lesswrong/unitTests/profileTopPosts.tests.ts
@@ -1,0 +1,32 @@
+import { PostsViews } from "../lib/collections/posts/views";
+
+describe("profile top posts", () => {
+  const userPostsView = PostsViews.getView("userPosts");
+
+  it("preserves the legacy userPosts rejected selector by default", () => {
+    const terms: PostsViewTerms = {
+      view: "userPosts",
+      userId: "testUserId",
+    };
+
+    const params = userPostsView(terms);
+
+    expect(params.selector).toMatchObject({
+      rejected: null,
+    });
+  });
+
+  it("can exclude rejected posts from userPosts results", () => {
+    const terms: PostsViewTerms = {
+      view: "userPosts",
+      userId: "testUserId",
+      filter: "notRejected",
+    };
+
+    const params = userPostsView(terms);
+
+    expect(params.selector).toMatchObject({
+      rejected: { $ne: true },
+    });
+  });
+});


### PR DESCRIPTION
Slack thread: https://forum-magnum.slack.com/archives/CJUN2UAFN/p1780612399334669

Github diff: https://github.com/ForumMagnum/ForumMagnum/compare/master...hide-rejected-top-posts

Preview deployment: `https://baserates-test-git-hide-rejected-top-posts.vercel.app`

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1215444613184775) by [Unito](https://www.unito.io)
