### PR TITLE
Add current conversation id to research system prompt

### DIFF
--- a/app/api/research/agent/conversations/[conversationId]/transcript/route.ts
+++ b/app/api/research/agent/conversations/[conversationId]/transcript/route.ts
@@ -55,8 +55,6 @@ export async function GET(
       return NextResponse.json({
         ok: true,
         conversationId,
-        callerConversationId: payload.conversationId,
-        isCurrentConversation: conversationId === payload.conversationId,
         incompleteTurn,
       });
     }
@@ -87,8 +85,6 @@ export async function GET(
     return NextResponse.json({
       ok: true,
       conversationId,
-      callerConversationId: payload.conversationId,
-      isCurrentConversation: conversationId === payload.conversationId,
       title: conversation.title ?? null,
       turns,
       incompleteTurn,

--- a/app/api/research/agent/conversations/[conversationId]/transcript/route.ts
+++ b/app/api/research/agent/conversations/[conversationId]/transcript/route.ts
@@ -52,7 +52,13 @@ export async function GET(
         projectId: payload.projectId,
         operationResult: "danglingCheck",
       });
-      return NextResponse.json({ ok: true, conversationId, incompleteTurn });
+      return NextResponse.json({
+        ok: true,
+        conversationId,
+        callerConversationId: payload.conversationId,
+        isCurrentConversation: conversationId === payload.conversationId,
+        incompleteTurn,
+      });
     }
 
     const events = await context.ResearchConversationEvents.find(
@@ -81,6 +87,8 @@ export async function GET(
     return NextResponse.json({
       ok: true,
       conversationId,
+      callerConversationId: payload.conversationId,
+      isCurrentConversation: conversationId === payload.conversationId,
       title: conversation.title ?? null,
       turns,
       incompleteTurn,

--- a/app/api/research/agent/documents/[documentId]/route.ts
+++ b/app/api/research/agent/documents/[documentId]/route.ts
@@ -147,6 +147,7 @@ export async function GET(
     return NextResponse.json({
       ok: true,
       documentId,
+      callerConversationId: payload.conversationId,
       title: document.title ?? null,
       markdown,
     });

--- a/app/api/research/agent/documents/[documentId]/route.ts
+++ b/app/api/research/agent/documents/[documentId]/route.ts
@@ -147,7 +147,6 @@ export async function GET(
     return NextResponse.json({
       ok: true,
       documentId,
-      callerConversationId: payload.conversationId,
       title: document.title ?? null,
       markdown,
     });

--- a/packages/lesswrong/server/research/sandbox/supervisor/agentInstructions.md
+++ b/packages/lesswrong/server/research/sandbox/supervisor/agentInstructions.md
@@ -71,7 +71,7 @@ research-tool fetch-doc <documentId>
 ```
 Returns the live document state serialized as markdown:
 ```json
-{ "ok": true, "documentId": "...", "callerConversationId": "...", "title": null, "markdown": "..." }
+{ "ok": true, "documentId": "...", "title": null, "markdown": "..." }
 ```
 The markdown comes from the *live* Yjs editor state — not the persisted
 snapshot — so it reflects changes you (or anyone else) made earlier in the
@@ -85,7 +85,6 @@ Returns a clean turn-by-turn transcript of a sibling conversation in the
 same project (bearer authorizes within-project access only):
 ```json
 { "ok": true, "conversationId": "...", "title": "Earlier zoning chat",
-  "callerConversationId": "...", "isCurrentConversation": false,
   "turns": [
     { "seq": 0, "role": "user", "text": "Compare doc A and doc B." },
     { "seq": 1, "role": "assistant", "text": "Sure, fetching now.\nfetch-doc" },
@@ -289,18 +288,6 @@ Each token is a typed reference to another resource in the current project:
   `research-tool fetch-doc <id>` if you need it.
 - `conv:<id>` — a `ResearchConversation`. Fetch its transcript with
   `research-tool fetch-conversation <id>` if you need it.
-
-If the `conv:<id>` matches your current conversation id, it is a reference
-to this conversation rather than to a prior/sibling conversation. Only fetch
-or summarize it when the user explicitly asks you to inspect your own
-transcript.
-
-Agent blocks embedded in documents appear as placeholder blocks with the
-same conversation id semantics:
-
-```
-%%% agent-block conversationId="def456" title="Earlier zoning chat" %%%
-```
 
 The quoted title is for prompt/markdown readability only; rely on the id
 when fetching. Treat tokens identically wherever they appear (a mention in

--- a/packages/lesswrong/server/research/sandbox/supervisor/agentInstructions.md
+++ b/packages/lesswrong/server/research/sandbox/supervisor/agentInstructions.md
@@ -16,6 +16,13 @@ You are working in research project **`{{RESEARCH_PROJECT_ID}}`**. All
 bearer token pins it server-side, so cross-project requests are
 rejected). You can't pivot to a different project from this sandbox.
 
+Your current conversation id is **`{{RESEARCH_CONVERSATION_ID}}`**. If
+fetched document markdown, a `fetch-conversation` result, an
+`@[conv:...]` mention, or an `%%% agent-block conversationId="..." %%%`
+placeholder refers to this same id, treat it as this conversation,
+including text you may have written earlier in the same task. Do not
+mistake it for an independent prior/sibling conversation.
+
 ## research-tool
 
 `research-tool` is on PATH and authenticates to the backend automatically
@@ -64,7 +71,7 @@ research-tool fetch-doc <documentId>
 ```
 Returns the live document state serialized as markdown:
 ```json
-{ "ok": true, "documentId": "...", "title": null, "markdown": "..." }
+{ "ok": true, "documentId": "...", "callerConversationId": "...", "title": null, "markdown": "..." }
 ```
 The markdown comes from the *live* Yjs editor state — not the persisted
 snapshot — so it reflects changes you (or anyone else) made earlier in the
@@ -78,6 +85,7 @@ Returns a clean turn-by-turn transcript of a sibling conversation in the
 same project (bearer authorizes within-project access only):
 ```json
 { "ok": true, "conversationId": "...", "title": "Earlier zoning chat",
+  "callerConversationId": "...", "isCurrentConversation": false,
   "turns": [
     { "seq": 0, "role": "user", "text": "Compare doc A and doc B." },
     { "seq": 1, "role": "assistant", "text": "Sure, fetching now.\nfetch-doc" },
@@ -281,6 +289,18 @@ Each token is a typed reference to another resource in the current project:
   `research-tool fetch-doc <id>` if you need it.
 - `conv:<id>` — a `ResearchConversation`. Fetch its transcript with
   `research-tool fetch-conversation <id>` if you need it.
+
+If the `conv:<id>` matches your current conversation id, it is a reference
+to this conversation rather than to a prior/sibling conversation. Only fetch
+or summarize it when the user explicitly asks you to inspect your own
+transcript.
+
+Agent blocks embedded in documents appear as placeholder blocks with the
+same conversation id semantics:
+
+```
+%%% agent-block conversationId="def456" title="Earlier zoning chat" %%%
+```
 
 The quoted title is for prompt/markdown readability only; rely on the id
 when fetching. Treat tokens identically wherever they appear (a mention in

--- a/packages/lesswrong/server/research/sandbox/supervisor/index.ts
+++ b/packages/lesswrong/server/research/sandbox/supervisor/index.ts
@@ -47,21 +47,25 @@ const CLAUDE_MD_PATH = path.join(homedir(), ".claude", "CLAUDE.md");
 const INIT_SCRIPT_TIMEOUT_MS = 5 * 60 * 1000;
 
 /**
- * Substitute the `{{RESEARCH_PROJECT_ID}}` placeholder in the agent's CLAUDE.md
- * so Claude Code's auto-loaded system prompt knows what project the agent is
+ * Substitute session placeholders in the agent's CLAUDE.md so Claude Code's
+ * auto-loaded system prompt knows what project and conversation the agent is
  * scoped to. Run at boot, *after* the backend's overlay write and *before* any
  * `claude` subprocess. Best-effort: a missing/unwritable file just logs.
  */
-function fillClaudeMdTemplate(env: { projectId: string }): void {
+function fillClaudeMdTemplate(env: { projectId: string; conversationId: string }): void {
   try {
     const template = fs.readFileSync(CLAUDE_MD_PATH, "utf8");
-    const filled = template.replace(/\{\{RESEARCH_PROJECT_ID\}\}/g, env.projectId);
+    const filled = template
+      .replace(/\{\{RESEARCH_PROJECT_ID\}\}/g, env.projectId)
+      .replace(/\{\{RESEARCH_CONVERSATION_ID\}\}/g, env.conversationId);
     if (filled !== template) {
       fs.writeFileSync(CLAUDE_MD_PATH, filled, "utf8");
     }
   } catch (err) {
     // eslint-disable-next-line no-console
-    console.warn(`[supervisor] could not fill CLAUDE.md template: ${(err as Error).message}`);
+    console.warn(
+      `[supervisor] could not fill CLAUDE.md template: ${err instanceof Error ? err.message : String(err)}`,
+    );
   }
 }
 
@@ -195,7 +199,7 @@ async function selfHealDanglingTurn(
 
 export async function bootSupervisor() {
   const env = readEnv();
-  fillClaudeMdTemplate({ projectId: env.projectId });
+  fillClaudeMdTemplate({ projectId: env.projectId, conversationId: env.conversationId });
 
   const postPersister = createPostPersister({
     backendBaseUrl: env.backendBaseUrl,
@@ -260,6 +264,7 @@ export async function bootSupervisor() {
             RESEARCH_BACKEND_BASE_URL: env.backendBaseUrl,
             RESEARCH_BACKEND_TOKEN: req.agentBackendToken,
             RESEARCH_PROJECT_ID: env.projectId,
+            RESEARCH_CONVERSATION_ID: req.conversationId,
             // Lets `research-tool dev …` reach the local dev-server controller.
             RESEARCH_DEV_CONTROL_URL: `http://127.0.0.1:${DEV_CONTROL_PORT}`,
           },

--- a/packages/lesswrong/server/research/sandbox/supervisor/researchTool/README.md
+++ b/packages/lesswrong/server/research/sandbox/supervisor/researchTool/README.md
@@ -42,6 +42,8 @@ The spawn must set per-subprocess env:
 - `RESEARCH_BACKEND_TOKEN` — the sandbox-callback token for *this conversation*
   (minted fresh per dispatch with a TTL sized to outlive the sandbox session)
 - `RESEARCH_PROJECT_ID` — convenience for `list-project`
+- `RESEARCH_CONVERSATION_ID` — the current conversation id, for disambiguating
+  fetched document/transcript references that point back to this same session
 
 ## Auth contract
 

--- a/packages/lesswrong/server/research/sandbox/supervisor/researchTool/researchTool.cjs
+++ b/packages/lesswrong/server/research/sandbox/supervisor/researchTool/researchTool.cjs
@@ -25,6 +25,9 @@
  *   RESEARCH_PROJECT_ID          — the project this sandbox is scoped to;
  *                                  used to build URLs (the bearer token also
  *                                  pins the project server-side)
+ *   RESEARCH_CONVERSATION_ID     — the current conversation id; useful when
+ *                                  comparing fetched transcript/document
+ *                                  references against the active session
  *
  * Output: JSON-serialized API response on stdout (one object per invocation).
  * Errors: human-readable message on stderr + non-zero exit code.

--- a/packages/lesswrong/server/research/systemReminder.ts
+++ b/packages/lesswrong/server/research/systemReminder.ts
@@ -21,17 +21,26 @@ export interface DocumentContext {
 interface SystemReminderInputs {
   activeDocument: DocumentContext;
   originDocument?: DocumentContext;
+  conversationId?: string;
 }
 
 export function buildSystemReminderWrap(inputs: SystemReminderInputs, userPrompt: string): string {
-  const { activeDocument, originDocument } = inputs;
+  const { activeDocument, originDocument, conversationId } = inputs;
   const attrs = [`active-document-id="${escapeHtml(activeDocument.id)}"`];
+  if (conversationId) {
+    attrs.push(`conversation-id="${escapeHtml(conversationId)}"`);
+  }
   if (originDocument && originDocument.id !== activeDocument.id) {
     attrs.push(`origin-document-id="${escapeHtml(originDocument.id)}"`);
   }
   const bodyLines = [
     `The user is currently viewing the research document "${activeDocument.title}" (id: ${activeDocument.id}) in the workspace.`,
   ];
+  if (conversationId) {
+    bodyLines.push(
+      `This is research conversation ${conversationId}; references to that same conversation id are this conversation, not a separate prior conversation.`,
+    );
+  }
   if (originDocument && originDocument.id !== activeDocument.id) {
     bodyLines.push(
       `This conversation was originally invoked from "${originDocument.title}" (id: ${originDocument.id}).`,
@@ -43,6 +52,7 @@ export function buildSystemReminderWrap(inputs: SystemReminderInputs, userPrompt
 export interface ParsedSystemReminder {
   activeDocumentId: string | null;
   originDocumentId: string | null;
+  conversationId: string | null;
 }
 
 export function parseLeadingSystemReminder(text: string): ParsedSystemReminder | null {
@@ -54,6 +64,7 @@ export function parseLeadingSystemReminder(text: string): ParsedSystemReminder |
   return {
     activeDocumentId: el.attr("active-document-id") ?? null,
     originDocumentId: el.attr("origin-document-id") ?? null,
+    conversationId: el.attr("conversation-id") ?? null,
   };
 }
 

--- a/packages/lesswrong/server/resolvers/researchResolvers.ts
+++ b/packages/lesswrong/server/resolvers/researchResolvers.ts
@@ -146,13 +146,23 @@ async function cancelTurnViaSupervisor(target: SupervisorTarget): Promise<void> 
 async function prepareTurnPrompt(args: {
   rawPrompt: string;
   projectId: string;
+  conversationId: string;
   activeDocumentId: string;
   entrypointKind: string;
   entrypointDocumentId: string;
   priorEvents: DbResearchConversationEvent[];
   context: ResolverContext;
 }): Promise<string> {
-  const { rawPrompt, projectId, activeDocumentId, entrypointKind, entrypointDocumentId, priorEvents, context } = args;
+  const {
+    rawPrompt,
+    projectId,
+    conversationId,
+    activeDocumentId,
+    entrypointKind,
+    entrypointDocumentId,
+    priorEvents,
+    context,
+  } = args;
 
   const lastInjected = deriveLastInjectedActiveDocumentId(priorEvents);
   if (lastInjected === activeDocumentId) return rawPrompt;
@@ -169,6 +179,7 @@ async function prepareTurnPrompt(args: {
   return buildSystemReminderWrap(
     {
       activeDocument: { id: activeDoc._id, title: activeDoc.title ?? "(untitled)" },
+      conversationId,
       originDocument: originDoc
         ? { id: originDoc._id, title: originDoc.title ?? "(untitled)" }
         : undefined,
@@ -320,6 +331,7 @@ export const researchResolversMutations = {
     const turnPrompt = await prepareTurnPrompt({
       rawPrompt: prompt,
       projectId,
+      conversationId,
       activeDocumentId,
       entrypointKind: kind,
       entrypointDocumentId: activeDocumentId,
@@ -375,6 +387,7 @@ export const researchResolversMutations = {
     const turnPrompt = await prepareTurnPrompt({
       rawPrompt: prompt,
       projectId: conv.projectId,
+      conversationId: conv._id,
       activeDocumentId: args.activeDocumentId,
       entrypointKind: conv.entrypointKind,
       entrypointDocumentId: conv.entrypointDocumentId,

--- a/packages/lesswrong/unitTests/researchSystemReminder.tests.ts
+++ b/packages/lesswrong/unitTests/researchSystemReminder.tests.ts
@@ -1,0 +1,39 @@
+import {
+  buildSystemReminderWrap,
+  parseLeadingSystemReminder,
+} from "../server/research/systemReminder";
+
+describe("research system reminders", () => {
+  it("includes and parses the current conversation id", () => {
+    const wrapped = buildSystemReminderWrap(
+      {
+        activeDocument: { id: "doc_123", title: "Active doc" },
+        originDocument: { id: "doc_origin", title: "Origin doc" },
+        conversationId: "conv_abc",
+      },
+      "Please read the doc.",
+    );
+
+    expect(wrapped).toContain('conversation-id="conv_abc"');
+    expect(wrapped).toContain(
+      "references to that same conversation id are this conversation, not a separate prior conversation",
+    );
+    expect(parseLeadingSystemReminder(wrapped)).toEqual({
+      activeDocumentId: "doc_123",
+      originDocumentId: "doc_origin",
+      conversationId: "conv_abc",
+    });
+  });
+
+  it("keeps conversation id optional for old persisted reminders", () => {
+    const parsed = parseLeadingSystemReminder(
+      '<system-reminder active-document-id="doc_123">\nThe user is viewing a document.\n</system-reminder>\n\nHello',
+    );
+
+    expect(parsed).toEqual({
+      activeDocumentId: "doc_123",
+      originDocumentId: null,
+      conversationId: null,
+    });
+  });
+});


### PR DESCRIPTION
Hopefully deconfuse agents about seeing the current converation in an AgentBlock in the current document if they fetch it, and prevent them from (pointlessly) fetching the conversation itself.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1215522712567695) by [Unito](https://www.unito.io)
