### PR TITLE
Add "Offboard?" supermod review tab

### DIFF
--- a/packages/lesswrong/components/sunshineDashboard/supermod/ModerationInboxItem.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/supermod/ModerationInboxItem.tsx
@@ -263,7 +263,7 @@ const ModerationInboxItem = ({
       )}
 
       <div className={classes.contextualInfo}>
-        {reviewGroup === 'newContent'
+        {reviewGroup === 'newContent' || reviewGroup === 'offboard'
           ? <ContentPreview user={user} />
           : <PreloadUserContents user={user} />
         }

--- a/packages/lesswrong/components/sunshineDashboard/supermod/ModerationInboxList.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/supermod/ModerationInboxList.tsx
@@ -30,6 +30,9 @@ const styles = defineStyles('ModerationInboxList', (theme: ThemeType) => ({
   newContent: {
     background: theme.palette.panelBackground.sunshineNewContentGroup,
   },
+  offboard: {
+    background: theme.palette.panelBackground.sunshineOffboardGroup,
+  },
   highContext: {
     background: theme.palette.panelBackground.sunshineHighContextGroup,
   },

--- a/packages/lesswrong/components/sunshineDashboard/supermod/ModerationInboxList.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/supermod/ModerationInboxList.tsx
@@ -31,7 +31,7 @@ const styles = defineStyles('ModerationInboxList', (theme: ThemeType) => ({
     background: theme.palette.panelBackground.sunshineNewContentGroup,
   },
   offboard: {
-    background: theme.palette.panelBackground.sunshineOffboardGroup,
+    background: theme.palette.panelBackground.sunshineWarningHighlight,
   },
   highContext: {
     background: theme.palette.panelBackground.sunshineHighContextGroup,

--- a/packages/lesswrong/components/sunshineDashboard/supermod/groupings.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/supermod/groupings.tsx
@@ -45,13 +45,15 @@ export function getDisplayedReasonForGroupAssignment(user: SunshineUsersList): R
 }
 
 export function getTabsInPriorityOrder(): ReviewGroup[] {
-  return ['newContent', 'highContext', 'maybeSpam', 'automod', 'snoozeExpired', 'unknown'];
+  return ['newContent', 'offboard', 'highContext', 'maybeSpam', 'automod', 'snoozeExpired', 'unknown'];
 }
 
 export function getReviewGroupDisplayName(group: TabId): string {
   switch (group) {
     case 'newContent':
       return 'New Content';
+    case 'offboard':
+      return 'Offboard?';
     case 'highContext':
       return 'High Context';
     case 'maybeSpam':

--- a/packages/lesswrong/lib/collections/users/newSchema.ts
+++ b/packages/lesswrong/lib/collections/users/newSchema.ts
@@ -37,7 +37,7 @@ import { bothChannelsEnabledNotificationTypeSettings, dailyEmailBatchNotificatio
 import { getWithLoader, getWithCustomLoader, loadByIds } from "@/lib/loaders";
 import { VOTING_DISABLED } from "../moderatorActions/constants";
 import { isActionActive } from "../moderatorActions/helpers";
-import { getReviewGroupFromActions } from "./reviewGroups";
+import { getReviewGroupFromActions, isOffboardCandidate, OFFBOARD_PANGRAM_THRESHOLD, type OffboardStats } from "./reviewGroups";
 import { validateFrontpageFilterSettings } from "@/server/users/validateFrontpageFilterSettings";
 
 const getCoauthoredPostCount = async (user: DbUser) => {
@@ -65,6 +65,14 @@ const getModeratorActionsForUser = (context: ResolverContext, userId: string) =>
     {},
     "userId",
     userId,
+  );
+};
+
+// Batched per-request lookup of the stats used to decide whether a `newContent`
+// user should instead be surfaced in the supermod "offboard" review group.
+const getOffboardStats = (context: ResolverContext, userId: string): Promise<OffboardStats> => {
+  return getWithCustomLoader(context, "offboardStats", userId, (userIds) =>
+    context.repos.users.getOffboardStatsForUsers(userIds, OFFBOARD_PANGRAM_THRESHOLD)
   );
 };
 
@@ -3977,7 +3985,18 @@ const schema = {
           active: isActionActive(action),
           createdAt: action.createdAt,
         }));
-        return getReviewGroupFromActions(actionsWithActiveStatus, lastRemovedFromReviewQueueAt);
+        const baseGroup = getReviewGroupFromActions(actionsWithActiveStatus, lastRemovedFromReviewQueueAt);
+
+        // Users who would otherwise be in `newContent` get pulled into the
+        // `offboard` group if their content matches the offboarding criteria.
+        if (baseGroup === 'newContent') {
+          const offboardStats = await getOffboardStats(context, doc._id);
+          if (isOffboardCandidate(offboardStats)) {
+            return 'offboard';
+          }
+        }
+
+        return baseGroup;
       },
     },
   },

--- a/packages/lesswrong/lib/collections/users/newSchema.ts
+++ b/packages/lesswrong/lib/collections/users/newSchema.ts
@@ -37,7 +37,7 @@ import { bothChannelsEnabledNotificationTypeSettings, dailyEmailBatchNotificatio
 import { getWithLoader, getWithCustomLoader, loadByIds } from "@/lib/loaders";
 import { VOTING_DISABLED } from "../moderatorActions/constants";
 import { isActionActive } from "../moderatorActions/helpers";
-import { getReviewGroupFromActions, isOffboardCandidate, OFFBOARD_PANGRAM_THRESHOLD, type OffboardStats } from "./reviewGroups";
+import { getReviewGroupFromActions } from "./reviewGroups";
 import { validateFrontpageFilterSettings } from "@/server/users/validateFrontpageFilterSettings";
 
 const getCoauthoredPostCount = async (user: DbUser) => {
@@ -68,12 +68,13 @@ const getModeratorActionsForUser = (context: ResolverContext, userId: string) =>
   );
 };
 
-// Batched per-request lookup of the stats used to decide whether a `newContent`
-// user should instead be surfaced in the supermod "offboard" review group.
-const getOffboardStats = (context: ResolverContext, userId: string): Promise<OffboardStats> => {
-  return getWithCustomLoader(context, "offboardStats", userId, (userIds) =>
-    context.repos.users.getOffboardStatsForUsers(userIds, OFFBOARD_PANGRAM_THRESHOLD)
-  );
+// Batched per-request check of whether a `newContent` user should instead be
+// surfaced in the supermod "offboard" review group.
+const getIsOffboardCandidate = (context: ResolverContext, userId: string): Promise<boolean> => {
+  return getWithCustomLoader(context, "offboardCandidates", userId, async (userIds) => {
+    const candidateIds = new Set(await context.repos.users.getOffboardCandidateUserIds(userIds));
+    return userIds.map((id) => candidateIds.has(id));
+  });
 };
 
 // Get last time user's `needsReview` flag was set to false (or null if never).
@@ -3989,11 +3990,8 @@ const schema = {
 
         // Users who would otherwise be in `newContent` get pulled into the
         // `offboard` group if their content matches the offboarding criteria.
-        if (baseGroup === 'newContent') {
-          const offboardStats = await getOffboardStats(context, doc._id);
-          if (isOffboardCandidate(offboardStats)) {
-            return 'offboard';
-          }
+        if (baseGroup === 'newContent' && await getIsOffboardCandidate(context, doc._id)) {
+          return 'offboard';
         }
 
         return baseGroup;

--- a/packages/lesswrong/lib/collections/users/reviewGroups.ts
+++ b/packages/lesswrong/lib/collections/users/reviewGroups.ts
@@ -8,13 +8,50 @@ import maxBy from "lodash/maxBy";
  * highest-priority fresh review-trigger group.
  */
 export const REVIEW_GROUP_TO_PRIORITY = {
-  newContent: 6,
+  newContent: 7,
+  offboard: 6,
   highContext: 5,
   maybeSpam: 4,
   automod: 3,
   snoozeExpired: 2,
   unknown: 1,
 } as const satisfies Record<ReviewGroup, number>;
+
+/**
+ * Pangram AI-detection score above which a rejected post/comment counts as an
+ * "autoreject" strong enough to flag the user for offboarding (criterion 1).
+ */
+export const OFFBOARD_PANGRAM_THRESHOLD = 0.8;
+
+/**
+ * Per-user stats (computed server-side from the user's posts & comments) used to
+ * decide whether a user who would otherwise be in `newContent` should instead be
+ * surfaced in the `offboard` review group.
+ */
+export interface OffboardStats {
+  /** Number of the user's rejected (non-deleted) comments. */
+  rejectedCommentCount: number;
+  /** Number of the user's non-rejected current posts + comments. */
+  liveContentCount: number;
+  /** Number of the user's current (non-draft/non-deleted) posts + comments. */
+  totalContentCount: number;
+  /** Whether any rejected post/comment has a Pangram score above the threshold. */
+  hasHighPangramAutoreject: boolean;
+}
+
+/**
+ * A `newContent` user is moved to the `offboard` group if any of:
+ *   1) they have a rejected post/comment with a high Pangram autoreject score
+ *   2) they have at least two rejected comments
+ *   3) all of their current posts/comments have already been rejected
+ */
+export function isOffboardCandidate(stats: OffboardStats): boolean {
+  return (
+    stats.hasHighPangramAutoreject ||
+    stats.rejectedCommentCount >= 2 ||
+    (stats.totalContentCount > 0 && stats.liveContentCount === 0)
+  );
+}
 
 /**
  * Ensures that we don't forget to add new review-trigger moderator action types

--- a/packages/lesswrong/lib/collections/users/reviewGroups.ts
+++ b/packages/lesswrong/lib/collections/users/reviewGroups.ts
@@ -18,42 +18,6 @@ export const REVIEW_GROUP_TO_PRIORITY = {
 } as const satisfies Record<ReviewGroup, number>;
 
 /**
- * Pangram AI-detection score above which a rejected post/comment counts as an
- * "autoreject" strong enough to flag the user for offboarding (criterion 1).
- */
-export const OFFBOARD_PANGRAM_THRESHOLD = 0.8;
-
-/**
- * Per-user stats (computed server-side from the user's posts & comments) used to
- * decide whether a user who would otherwise be in `newContent` should instead be
- * surfaced in the `offboard` review group.
- */
-export interface OffboardStats {
-  /** Number of the user's rejected (non-deleted) comments. */
-  rejectedCommentCount: number;
-  /** Number of the user's non-rejected current posts + comments. */
-  liveContentCount: number;
-  /** Number of the user's current (non-draft/non-deleted) posts + comments. */
-  totalContentCount: number;
-  /** Whether any rejected post/comment has a Pangram score above the threshold. */
-  hasHighPangramAutoreject: boolean;
-}
-
-/**
- * A `newContent` user is moved to the `offboard` group if any of:
- *   1) they have a rejected post/comment with a high Pangram autoreject score
- *   2) they have at least two rejected comments
- *   3) all of their current posts/comments have already been rejected
- */
-export function isOffboardCandidate(stats: OffboardStats): boolean {
-  return (
-    stats.hasHighPangramAutoreject ||
-    stats.rejectedCommentCount >= 2 ||
-    (stats.totalContentCount > 0 && stats.liveContentCount === 0)
-  );
-}
-
-/**
  * Ensures that we don't forget to add new review-trigger moderator action types
  * as explicitly-handled cases in the `getModeratorActionGroup` and
  * `getPrimaryDisplayedModeratorAction` switch statements

--- a/packages/lesswrong/lib/generated/gql-codegen/graphql.ts
+++ b/packages/lesswrong/lib/generated/gql-codegen/graphql.ts
@@ -10821,6 +10821,7 @@ export type ReviewGroup =
   | 'highContext'
   | 'maybeSpam'
   | 'newContent'
+  | 'offboard'
   | 'snoozeExpired'
   | 'unknown';
 

--- a/packages/lesswrong/lib/generated/gqlSchema.gql
+++ b/packages/lesswrong/lib/generated/gqlSchema.gql
@@ -7809,6 +7809,7 @@ enum SubforumPreferredLayout {
 
 enum ReviewGroup {
   newContent
+  offboard
   highContext
   maybeSpam
   automod

--- a/packages/lesswrong/lib/generated/graphqlCodegenTypes.d.ts
+++ b/packages/lesswrong/lib/generated/graphqlCodegenTypes.d.ts
@@ -8954,6 +8954,7 @@ type ReviewGroup =
   | 'highContext'
   | 'maybeSpam'
   | 'newContent'
+  | 'offboard'
   | 'snoozeExpired'
   | 'unknown';
 

--- a/packages/lesswrong/server/collections/users/queries.ts
+++ b/packages/lesswrong/server/collections/users/queries.ts
@@ -56,6 +56,7 @@ export const graphqlUserQueryTypeDefs = gql`
 
   enum ReviewGroup {
     newContent
+    offboard
     highContext
     maybeSpam
     automod

--- a/packages/lesswrong/server/repos/UsersRepo.ts
+++ b/packages/lesswrong/server/repos/UsersRepo.ts
@@ -5,6 +5,7 @@ import { isEAForum } from "../../lib/instanceSettings";
 import { getDefaultFacetFieldSelector, getFacetField } from "../search/facetFieldSearch";
 import { MULTISELECT_SUGGESTION_LIMIT } from "@/lib/collections/users/helpers";
 import { getViewablePostsSelector } from "./helpers";
+import type { OffboardStats } from "@/lib/collections/users/reviewGroups";
 
 const GET_USERS_BY_EMAIL_QUERY = `
 -- UsersRepo.GET_USERS_BY_EMAIL_QUERY 
@@ -400,6 +401,69 @@ class UsersRepo extends AbstractRepo<"Users"> {
       SELECT "_id" FROM "Sequences" WHERE "userId" = $1
     `, [userId]);
     return results.map(({_id}) => _id);
+  }
+
+  /**
+   * For each requested user, compute the stats used to decide whether they
+   * belong in the supermod "offboard" review group (see `isOffboardCandidate`).
+   * "Content" here means non-draft posts and non-deleted comments. For rejected
+   * items we look up the latest Pangram AI-detection score (via their content
+   * revisions) to detect high-confidence autorejects.
+   */
+  async getOffboardStatsForUsers(userIds: string[], pangramThreshold: number): Promise<OffboardStats[]> {
+    const rows = await this.getRawDb().any<{
+      userId: string,
+      rejectedCommentCount: number,
+      totalContentCount: number,
+      liveContentCount: number,
+      hasHighPangramAutoreject: boolean,
+    }>(`
+      -- UsersRepo.getOffboardStatsForUsers
+      WITH content AS (
+        SELECT p."_id" AS "documentId", p."userId", p."rejected", FALSE AS "isComment"
+        FROM "Posts" p
+        WHERE p."userId" = ANY($1::text[])
+          AND p."draft" IS NOT TRUE
+          AND p."deletedDraft" IS NOT TRUE
+        UNION ALL
+        SELECT c."_id" AS "documentId", c."userId", c."rejected", TRUE AS "isComment"
+        FROM "Comments" c
+        WHERE c."userId" = ANY($1::text[])
+          AND c."deleted" IS NOT TRUE
+      ),
+      content_with_pangram AS (
+        SELECT
+          ct.*,
+          CASE WHEN ct."rejected" IS TRUE THEN (
+            SELECT ace."pangramScore"
+            FROM "Revisions" r
+            JOIN "AutomatedContentEvaluations" ace ON ace."revisionId" = r."_id"
+            WHERE r."documentId" = ct."documentId" AND r."fieldName" = 'contents'
+            ORDER BY ace."createdAt" DESC
+            LIMIT 1
+          ) ELSE NULL END AS "pangramScore"
+        FROM content ct
+      )
+      SELECT
+        "userId",
+        COUNT(*) FILTER (WHERE "isComment" AND "rejected" IS TRUE)::int AS "rejectedCommentCount",
+        COUNT(*)::int AS "totalContentCount",
+        COUNT(*) FILTER (WHERE "rejected" IS NOT TRUE)::int AS "liveContentCount",
+        COALESCE(BOOL_OR("rejected" IS TRUE AND "pangramScore" > $2), FALSE) AS "hasHighPangramAutoreject"
+      FROM content_with_pangram
+      GROUP BY "userId"
+    `, [userIds, pangramThreshold]);
+
+    const statsByUser = new Map(rows.map((row) => [row.userId, row]));
+    return userIds.map((userId) => {
+      const stats = statsByUser.get(userId);
+      return {
+        rejectedCommentCount: stats?.rejectedCommentCount ?? 0,
+        liveContentCount: stats?.liveContentCount ?? 0,
+        totalContentCount: stats?.totalContentCount ?? 0,
+        hasHighPangramAutoreject: stats?.hasHighPangramAutoreject ?? false,
+      };
+    });
   }
 
   async getRejectedContentCounts(userIds: string[]): Promise<number[]> {

--- a/packages/lesswrong/server/repos/UsersRepo.ts
+++ b/packages/lesswrong/server/repos/UsersRepo.ts
@@ -6,6 +6,11 @@ import { getDefaultFacetFieldSelector, getFacetField } from "../search/facetFiel
 import { MULTISELECT_SUGGESTION_LIMIT } from "@/lib/collections/users/helpers";
 import { getViewablePostsSelector } from "./helpers";
 
+// Pangram score above which a rejected item counts toward offboarding 
+// deliberately higher than the autoreject threshold in
+// `createAutomatedContentEvaluation`;
+const OFFBOARD_HIGH_PANGRAM_SCORE_THRESHOLD = 0.6;
+
 const GET_USERS_BY_EMAIL_QUERY = `
 -- UsersRepo.GET_USERS_BY_EMAIL_QUERY 
 SELECT *
@@ -405,45 +410,48 @@ class UsersRepo extends AbstractRepo<"Users"> {
   /**
    * Of the requested users, return the ids of those who belong in the supermod
    * "offboard" review group, because they either:
-   *   (1) have a rejected post/comment with a high Pangram autoreject score, or
-   *   (2) have at least two rejected comments, or
-   *   (3) have all of their current content rejected.
-   * Criteria (2) and (3) consider "current" content (non-draft posts / non-deleted
-   * comments). Criterion (1) also counts posts that have since been re-drafted: a
-   * high-scoring autoreject still counts even if the user pulled the post back to
-   * drafts.
+   *   (1) have a rejected post/comment with a high Pangram score, or
+   *   (2) have at least two rejected posts and/or comments, or
+   *   (3) have all of their content rejected.
+   * Rejected content counts for all criteria even if the user has since
+   * re-drafted/deleted the post or deleted the comment; never-rejected drafts
+   * and deleted items are ignored. Criterion (1) considers evaluations of any
+   * revision, not just the latest.
+   * All criteria are evaluated over all-time content state (deliberately not
+   * bounded by `lastRemovedFromReviewQueueAt`), so the offboard question keeps
+   * getting re-asked until the user is offboarded or their record improves.
    */
   async getOffboardCandidateUserIds(userIds: string[]): Promise<string[]> {
     const rows = await this.getRawDb().any<{ userId: string }>(`
       -- UsersRepo.getOffboardCandidateUserIds
       WITH content AS (
-        SELECT p."_id" AS "documentId", p."userId", p."rejected", FALSE AS "isComment",
-          (p."draft" IS NOT TRUE) AS "isCurrent"
+        SELECT p."_id" AS "documentId", p."userId", p."rejected"
         FROM "Posts" p
-        WHERE p."userId" = ANY($(userIds)::text[]) AND p."deletedDraft" IS NOT TRUE
+        WHERE p."userId" = ANY($(userIds)::text[])
+          AND (p."rejected" IS TRUE OR (p."draft" IS NOT TRUE AND p."deletedDraft" IS NOT TRUE))
         UNION ALL
-        SELECT c."_id", c."userId", c."rejected", TRUE, TRUE
+        SELECT c."_id", c."userId", c."rejected"
         FROM "Comments" c
-        WHERE c."userId" = ANY($(userIds)::text[]) AND c."deleted" IS NOT TRUE
+        WHERE c."userId" = ANY($(userIds)::text[])
+          AND (c."rejected" IS TRUE OR c."deleted" IS NOT TRUE)
       ),
       highPangramRejections AS (
         SELECT c."userId"
         FROM content c
         JOIN "Revisions" r ON r."documentId" = c."documentId" AND r."fieldName" = 'contents'
         JOIN "AutomatedContentEvaluations" ace ON ace."revisionId" = r."_id"
-        WHERE c."rejected" IS TRUE AND ace."pangramScore" > 0.6
+        WHERE c."rejected" IS TRUE AND ace."pangramScore" > $(highPangramScoreThreshold)
       )
-      -- (1) a rejected item (including re-drafted posts) with a high Pangram autoreject score
+      -- (1) a rejected item with a high Pangram score
       SELECT "userId" FROM highPangramRejections
       UNION
-      -- (2) at least two rejected comments, or (3) all current content rejected
+      -- (2) at least two rejected items, or (3) all content rejected
       SELECT c."userId"
       FROM content c
-      WHERE c."isCurrent"
       GROUP BY c."userId"
-      HAVING COUNT(*) FILTER (WHERE c."isComment" AND c."rejected" IS TRUE) >= 2
+      HAVING COUNT(*) FILTER (WHERE c."rejected" IS TRUE) >= 2
         OR COUNT(*) FILTER (WHERE c."rejected" IS NOT TRUE) = 0
-    `, { userIds });
+    `, { userIds, highPangramScoreThreshold: OFFBOARD_HIGH_PANGRAM_SCORE_THRESHOLD });
     return rows.map((row) => row.userId);
   }
 

--- a/packages/lesswrong/server/repos/UsersRepo.ts
+++ b/packages/lesswrong/server/repos/UsersRepo.ts
@@ -5,7 +5,6 @@ import { isEAForum } from "../../lib/instanceSettings";
 import { getDefaultFacetFieldSelector, getFacetField } from "../search/facetFieldSearch";
 import { MULTISELECT_SUGGESTION_LIMIT } from "@/lib/collections/users/helpers";
 import { getViewablePostsSelector } from "./helpers";
-import type { OffboardStats } from "@/lib/collections/users/reviewGroups";
 
 const GET_USERS_BY_EMAIL_QUERY = `
 -- UsersRepo.GET_USERS_BY_EMAIL_QUERY 
@@ -404,66 +403,36 @@ class UsersRepo extends AbstractRepo<"Users"> {
   }
 
   /**
-   * For each requested user, compute the stats used to decide whether they
-   * belong in the supermod "offboard" review group (see `isOffboardCandidate`).
-   * "Content" here means non-draft posts and non-deleted comments. For rejected
-   * items we look up the latest Pangram AI-detection score (via their content
-   * revisions) to detect high-confidence autorejects.
+   * Of the requested users, return the ids of those who belong in the supermod
+   * "offboard" review group: their (non-draft post / non-deleted comment) content
+   * either (1) includes a rejected item with a high Pangram autoreject score,
+   * (2) includes at least two rejected comments, or (3) is entirely rejected.
    */
-  async getOffboardStatsForUsers(userIds: string[], pangramThreshold: number): Promise<OffboardStats[]> {
-    const rows = await this.getRawDb().any<{
-      userId: string,
-      rejectedCommentCount: number,
-      totalContentCount: number,
-      liveContentCount: number,
-      hasHighPangramAutoreject: boolean,
-    }>(`
-      -- UsersRepo.getOffboardStatsForUsers
+  async getOffboardCandidateUserIds(userIds: string[]): Promise<string[]> {
+    const rows = await this.getRawDb().any<{ userId: string }>(`
+      -- UsersRepo.getOffboardCandidateUserIds
       WITH content AS (
         SELECT p."_id" AS "documentId", p."userId", p."rejected", FALSE AS "isComment"
         FROM "Posts" p
-        WHERE p."userId" = ANY($1::text[])
-          AND p."draft" IS NOT TRUE
-          AND p."deletedDraft" IS NOT TRUE
+        WHERE p."userId" = ANY($1::text[]) AND p."draft" IS NOT TRUE AND p."deletedDraft" IS NOT TRUE
         UNION ALL
-        SELECT c."_id" AS "documentId", c."userId", c."rejected", TRUE AS "isComment"
+        SELECT c."_id", c."userId", c."rejected", TRUE
         FROM "Comments" c
-        WHERE c."userId" = ANY($1::text[])
-          AND c."deleted" IS NOT TRUE
-      ),
-      content_with_pangram AS (
-        SELECT
-          ct.*,
-          CASE WHEN ct."rejected" IS TRUE THEN (
-            SELECT ace."pangramScore"
-            FROM "Revisions" r
-            JOIN "AutomatedContentEvaluations" ace ON ace."revisionId" = r."_id"
-            WHERE r."documentId" = ct."documentId" AND r."fieldName" = 'contents'
-            ORDER BY ace."createdAt" DESC
-            LIMIT 1
-          ) ELSE NULL END AS "pangramScore"
-        FROM content ct
+        WHERE c."userId" = ANY($1::text[]) AND c."deleted" IS NOT TRUE
       )
-      SELECT
-        "userId",
-        COUNT(*) FILTER (WHERE "isComment" AND "rejected" IS TRUE)::int AS "rejectedCommentCount",
-        COUNT(*)::int AS "totalContentCount",
-        COUNT(*) FILTER (WHERE "rejected" IS NOT TRUE)::int AS "liveContentCount",
-        COALESCE(BOOL_OR("rejected" IS TRUE AND "pangramScore" > $2), FALSE) AS "hasHighPangramAutoreject"
-      FROM content_with_pangram
-      GROUP BY "userId"
-    `, [userIds, pangramThreshold]);
-
-    const statsByUser = new Map(rows.map((row) => [row.userId, row]));
-    return userIds.map((userId) => {
-      const stats = statsByUser.get(userId);
-      return {
-        rejectedCommentCount: stats?.rejectedCommentCount ?? 0,
-        liveContentCount: stats?.liveContentCount ?? 0,
-        totalContentCount: stats?.totalContentCount ?? 0,
-        hasHighPangramAutoreject: stats?.hasHighPangramAutoreject ?? false,
-      };
-    });
+      SELECT c."userId"
+      FROM content c
+      GROUP BY c."userId"
+      HAVING COUNT(*) FILTER (WHERE c."isComment" AND c."rejected" IS TRUE) >= 2
+        OR COUNT(*) FILTER (WHERE c."rejected" IS NOT TRUE) = 0
+        OR EXISTS (
+          SELECT 1 FROM content c2
+          JOIN "Revisions" r ON r."documentId" = c2."documentId" AND r."fieldName" = 'contents'
+          JOIN "AutomatedContentEvaluations" ace ON ace."revisionId" = r."_id"
+          WHERE c2."userId" = c."userId" AND c2."rejected" IS TRUE AND ace."pangramScore" > 0.8
+        )
+    `, [userIds]);
+    return rows.map((row) => row.userId);
   }
 
   async getRejectedContentCounts(userIds: string[]): Promise<number[]> {

--- a/packages/lesswrong/server/repos/UsersRepo.ts
+++ b/packages/lesswrong/server/repos/UsersRepo.ts
@@ -417,28 +417,21 @@ class UsersRepo extends AbstractRepo<"Users"> {
     const rows = await this.getRawDb().any<{ userId: string }>(`
       -- UsersRepo.getOffboardCandidateUserIds
       WITH content AS (
-        SELECT p."_id" AS "documentId", p."userId", p."rejected", FALSE AS "isComment"
+        SELECT p."_id" AS "documentId", p."userId", p."rejected", FALSE AS "isComment",
+          (p."draft" IS NOT TRUE) AS "isCurrent"
         FROM "Posts" p
-        WHERE p."userId" = ANY($1::text[]) AND p."draft" IS NOT TRUE AND p."deletedDraft" IS NOT TRUE
+        WHERE p."userId" = ANY($(userIds)::text[]) AND p."deletedDraft" IS NOT TRUE
         UNION ALL
-        SELECT c."_id", c."userId", c."rejected", TRUE
+        SELECT c."_id", c."userId", c."rejected", TRUE, TRUE
         FROM "Comments" c
-        WHERE c."userId" = ANY($1::text[]) AND c."deleted" IS NOT TRUE
+        WHERE c."userId" = ANY($(userIds)::text[]) AND c."deleted" IS NOT TRUE
       ),
       highPangramRejections AS (
-        SELECT x."userId"
-        FROM (
-          SELECT p."_id" AS "documentId", p."userId"
-          FROM "Posts" p
-          WHERE p."userId" = ANY($1::text[]) AND p."rejected" IS TRUE AND p."deletedDraft" IS NOT TRUE
-          UNION ALL
-          SELECT c."_id", c."userId"
-          FROM "Comments" c
-          WHERE c."userId" = ANY($1::text[]) AND c."rejected" IS TRUE AND c."deleted" IS NOT TRUE
-        ) x
-        JOIN "Revisions" r ON r."documentId" = x."documentId" AND r."fieldName" = 'contents'
+        SELECT c."userId"
+        FROM content c
+        JOIN "Revisions" r ON r."documentId" = c."documentId" AND r."fieldName" = 'contents'
         JOIN "AutomatedContentEvaluations" ace ON ace."revisionId" = r."_id"
-        WHERE ace."pangramScore" > 0.8
+        WHERE c."rejected" IS TRUE AND ace."pangramScore" > 0.6
       )
       -- (1) a rejected item (including re-drafted posts) with a high Pangram autoreject score
       SELECT "userId" FROM highPangramRejections
@@ -446,10 +439,11 @@ class UsersRepo extends AbstractRepo<"Users"> {
       -- (2) at least two rejected comments, or (3) all current content rejected
       SELECT c."userId"
       FROM content c
+      WHERE c."isCurrent"
       GROUP BY c."userId"
       HAVING COUNT(*) FILTER (WHERE c."isComment" AND c."rejected" IS TRUE) >= 2
         OR COUNT(*) FILTER (WHERE c."rejected" IS NOT TRUE) = 0
-    `, [userIds]);
+    `, { userIds });
     return rows.map((row) => row.userId);
   }
 

--- a/packages/lesswrong/server/repos/UsersRepo.ts
+++ b/packages/lesswrong/server/repos/UsersRepo.ts
@@ -404,9 +404,14 @@ class UsersRepo extends AbstractRepo<"Users"> {
 
   /**
    * Of the requested users, return the ids of those who belong in the supermod
-   * "offboard" review group: their (non-draft post / non-deleted comment) content
-   * either (1) includes a rejected item with a high Pangram autoreject score,
-   * (2) includes at least two rejected comments, or (3) is entirely rejected.
+   * "offboard" review group, because they either:
+   *   (1) have a rejected post/comment with a high Pangram autoreject score, or
+   *   (2) have at least two rejected comments, or
+   *   (3) have all of their current content rejected.
+   * Criteria (2) and (3) consider "current" content (non-draft posts / non-deleted
+   * comments). Criterion (1) also counts posts that have since been re-drafted: a
+   * high-scoring autoreject still counts even if the user pulled the post back to
+   * drafts.
    */
   async getOffboardCandidateUserIds(userIds: string[]): Promise<string[]> {
     const rows = await this.getRawDb().any<{ userId: string }>(`
@@ -419,18 +424,31 @@ class UsersRepo extends AbstractRepo<"Users"> {
         SELECT c."_id", c."userId", c."rejected", TRUE
         FROM "Comments" c
         WHERE c."userId" = ANY($1::text[]) AND c."deleted" IS NOT TRUE
+      ),
+      highPangramRejections AS (
+        SELECT x."userId"
+        FROM (
+          SELECT p."_id" AS "documentId", p."userId"
+          FROM "Posts" p
+          WHERE p."userId" = ANY($1::text[]) AND p."rejected" IS TRUE AND p."deletedDraft" IS NOT TRUE
+          UNION ALL
+          SELECT c."_id", c."userId"
+          FROM "Comments" c
+          WHERE c."userId" = ANY($1::text[]) AND c."rejected" IS TRUE AND c."deleted" IS NOT TRUE
+        ) x
+        JOIN "Revisions" r ON r."documentId" = x."documentId" AND r."fieldName" = 'contents'
+        JOIN "AutomatedContentEvaluations" ace ON ace."revisionId" = r."_id"
+        WHERE ace."pangramScore" > 0.8
       )
+      -- (1) a rejected item (including re-drafted posts) with a high Pangram autoreject score
+      SELECT "userId" FROM highPangramRejections
+      UNION
+      -- (2) at least two rejected comments, or (3) all current content rejected
       SELECT c."userId"
       FROM content c
       GROUP BY c."userId"
       HAVING COUNT(*) FILTER (WHERE c."isComment" AND c."rejected" IS TRUE) >= 2
         OR COUNT(*) FILTER (WHERE c."rejected" IS NOT TRUE) = 0
-        OR EXISTS (
-          SELECT 1 FROM content c2
-          JOIN "Revisions" r ON r."documentId" = c2."documentId" AND r."fieldName" = 'contents'
-          JOIN "AutomatedContentEvaluations" ace ON ace."revisionId" = r."_id"
-          WHERE c2."userId" = c."userId" AND c2."rejected" IS TRUE AND ace."pangramScore" > 0.8
-        )
     `, [userIds]);
     return rows.map((row) => row.userId);
   }

--- a/packages/lesswrong/themes/defaultPalette.ts
+++ b/packages/lesswrong/themes/defaultPalette.ts
@@ -389,6 +389,7 @@ export const defaultComponentPalette = (dark: boolean, isAF: boolean) => ({
     sunshineNewTags: "rgba(80,80,0,.08)",
     sunshineWarningHighlight: "rgba(255,50,0,.2)",
     sunshineNewContentGroup: "light-dark(linear-gradient(135deg, rgba(0,80,0,.20) 0%, rgba(0,80,0,0) 100%),linear-gradient(135deg, rgba(0,80,0,.50) 0%, rgba(0,80,0,0) 100%))",
+    sunshineOffboardGroup: "light-dark(linear-gradient(135deg, rgba(160,0,0,.20) 0%, rgba(160,0,0,0) 100%),linear-gradient(135deg, rgba(160,0,0,.50) 0%, rgba(160,0,0,0) 100%))",
     sunshineHighContextGroup: "light-dark(linear-gradient(135deg, rgba(120,120,0,.20) 0%, rgba(120,120,0,0) 100%),linear-gradient(135deg, rgba(120,120,0,.50) 0%, rgba(36, 36, 9, 0) 100%))",
     sunshineMaybeSpamGroup: "light-dark(linear-gradient(135deg, rgba(120,0,120,.20) 0%, rgba(120,0,120,0) 100%),linear-gradient(135deg, rgba(120,0,120,.50) 0%, rgba(120,0,120,0) 100%))",
     sunshineAutomodGroup: "light-dark(linear-gradient(135deg, rgba(120,120,0,.20) 0%, rgba(120,120,0,0) 100%),linear-gradient(135deg, rgba(120,120,0,.50) 0%, rgba(120,120,0,0) 100%))",

--- a/packages/lesswrong/themes/defaultPalette.ts
+++ b/packages/lesswrong/themes/defaultPalette.ts
@@ -389,7 +389,6 @@ export const defaultComponentPalette = (dark: boolean, isAF: boolean) => ({
     sunshineNewTags: "rgba(80,80,0,.08)",
     sunshineWarningHighlight: "rgba(255,50,0,.2)",
     sunshineNewContentGroup: "light-dark(linear-gradient(135deg, rgba(0,80,0,.20) 0%, rgba(0,80,0,0) 100%),linear-gradient(135deg, rgba(0,80,0,.50) 0%, rgba(0,80,0,0) 100%))",
-    sunshineOffboardGroup: "light-dark(linear-gradient(135deg, rgba(160,0,0,.20) 0%, rgba(160,0,0,0) 100%),linear-gradient(135deg, rgba(160,0,0,.50) 0%, rgba(160,0,0,0) 100%))",
     sunshineHighContextGroup: "light-dark(linear-gradient(135deg, rgba(120,120,0,.20) 0%, rgba(120,120,0,0) 100%),linear-gradient(135deg, rgba(120,120,0,.50) 0%, rgba(36, 36, 9, 0) 100%))",
     sunshineMaybeSpamGroup: "light-dark(linear-gradient(135deg, rgba(120,0,120,.20) 0%, rgba(120,0,120,0) 100%),linear-gradient(135deg, rgba(120,0,120,.50) 0%, rgba(120,0,120,0) 100%))",
     sunshineAutomodGroup: "light-dark(linear-gradient(135deg, rgba(120,120,0,.20) 0%, rgba(120,120,0,0) 100%),linear-gradient(135deg, rgba(120,120,0,.50) 0%, rgba(120,120,0,0) 100%))",

--- a/packages/lesswrong/unitTests/moderationInboxReducer.tests.ts
+++ b/packages/lesswrong/unitTests/moderationInboxReducer.tests.ts
@@ -10,6 +10,9 @@ import {
 
 const moderatorActionTypes: Record<ReviewGroup, ModeratorActionType> = {
   newContent: UNREVIEWED_FIRST_POST,
+  // `offboard` is derived from content (not a moderator action); this mapping is
+  // only used to attach a plausible action to mock users in these reducer tests.
+  offboard: UNREVIEWED_FIRST_POST,
   highContext: MANUAL_FLAG_ALERT,
   maybeSpam: UNREVIEWED_BIO_UPDATE,
   automod: STRICTER_COMMENT_AUTOMOD_RATE_LIMIT,


### PR DESCRIPTION
## Summary

Adds an **Offboard?** tab to the users section of `/supermod`. It surfaces users who would otherwise land in **New Content** but whose content suggests they should be offboarded, so **New Content** only contains users who do *not* match the criteria.

A `newContent` user is moved to the new `offboard` review group if any of:
1. they have a rejected post/comment with a Pangram autoreject score > 0.8
2. they have at least two rejected comments
3. all of their current (non-draft post / non-deleted comment) content is already rejected

## Implementation

- New `offboard` value in the `ReviewGroup` GraphQL enum, with priority placing the tab just after `New Content`.
- The grouping is computed server-side in the existing `User.reviewGroup` resolver: when the base group is `newContent`, it checks a batched `UsersRepo.getOffboardCandidateUserIds` query (all three criteria live in that one SQL query) and returns `offboard` if matched.
- Client tab wiring: display name, tab order, content preview for the new group (treated like `newContent`), and a subtle warning-tinted background in the `All` view (reusing the existing `sunshineWarningHighlight` color).

### Notes / interpretation
- "Autorejected with pangram score > .8" is implemented as a *rejected* post/comment whose latest `AutomatedContentEvaluation.pangramScore` exceeds 0.8 (the supermod UI already labels rejected items with pangram ≥ 0.5 as "Autorejected").
- "Current posts/comments" = non-draft posts and non-deleted comments.

## Test plan
- [x] `yarn tsc`
- [x] `yarn unit packages/lesswrong/unitTests/moderationInboxReducer.tests.ts`
- [x] Ran the offboard SQL against the dev DB (valid; returns expected candidate user ids)
- [ ] Manually verify the `Offboard?` tab appears and filters correctly in `/supermod`

Made with [Cursor](https://cursor.com)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1215530197222707) by [Unito](https://www.unito.io)
