### PR TITLE
Research: long-lived streaming supervisor, Fable 5, pinned Claude Code

### DIFF
--- a/app/api/research/agent/conversations/[conversationId]/events/route.ts
+++ b/app/api/research/agent/conversations/[conversationId]/events/route.ts
@@ -2,7 +2,6 @@ import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
 import { captureException } from "@/lib/sentryWrapper";
 import { getContextFromReqAndRes } from "@/server/vulcan-lib/apollo-server/context";
-import { backgroundTask } from "@/server/utils/backgroundTask";
 import {
   authorizeAgentRequest,
   authorizeAgentResearchConversationAccess,
@@ -132,7 +131,7 @@ export async function POST(
       );
     }
 
-    const { rawJsonl, kind, claudeMessageUuid, claudeSessionId } = parseResult.data;
+    const { rawJsonl, kind, claudeMessageUuid } = parseResult.data;
 
     // Parse the verbatim line into a JSON object for the JSONB column.
     // A parse failure means the supervisor sent a malformed line — return
@@ -164,16 +163,6 @@ export async function POST(
         { _id: conversationId },
         { $set: { lastActivityAt: new Date() } },
       );
-    }
-
-    // First-write-wins capture for `--resume`'s session id; the supervisor
-    // sends the same id on every event POST, so the IS NULL filter ensures
-    // only the first one writes.
-    if (claudeSessionId) {
-      backgroundTask(context.ResearchConversations.rawUpdateOne(
-        { _id: conversationId, claudeSessionId: null },
-        { $set: { claudeSessionId } },
-      ));
     }
 
     captureResearchAgentApiEvent({

--- a/app/api/research/agent/conversations/[conversationId]/transcript/route.ts
+++ b/app/api/research/agent/conversations/[conversationId]/transcript/route.ts
@@ -11,6 +11,7 @@ import {
 } from "../../../captureResearchAgentAnalytics";
 import {
   getAgentTranscriptTurns,
+  isTurnInFlight,
   type TranscriptOptions,
 } from "@/components/research/conversationEventFormat";
 
@@ -65,14 +66,7 @@ export async function GET(
     ).fetch();
 
     const turns = getAgentTranscriptTurns(events, options);
-
-    let userCount = 0;
-    let resultCount = 0;
-    for (const e of events) {
-      if (e.kind === "user") userCount++;
-      else if (e.kind === "result") resultCount++;
-    }
-    const incompleteTurn = userCount > resultCount;
+    const incompleteTurn = isTurnInFlight(events, Date.now());
 
     captureResearchAgentApiEvent({
       route: ROUTE,

--- a/app/api/research/agent/researchAgentAuth.ts
+++ b/app/api/research/agent/researchAgentAuth.ts
@@ -34,6 +34,9 @@ export interface SandboxCallbackTokenPayload {
   exp: number;
 }
 
+// Must stay longer than the sandbox session lifetime cap (5h on Vercel): the
+// agent-scoped token is handed to the long-lived claude process as spawn-time
+// env, so it has to outlive any process that could receive it.
 const SANDBOX_CALLBACK_TOKEN_MAX_TTL_SECONDS = 6 * 60 * 60;
 const SUPERVISOR_TOKEN_MAX_TTL_SECONDS = 6 * 60 * 60;
 

--- a/packages/lesswrong/components/research/conversationEventFormat.ts
+++ b/packages/lesswrong/components/research/conversationEventFormat.ts
@@ -1,10 +1,16 @@
 import { getMarkdownItNoMathjax } from "@/lib/utils/markdownItPlugins";
 import { sanitize } from "@/lib/utils/sanitize";
 import { stripLeadingSystemReminder } from "@/lib/research/systemReminderFormat";
+import {
+  isTurnActivity,
+  FLUSH_RESULT_SUBTYPE,
+  TURN_OPENING_SYSTEM_SUBTYPE,
+} from "@/lib/research/turnActivity";
 
 interface ResearchConversationEventLike {
   kind: string;
   payload: unknown;
+  createdAt?: string | Date;
 }
 
 /**
@@ -37,18 +43,77 @@ export function isVisibleConversationEvent(event: { kind: string }): boolean {
 }
 
 /**
- * Whether the transcript has an unanswered turn. Claude Code emits exactly one
- * `result` per turn, so `userCount > resultCount` means a turn is still
- * running (or queued waiting for its sandbox to start).
+ * A user message dispatched while another turn runs is persisted immediately
+ * but queued by Claude Code, so it can sit *before* the running turn's
+ * `result` in seq order — masked from the since-last-result scan below. Such
+ * a message counts as in flight while recent. The time bound exists because
+ * older transcripts (from the per-turn supervisor era) don't reliably contain
+ * a `system:init` after every user event, and an unbounded "user turn never
+ * started" clause would wedge them as permanently in flight; the real
+ * queued-turn gap is seconds, so fifteen minutes is generous.
  */
-export function isTurnInFlight(events: readonly { kind: string }[]): boolean {
-  let userCount = 0;
-  let resultCount = 0;
-  for (const event of events) {
-    if (event.kind === 'user') userCount++;
-    else if (event.kind === 'result') resultCount++;
+const RECENT_UNSTARTED_USER_TURN_MS = 15 * 60 * 1000;
+
+/**
+ * Whether the transcript currently has a running (or queued) turn. Claude
+ * Code emits exactly one `result` per turn, but turns aren't always
+ * user-initiated — a finishing background task re-invokes the agent with no
+ * user event, and a crashed process gets its turn closed by a synthetic
+ * supervisor result — so counting user events against results drifts apart
+ * over a conversation's lifetime. Instead:
+ *
+ *  1. any turn content since the most recent `result` (shared definition in
+ *     `@/lib/research/turnActivity`, mirrored by the supervisor's busy state
+ *     and the repo's `hasIncompleteTurn`) means a turn is in flight;
+ *  2. a recent user message that no turn-opening `system:init` or synthetic
+ *     flush result has answered yet means a turn is queued (see above).
+ *
+ * Clause 2 needs the current time, which the caller must supply — calling
+ * `Date.now()` here would run during React render (this is computed in
+ * useMemo) and trip Next's prerender purity check. With `nowMs` omitted the
+ * queued-turn clause is skipped, which only under-reports during the brief
+ * gap before a queued turn opens.
+ */
+export function isTurnInFlight(
+  events: readonly ResearchConversationEventLike[],
+  nowMs?: number,
+): boolean {
+  let lastResultIdx = -1;
+  let lastActivityIdx = -1;
+  let lastUserIdx = -1;
+  let lastTurnStartOrFlushIdx = -1;
+  let lastUserEvent: ResearchConversationEventLike | null = null;
+
+  for (let i = 0; i < events.length; i++) {
+    const event = events[i];
+    const subtype = isPlainRecord(event.payload) && typeof event.payload.subtype === 'string'
+      ? event.payload.subtype
+      : undefined;
+    if (event.kind === 'result') {
+      lastResultIdx = i;
+      if (subtype === FLUSH_RESULT_SUBTYPE) lastTurnStartOrFlushIdx = i;
+      continue;
+    }
+    if (isTurnActivity(event.kind, subtype)) lastActivityIdx = i;
+    if (event.kind === 'user') {
+      lastUserIdx = i;
+      lastUserEvent = event;
+    }
+    if (event.kind === 'system' && subtype === TURN_OPENING_SYSTEM_SUBTYPE) {
+      lastTurnStartOrFlushIdx = i;
+    }
   }
-  return userCount > resultCount;
+
+  if (lastActivityIdx > lastResultIdx) return true;
+
+  if (nowMs !== undefined && lastUserIdx >= 0 && lastUserIdx > lastTurnStartOrFlushIdx && lastUserEvent?.createdAt) {
+    const createdMs = new Date(lastUserEvent.createdAt).valueOf();
+    if (!Number.isNaN(createdMs) && nowMs - createdMs < RECENT_UNSTARTED_USER_TURN_MS) {
+      return true;
+    }
+  }
+
+  return false;
 }
 
 /**

--- a/packages/lesswrong/components/research/hooks/useConversationStream.ts
+++ b/packages/lesswrong/components/research/hooks/useConversationStream.ts
@@ -30,16 +30,20 @@ interface UseConversationStreamResult {
   events: ConversationEvent[];
   status: StreamStatus;
   error: string | null;
+  // Derived once here (with a render-safe clock) so every consumer agrees;
+  // see isTurnInFlight for the derivation.
+  turnInFlight: boolean;
   latestSeq: number;
   refresh: () => void;
   // Optimistic local-only insert (seq < 0); dropped once its persisted twin lands.
   injectOptimisticEvent: (event: ConversationEvent) => void;
   clearOptimistic: () => void;
   // Signal that a turn was just dispatched for this conversation, so the live
-  // stream opens immediately — before the first event is persisted. With the
-  // single-writer design the user turn isn't persisted until Claude echoes it,
-  // so `isTurnInFlight(events)` is briefly false on the first turn; without this
-  // the stream would close into slow polling and the turn would look idle.
+  // stream opens immediately — before the first event is persisted. The
+  // supervisor records the user turn at dispatch, but it reaches the backend
+  // (and then this client) asynchronously, so `isTurnInFlight(events)` is
+  // briefly false; without this the stream would close into slow polling and
+  // the turn would look idle.
   markTurnExpected: () => void;
 }
 
@@ -107,7 +111,22 @@ export function useConversationStream(
     () => [...persisted, ...optimistic.filter((e) => e.conversationId === conversationId)],
     [persisted, optimistic, conversationId],
   );
-  const turnInFlight = useMemo(() => isTurnInFlight(events), [events]);
+
+  // Clock for isTurnInFlight's queued-turn recency check. Render must stay
+  // pure (Next prerender forbids Date.now() in components), so the time lives
+  // in state and ticks in an effect — null until hydration, which just means
+  // the queued-turn clause kicks in a moment later on the client.
+  const [nowMs, setNowMs] = useState<number | null>(null);
+  useEffect(() => {
+    setNowMs(Date.now());
+    const tick = setInterval(() => setNowMs(Date.now()), 60_000);
+    return () => clearInterval(tick);
+  }, []);
+
+  const turnInFlight = useMemo(
+    () => isTurnInFlight(events, nowMs ?? undefined),
+    [events, nowMs],
+  );
   const streamShouldBeOpen = turnInFlight || expectingTurn;
 
   const latestSeq = useMemo(() => {
@@ -209,6 +228,7 @@ export function useConversationStream(
     events,
     status,
     error: queryError ? queryError.message : null,
+    turnInFlight,
     latestSeq,
     refresh,
     injectOptimisticEvent,

--- a/packages/lesswrong/components/research/lexical/AgentBlockComponent.tsx
+++ b/packages/lesswrong/components/research/lexical/AgentBlockComponent.tsx
@@ -10,7 +10,6 @@ import { $isAgentBlockNode } from './AgentBlockNode';
 import { useResearchEditorEnvironment, useResearchNavigationContext, usePendingConversation } from './ResearchEditorContext';
 import {
   getConversationEventChunks,
-  isTurnInFlight,
   isVisibleConversationEvent,
 } from '../conversationEventFormat';
 import { ConversationEventRow } from '../ConversationEventRow';
@@ -338,39 +337,61 @@ interface ActiveAgentBlockProps {
 
 function ActiveAgentBlock({ conversationId, fromAgent, justDispatched, onOpenInChat, onRemove: _onRemove }: ActiveAgentBlockProps) {
   const classes = useStyles(styles);
-  const { events, status, error, markTurnExpected } = useConversationStream(conversationId);
+  const { events, status, error, turnInFlight, markTurnExpected } = useConversationStream(conversationId);
 
   useEffect(() => {
     if (justDispatched) markTurnExpected();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  const { resultCount, turnInFlight, visibleEvents, latestVisible } = useMemo(() => {
+  const { resultCount, userEventCount, visibleEvents, latestVisible } = useMemo(() => {
     let rc = 0;
+    let uc = 0;
     const visible: ConversationEvent[] = [];
     for (const e of events) {
       if (e.kind === 'result') rc++;
+      if (e.kind === 'user') uc++;
       if (isVisibleConversationEvent(e)) visible.push(e);
     }
     return {
       resultCount: rc,
-      turnInFlight: isTurnInFlight(events),
+      userEventCount: uc,
       visibleEvents: visible,
       latestVisible: visible.length > 0 ? visible[visible.length - 1] : null,
     };
   }, [events]);
 
-  // Auto-expand on the falling edge of `turnInFlight` only, so loading a
-  // document with previously-completed blocks (no rising edge) leaves them
-  // collapsed; a turn the user actually watches complete expands.
+  // Auto-expand on the falling edge of `turnInFlight`, but only when a user
+  // message arrived since the baseline: loading a document with
+  // previously-completed blocks (no rising edge) leaves them collapsed, and
+  // turns that start with no user action — background-task re-invocations,
+  // synthetic supervisor results closing a crashed turn — don't pop a
+  // collapsed block open while the user is passively reading.
   const [expanded, setExpanded] = useState(false);
   const wasInFlightRef = useRef(false);
+  // Baseline of the user-event count: established from the first non-empty
+  // transcript observation — even one that's already mid-turn, so a block
+  // mounted while a re-invocation runs doesn't count the whole history as
+  // "new" at the falling edge — then kept current while idle. The message
+  // that created a just-dispatched block is excluded from its own baseline,
+  // so the turn the user just fired still expands on completion. `null`
+  // means "history not loaded yet"; no expand decisions until it is.
+  const userCountBaselineRef = useRef<number | null>(null);
   useEffect(() => {
+    if (userCountBaselineRef.current === null) {
+      if (events.length === 0) return;
+      userCountBaselineRef.current = Math.max(0, userEventCount - (justDispatched ? 1 : 0));
+    }
     if (wasInFlightRef.current && !turnInFlight) {
-      setExpanded(true);
+      if (userEventCount > userCountBaselineRef.current) {
+        setExpanded(true);
+      }
+    }
+    if (!turnInFlight) {
+      userCountBaselineRef.current = userEventCount;
     }
     wasInFlightRef.current = turnInFlight;
-  }, [turnInFlight]);
+  }, [turnInFlight, userEventCount, events.length, justDispatched]);
 
   const handleOpenInChat = useCallback(
     (e: React.MouseEvent<HTMLButtonElement>) => {

--- a/packages/lesswrong/lib/research/turnActivity.ts
+++ b/packages/lesswrong/lib/research/turnActivity.ts
@@ -1,0 +1,42 @@
+/**
+ * Shared definition of which research-conversation events mean "a turn is in
+ * progress". Three derivations must agree on this and have already diverged
+ * once (on the `error` kind), so they all draw from here:
+ *
+ *  - the supervisor's in-memory busy state (`conversationHub`)
+ *  - the client/transcript `isTurnInFlight` (`conversationEventFormat`)
+ *  - the dangling-turn SQL check (`ResearchConversationEventsRepo.hasIncompleteTurn`)
+ *
+ * This module must stay dependency-free: the supervisor bundle imports it by
+ * relative path (no `@/` alias in its esbuild config), and it's also imported
+ * from client code.
+ *
+ * `error` is deliberately NOT activity: an in-turn error is always preceded by
+ * the turn's `system:init` (and usually a user event), so counting it adds
+ * nothing — while an error line arriving *outside* a turn would otherwise wedge
+ * the conversation as busy forever, since no `result` follows it.
+ */
+export const TURN_ACTIVITY_EVENT_KINDS = [
+  "user",
+  "assistant",
+  "thinking",
+  "tool_use",
+  "tool_result",
+] as const;
+
+/** Every turn — dispatched, queued, or background-task re-invocation — opens
+ * with a `system` line of this subtype. */
+export const TURN_OPENING_SYSTEM_SUBTYPE = "init";
+
+/**
+ * Supervisor-synthesized `result` lines carry this subtype. Unlike a normal
+ * per-turn result, they mean "everything outstanding was closed" (crash,
+ * cancel flush, sandbox restart), so in-flight derivations treat them as
+ * answering any user turn that never got to start.
+ */
+export const FLUSH_RESULT_SUBTYPE = "interrupted";
+
+export function isTurnActivity(kind: string, systemSubtype: string | null | undefined): boolean {
+  if (kind === "system") return systemSubtype === TURN_OPENING_SYSTEM_SUBTYPE;
+  return (TURN_ACTIVITY_EVENT_KINDS as readonly string[]).includes(kind);
+}

--- a/packages/lesswrong/server/repos/ResearchConversationEventsRepo.ts
+++ b/packages/lesswrong/server/repos/ResearchConversationEventsRepo.ts
@@ -3,6 +3,10 @@ import { recordPerfMetrics } from "./perfMetricWrapper";
 import ResearchConversationEvents from "../collections/researchConversationEvents/collection";
 import { randomId } from "@/lib/random";
 import { isPostgresUniqueViolation } from "@/server/utils/postgresErrors";
+import {
+  TURN_ACTIVITY_EVENT_KINDS,
+  TURN_OPENING_SYSTEM_SUBTYPE,
+} from "@/lib/research/turnActivity";
 
 export interface IncomingResearchConversationEvent {
   claudeMessageUuid: string;
@@ -161,16 +165,35 @@ class ResearchConversationEventsRepo extends AbstractRepo<"ResearchConversationE
     });
   }
 
+  /**
+   * Whether the conversation's most recent turn is missing its terminal
+   * `result`. Counting user events against results would drift: background
+   * task re-invocations produce results with no user event, and synthetic
+   * supervisor results close crashed turns. Instead, look at the latest
+   * turn-relevant event — turn content (the shared kind list from
+   * `@/lib/research/turnActivity`, or the `system:init` that opens every
+   * turn) with no `result` after it means the turn is dangling. Mirrors
+   * `isTurnInFlight` on the client and the supervisor's busy state.
+   */
   public async hasIncompleteTurn(conversationId: string): Promise<boolean> {
-    const row = await this.getRawDb().one<{ userCount: string; resultCount: string }>(`
+    const row = await this.getRawDb().oneOrNone<{ kind: string }>(`
       -- ResearchConversationEventsRepo.hasIncompleteTurn
-      SELECT
-        COUNT(*) FILTER (WHERE "kind" = 'user') AS "userCount",
-        COUNT(*) FILTER (WHERE "kind" = 'result') AS "resultCount"
+      SELECT "kind"
       FROM "ResearchConversationEvents"
       WHERE "conversationId" = $(conversationId)
-    `, { conversationId });
-    return Number(row.userCount) > Number(row.resultCount);
+        AND (
+          "kind" IN ($(turnActivityKinds:csv))
+          OR "kind" = 'result'
+          OR ("kind" = 'system' AND "payload"->>'subtype' = $(turnOpeningSubtype))
+        )
+      ORDER BY "seq" DESC
+      LIMIT 1
+    `, {
+      conversationId,
+      turnActivityKinds: [...TURN_ACTIVITY_EVENT_KINDS],
+      turnOpeningSubtype: TURN_OPENING_SYSTEM_SUBTYPE,
+    });
+    return row !== null && row.kind !== "result";
   }
 
   /**

--- a/packages/lesswrong/server/research/sandbox/sandboxLayout.ts
+++ b/packages/lesswrong/server/research/sandbox/sandboxLayout.ts
@@ -21,3 +21,21 @@ export const RESEARCH_TOOL_PATH = `${PLATFORM_DIR}/bin/research-tool`;
 export const QUEUE_DIR = `${PLATFORM_DIR}/queue`;
 export const CLAUDE_DIR = `${SANDBOX_HOME_DIR}/.claude`;
 export const CLAUDE_MD_PATH = `${CLAUDE_DIR}/CLAUDE.md`;
+
+/**
+ * The Claude Code version every sandbox runs. Pinned because the supervisor
+ * speaks the CLI's stream-json + control protocol (undocumented; this is the
+ * compatibility surface flagged in claudeRunner.ts) and because the agent
+ * model below may require a minimum CLI version. Enforcement is two-sided:
+ * `buildResearchSandboxSnapshot` installs exactly this version into fresh
+ * baselines, and `sandboxManager.reconcileClaudeCodeVersion` upgrades any
+ * older sandbox/environment snapshot at launch, before the supervisor starts —
+ * snapshots otherwise carry their build-time CLI forever. To upgrade: bump
+ * this, rebuild the baseline snapshots, and existing sandboxes reconcile on
+ * their next launch.
+ */
+export const PINNED_CLAUDE_CODE_VERSION = "2.1.170";
+
+/** The model the research agent runs (`claude --model ...`). Requires a CLI
+ * version that knows the model family — see PINNED_CLAUDE_CODE_VERSION. */
+export const RESEARCH_AGENT_MODEL = "claude-fable-5";

--- a/packages/lesswrong/server/research/sandbox/sandboxManager.ts
+++ b/packages/lesswrong/server/research/sandbox/sandboxManager.ts
@@ -35,6 +35,7 @@ import { getPlatformAssets } from "./platformAssets";
 import {
   AGENT_CWD,
   CLAUDE_MD_PATH,
+  PINNED_CLAUDE_CODE_VERSION,
   PLATFORM_DIR,
   QUEUE_DIR,
   RESEARCH_TOOL_PATH,
@@ -114,7 +115,6 @@ export interface ProvisionedSandbox {
    * to decide whether to ship a reconstructed Claude session.
    */
   wasFreshlyCreated: boolean;
-  isFirstProvision: boolean;
 }
 
 interface SupervisorLaunchEnv {
@@ -148,9 +148,9 @@ function isSnapshotNotFoundError(err: unknown): boolean {
  * Overlay the current platform files into the sandbox. Run on every fresh
  * provision and every resume, *before* launching the supervisor — so a snapshot
  * taken with old platform code runs today's code. Only writes new files; it
- * never removes old ones. The `{{RESEARCH_PROJECT_ID}}` placeholder in
- * `CLAUDE.md` is left intact here and filled by the supervisor at boot (after
- * this overlay, before any `claude` subprocess).
+ * never removes old ones. `CLAUDE.md` is static; per-conversation context
+ * (project/conversation ids) reaches the agent via `--append-system-prompt`
+ * at claude-process spawn instead.
  *
  * The durable event queue under `~/.research/queue/` is **not** overlaid — it is
  * durable state, not code.
@@ -162,6 +162,58 @@ async function overlayPlatformFiles(sandbox: Sandbox): Promise<void> {
     { path: RESEARCH_TOOL_PATH, content: assets.researchTool, mode: 0o755 },
     { path: CLAUDE_MD_PATH, content: assets.claudeMd },
   ]);
+}
+
+/**
+ * Bring the sandbox's Claude Code install to the pinned version. Run on every
+ * launch (provision and resume), after the platform-file overlay and before
+ * the supervisor starts, so the supervisor's claude subprocess can never run
+ * a version older than the model/protocol it expects. Snapshots freeze the
+ * CLI at their build time and have no other upgrade affordance — without this,
+ * every pre-existing conversation sandbox and saved environment would be
+ * stuck on whatever version its baseline was built with.
+ *
+ * Fast path (version already matches) is one `claude --version` (~1s) with no
+ * network dependency. The upgrade path npm-installs the pinned version (tens
+ * of seconds, once per stale sandbox) and re-verifies the version afterward,
+ * so an install that "succeeds" without changing what's first on PATH fails
+ * loudly instead of silently launching the stale CLI. The non-sudo attempt
+ * covers the node* images (user-writable npm prefix); the sudo retry covers
+ * dnf-installed Node (system prefix) on python images.
+ *
+ * On failure the sandbox is stopped before the error propagates: the launch
+ * hooks only run on create/resume, so leaving a freshly-resumed sandbox
+ * running without a supervisor would wedge every retry in the
+ * supervisor-not-ready path until the session times out. Stopped, the next
+ * attempt resumes and re-runs the whole launch sequence.
+ */
+async function reconcileClaudeCodeVersion(sandbox: Sandbox): Promise<void> {
+  const script =
+    `current="$(claude --version 2>/dev/null | cut -d' ' -f1)"; ` +
+    `if [ "$current" = "${PINNED_CLAUDE_CODE_VERSION}" ]; then exit 0; fi; ` +
+    `echo "upgrading claude-code $current -> ${PINNED_CLAUDE_CODE_VERSION}"; ` +
+    `npm install -g @anthropic-ai/claude-code@${PINNED_CLAUDE_CODE_VERSION} && ` +
+    `installed="$(claude --version 2>/dev/null | cut -d' ' -f1)"; ` +
+    `[ "$installed" = "${PINNED_CLAUDE_CODE_VERSION}" ] || { echo "still on $installed after install" >&2; exit 1; }`;
+  let result = await sandbox.runCommand({ cmd: "sh", args: ["-c", script] });
+  if (result.exitCode !== 0) {
+    result = await sandbox.runCommand({ cmd: "sh", args: ["-c", script], sudo: true });
+  }
+  if (result.exitCode !== 0) {
+    const stderr = await result.stderr();
+    await sandbox.stop().catch((stopErr: unknown) => {
+      // eslint-disable-next-line no-console
+      console.warn(`[sandbox] stop after failed reconcile failed: ${(stopErr as Error).message}`);
+    });
+    throw new Error(
+      `claude-code version reconcile failed (exit ${result.exitCode}): ${stderr.slice(0, 500)}`,
+    );
+  }
+  const stdout = await result.stdout();
+  if (stdout.includes("upgrading claude-code")) {
+    // eslint-disable-next-line no-console
+    console.log(`[sandbox] ${sandbox.name}: ${stdout.split("\n")[0]}`);
+  }
 }
 
 /**
@@ -335,7 +387,6 @@ export async function getOrCreateSandbox(
         supervisorSecret: existingRow.supervisorSecret,
         devProxySecret: existingRow.devProxySecret,
         wasFreshlyCreated: false,
-        isFirstProvision: false,
       };
     }
   }
@@ -402,22 +453,16 @@ export async function getOrCreateSandbox(
 
   const onResume = async (sandbox: Sandbox) => {
     await overlayPlatformFiles(sandbox);
+    await reconcileClaudeCodeVersion(sandbox);
     await launchSupervisor(sandbox, launchEnv);
   };
   const onCreate = async (sandbox: Sandbox) => {
     wasFreshlyCreated = true;
     await overlayPlatformFiles(sandbox);
+    await reconcileClaudeCodeVersion(sandbox);
     await launchSupervisor(sandbox, launchEnv);
   };
 
-  // `getOrCreate` covers all three branches: resume an existing sandbox,
-  // create a fresh one when none exists, and rebuild (delete + create) when
-  // the existing sandbox's snapshot has expired. `source` is consumed only on
-  // the create path — `Sandbox.get` ignores it — so a warm resume can't
-  // clobber the snapshot we're trying to recover from. `resume: true` is
-  // passed explicitly because the SDK omits the `resume` query param entirely
-  // when it's left undefined, and the backend in that case hands back a
-  // stopped-session handle rather than starting a new session.
   let sandbox: Sandbox;
   try {
     // `getOrCreate` covers all three branches: resume an existing sandbox,
@@ -473,7 +518,6 @@ export async function getOrCreateSandbox(
     supervisorSecret,
     devProxySecret,
     wasFreshlyCreated,
-    isFirstProvision: !existingRow,
   };
 }
 

--- a/packages/lesswrong/server/research/sandbox/saveEnvironment.ts
+++ b/packages/lesswrong/server/research/sandbox/saveEnvironment.ts
@@ -54,7 +54,10 @@ async function quiesce(supervisorUrl: string, bearer: string): Promise<void> {
     const status = await fetchSupervisorStatus(supervisorUrl, bearer);
     if (status) {
       if (status.turnRunning) {
-        throw new Error("Can't save an environment while a turn is running. Wait for it to finish.");
+        // `turnRunning` also covers pending background tasks: snapshotting
+        // stops the sandbox, which would kill the task and the agent's
+        // promised continuation.
+        throw new Error("Can't save an environment while a turn or background task is running. Wait for it to finish.");
       }
       if (status.pendingEvents === 0) return;
     }

--- a/packages/lesswrong/server/research/sandbox/supervisor/agentInstructions.md
+++ b/packages/lesswrong/server/research/sandbox/supervisor/agentInstructions.md
@@ -7,21 +7,9 @@ WebSearch, Task, etc.) plus a custom `research-tool` CLI that talks to the
 LessWrong research backend with the user's auth already loaded.
 
 > This file is shipped into the sandbox as `CLAUDE.md` so Claude Code
-> auto-loads it. Do not look for a different system prompt.
-
-## Current session
-
-You are working in research project **`{{RESEARCH_PROJECT_ID}}`**. All
-`research-tool` calls are scoped to this project automatically (the
-bearer token pins it server-side, so cross-project requests are
-rejected). You can't pivot to a different project from this sandbox.
-
-Your current conversation id is **`{{RESEARCH_CONVERSATION_ID}}`**. If
-fetched document markdown, a `fetch-conversation` result, an
-`@[conv:...]` mention, or an `%%% agent-block conversationId="..." %%%`
-placeholder refers to this same id, treat it as this conversation,
-including text you may have written earlier in the same task. Do not
-mistake it for an independent prior/sibling conversation.
+> auto-loads it. Do not look for a different system prompt. Your current
+> project and conversation ids arrive as appended system-prompt context
+> (see `buildAppendSystemPrompt` in the supervisor), not in this file.
 
 ## research-tool
 
@@ -444,12 +432,16 @@ A few rules:
   turn's env. Anything your app needs at boot, the scripts must establish
   themselves (e.g. load a `.env` you wrote during setup).
 - **Don't run the dev server (or any long-lived service) yourself inside a turn**
-  — not with `&`, `nohup`, or a background task. Processes you start in a turn are
-  tied to that turn and won't reliably outlive it. Let the platform run it via
+  — not with `&`, `nohup`, or a background task. Let the platform run it via
   `dev-server.sh` and use the controls below.
-- **Treat in-turn background tasks as turn-scoped** — fine for "kick off a build
-  while I work and check it before the turn ends," not for anything that must
-  survive to a later turn.
+- **Background tasks survive across turns.** A Bash task started with
+  `run_in_background` keeps running after your turn ends; when it finishes
+  you're re-invoked automatically with its output, with full memory of any
+  turns the user ran with you in the meantime. Use this freely for long
+  scrapes/builds: kick it off, tell the user you'll continue when it's done,
+  and keep working with them while it runs. A pending task also keeps the
+  sandbox awake — but sandbox sessions have a hard cap of a few hours, so
+  design jobs that could run longer than that to checkpoint and be resumable.
 
 Controlling the dev server:
 

--- a/packages/lesswrong/server/research/sandbox/supervisor/claudeRunner.ts
+++ b/packages/lesswrong/server/research/sandbox/supervisor/claudeRunner.ts
@@ -1,11 +1,30 @@
 /**
  * Claude Code subprocess runner.
  *
- * Spawns `claude -p --input-format stream-json --output-format stream-json
- * [--resume <sessionId>]`, feeds the user turn in via stdin as a stream-json
- * message, pipes stdout through the JSONL chunker, and emits each
- * `ParsedJsonlLine` to a caller-supplied sink. Manages cancellation, exit-code
- * propagation, and cleanup of per-conversation runner state.
+ * Spawns one long-lived `claude -p --input-format stream-json --output-format
+ * stream-json` process per conversation and keeps its stdin open for the life
+ * of the conversation (until the sandbox stops, the process crashes, or it is
+ * deliberately killed). User turns are fed in over time as stream-json user
+ * messages; Claude Code queues a message that arrives mid-turn and runs it as
+ * its own turn after the current one completes.
+ *
+ * This single-process model is what makes background Bash tasks safe: when a
+ * harness-tracked background task finishes, Claude Code re-invokes the agent
+ * loop *inside this same process*, so the continuation shares one context with
+ * any user turns dispatched while the task was pending. (The previous
+ * process-per-turn design spawned a concurrent `--resume` of the same session
+ * while the old process was still alive waiting on its background task; the
+ * woken process then continued from a stale context and forked the session
+ * file's parentUuid chain, permanently orphaning the interleaved turns.)
+ * Corollary: at most one live process may ever hold a given Claude session.
+ * The hub enforces that invariant; nothing in this module may spawn without it.
+ *
+ * Cancellation uses the stream-json control protocol (`control_request` /
+ * `interrupt`) rather than signals: the CLI aborts the in-flight turn, records
+ * a "[Request interrupted by user]" user turn, and emits a normal `result`
+ * line, leaving the session file consistent and the process alive for the
+ * next turn. SIGTERM/SIGKILL remain as an escalation path only; after a kill
+ * the next dispatch respawns with `--resume`.
  *
  * Note: we deliberately do NOT pass `--replay-user-messages`. That flag only
  * re-emits the user turn bundled with the model's first output (gated behind
@@ -13,12 +32,9 @@
  * instead (see `conversationHub.dispatch`) — earlier and independent of the
  * model's response latency.
  *
- * Design constraints:
- * - Multiple conversations may be running concurrently in the same supervisor
- *   process; each gets its own `claudeSessionId` and its own subprocess. The
- *   supervisor enforces the per-sandbox concurrency cap before calling here.
- * - We do not parse the JSONL into our own shapes; emission is verbatim. The
- *   parsed object is provided for routing/dedup convenience only.
+ * The control protocol is undocumented but is the same wire protocol the
+ * official Agent SDK speaks to this binary; the sandbox image pins the CLI
+ * version, so treat CLI upgrades as a compatibility surface.
  */
 import { ChildProcessByStdio, spawn } from "node:child_process";
 import type { Readable, Writable } from "node:stream";
@@ -26,12 +42,20 @@ import {
   createJsonlChunker,
   ParsedJsonlLine,
 } from "./jsonlParser";
+import { RESEARCH_AGENT_MODEL } from "../sandboxLayout";
 
-export interface ClaudeRunnerOptions {
+export interface ClaudeProcessOptions {
   conversationId: string;
-  prompt: string;
-  /** If provided, runs `claude -p ... --resume <claudeSessionId>`. */
-  claudeSessionId?: string;
+  /**
+   * The Claude session this process owns. With `sessionMode: "new"` the
+   * process is started with `--session-id` (fresh session under this exact
+   * id); with `"resume"` it's started with `--resume` (session JSONL must
+   * already exist on disk, possibly synthesized by the bootstrap step).
+   */
+  claudeSessionId: string;
+  sessionMode: "new" | "resume";
+  /** Appended to Claude Code's default system prompt (per-conversation context). */
+  appendSystemPrompt?: string;
   /** Path to the claude binary. Defaults to `claude` (must be on PATH). */
   claudePath?: string;
   /** Working directory of the subprocess. Defaults to `/vercel/sandbox`. */
@@ -48,17 +72,31 @@ export interface ClaudeRunnerOptions {
   onStderr?: (chunk: string) => void;
 }
 
-export interface ClaudeRunnerHandle {
+export interface ClaudeProcessHandle {
   conversationId: string;
+  claudeSessionId: string;
   /** PID once spawned; null if spawn failed. */
   pid: number | null;
-  /** Send a signal to the subprocess. Default: SIGTERM. */
-  cancel(signal?: NodeJS.Signals): void;
+  /** True until the process has exited (or failed to spawn). */
+  alive(): boolean;
+  /**
+   * Feed one user turn as a stream-json message. Returns false if the process
+   * is no longer writable (caller should respawn and retry).
+   */
+  sendUserMessage(content: string): boolean;
+  /**
+   * Send an `interrupt` control_request. The CLI acks with a
+   * `control_response` line and ends the in-flight turn with a `result`.
+   * Returns false if the process is no longer writable.
+   */
+  interrupt(requestId: string): boolean;
+  /** Escalation path; prefer `interrupt`. Default: SIGTERM. */
+  kill(signal?: NodeJS.Signals): void;
   /** Resolves when the subprocess has fully exited and onExit has been called. */
   done: Promise<void>;
 }
 
-export function startClaudeRunner(opts: ClaudeRunnerOptions): ClaudeRunnerHandle {
+export function startClaudeProcess(opts: ClaudeProcessOptions): ClaudeProcessHandle {
   const claudePath = opts.claudePath ?? "claude";
   const cwd = opts.cwd ?? "/vercel/sandbox";
   const args = buildArgs(opts);
@@ -77,14 +115,19 @@ export function startClaudeRunner(opts: ClaudeRunnerOptions): ClaudeRunnerHandle
       stdio: ["pipe", "pipe", "pipe"],
     });
   } catch (err) {
+    exited = true;
     opts.onError(err as Error);
     opts.onExit({ code: null, signal: null });
     resolveDone!();
     return {
       conversationId: opts.conversationId,
+      claudeSessionId: opts.claudeSessionId,
       pid: null,
-      cancel() {
-        /* nothing to cancel */
+      alive: () => false,
+      sendUserMessage: () => false,
+      interrupt: () => false,
+      kill() {
+        /* nothing to kill */
       },
       done,
     };
@@ -111,16 +154,6 @@ export function startClaudeRunner(opts: ClaudeRunnerOptions): ClaudeRunnerHandle
   });
 
   proc.stdin.on("error", (err) => opts.onError(err));
-  try {
-    const userMessage = JSON.stringify({
-      type: "user",
-      message: { role: "user", content: opts.prompt },
-    });
-    proc.stdin.write(`${userMessage}\n`);
-    proc.stdin.end();
-  } catch (err) {
-    opts.onError(err as Error);
-  }
 
   proc.on("close", (code, signal) => {
     if (exited) return;
@@ -134,10 +167,36 @@ export function startClaudeRunner(opts: ClaudeRunnerOptions): ClaudeRunnerHandle
     resolveDone!();
   });
 
+  function writeLine(payload: unknown): boolean {
+    if (exited || !proc.stdin.writable) return false;
+    try {
+      proc.stdin.write(`${JSON.stringify(payload)}\n`);
+      return true;
+    } catch (err) {
+      opts.onError(err as Error);
+      return false;
+    }
+  }
+
   return {
     conversationId: opts.conversationId,
+    claudeSessionId: opts.claudeSessionId,
     pid: proc.pid ?? null,
-    cancel(signal: NodeJS.Signals = "SIGTERM") {
+    alive: () => !exited,
+    sendUserMessage(content: string): boolean {
+      return writeLine({
+        type: "user",
+        message: { role: "user", content },
+      });
+    },
+    interrupt(requestId: string): boolean {
+      return writeLine({
+        type: "control_request",
+        request_id: requestId,
+        request: { subtype: "interrupt" },
+      });
+    },
+    kill(signal: NodeJS.Signals = "SIGTERM") {
       if (exited) return;
       try {
         proc.kill(signal);
@@ -149,7 +208,9 @@ export function startClaudeRunner(opts: ClaudeRunnerOptions): ClaudeRunnerHandle
   };
 }
 
-export function buildArgs(opts: Pick<ClaudeRunnerOptions, "claudeSessionId">): string[] {
+export function buildArgs(
+  opts: Pick<ClaudeProcessOptions, "claudeSessionId" | "sessionMode" | "appendSystemPrompt">,
+): string[] {
   // `auto` is Claude Code's classifier-backed auto-approval mode (v2.1.83+).
   // The classifier model auto-approves safe operations (local edits, reads,
   // research-tool invocations, etc.) and blocks risky ones (hostile deploys,
@@ -164,10 +225,15 @@ export function buildArgs(opts: Pick<ClaudeRunnerOptions, "claudeSessionId">): s
     "--output-format", "stream-json",
     "--verbose",
     "--permission-mode", "auto",
-    "--model", "claude-opus-4-8",
+    "--model", RESEARCH_AGENT_MODEL,
   ];
-  if (opts.claudeSessionId) {
+  if (opts.sessionMode === "resume") {
     args.push("--resume", opts.claudeSessionId);
+  } else {
+    args.push("--session-id", opts.claudeSessionId);
+  }
+  if (opts.appendSystemPrompt) {
+    args.push("--append-system-prompt", opts.appendSystemPrompt);
   }
   return args;
 }

--- a/packages/lesswrong/server/research/sandbox/supervisor/conversationHub.ts
+++ b/packages/lesswrong/server/research/sandbox/supervisor/conversationHub.ts
@@ -1,57 +1,182 @@
 /**
  * Per-conversation runner hub.
  *
- * Owns the live Claude Code runner for each conversation and fans every parsed
- * JSONL line to `postPersister`, which durably ships it to the backend (the
- * single source of truth for clients). Persistence happens regardless of
- * whether any client is watching.
+ * Owns the single long-lived Claude Code process for each conversation and
+ * fans every parsed JSONL line to `postPersister`, which durably ships it to
+ * the backend (the single source of truth for clients). Persistence happens
+ * regardless of whether any client is watching.
+ *
+ * Invariant: at most one live claude process per conversation (and therefore
+ * per Claude session — sandboxes are one-conversation scoped). All spawns go
+ * through `ensureProcess`, which awaits the previous process's full exit
+ * before starting a replacement. Two processes holding the same session is
+ * exactly the bug class that caused permanent history loss under the old
+ * process-per-turn design: a process kept alive by a background task would
+ * later continue from a stale context and fork the session file's parentUuid
+ * chain, orphaning every turn dispatched in the interim.
+ *
+ * Turn lifecycle: a dispatch writes one user message to the process's stdin.
+ * Claude Code queues messages that arrive mid-turn and runs each as its own
+ * turn (one `result` line per turn). Background-task completions re-invoke
+ * the agent inside the same process with *no* dispatch — such turns begin
+ * with a `system:init` line and also end with a `result`. Busy state is
+ * therefore derived from the stream itself:
+ *
+ *  - `pendingTurns` counts dispatched user messages whose turn hasn't
+ *    *started* yet. It's decremented on `system:init` (the line that opens
+ *    every turn), NOT on `result` — a result can belong to a background-task
+ *    re-invocation that had no dispatch, and consuming a queued turn's count
+ *    there would let the conversation read idle (and the sandbox get rolled)
+ *    out from under a queued message. A re-invocation's init can still
+ *    consume a queued turn's count, but that mislabels a much smaller window
+ *    (the re-invocation itself is busy via activity) and re-rights itself at
+ *    the queued turn's own init.
+ *  - `activitySinceResult` is true while turn output is streaming.
  */
-import { ClaudeEventKind, ParsedJsonlLine } from "./jsonlParser";
-import { ClaudeRunnerHandle, startClaudeRunner } from "./claudeRunner";
+import { randomUUID } from "node:crypto";
+import { ParsedJsonlLine, ClaudeEventKind } from "./jsonlParser";
+import { ClaudeProcessHandle, startClaudeProcess } from "./claudeRunner";
 import { BackendEvent, PostPersister } from "./postPersister";
 import { writeBootstrapJsonl } from "./sessionBootstrap";
 import { ConversationState } from "./server";
+import {
+  isTurnActivity,
+  FLUSH_RESULT_SUBTYPE,
+  TURN_OPENING_SYSTEM_SUBTYPE,
+} from "../../../../lib/research/turnActivity";
+
+/** How long cancel waits for the interrupt control_request to end the turn
+ * before escalating to SIGTERM (then SIGKILL). Interrupt normally lands in
+ * single-digit seconds; the margin covers a turn stuck in a slow tool call. */
+const CANCEL_INTERRUPT_GRACE_MS = 10_000;
+const CANCEL_SIGKILL_GRACE_MS = 5_000;
+
+/**
+ * `task_notification` statuses that do NOT mean the task ended. The CLI's
+ * task events are undocumented, so deletion from the outstanding set is the
+ * default (a wedged-awake sandbox is bounded by the 5h session cap and the
+ * liveness gate in `hasPendingWork`), and only an explicitly in-progress
+ * status keeps the task counted.
+ */
+const NON_TERMINAL_TASK_STATUSES = new Set(["running", "pending", "queued", "in_progress", "started"]);
 
 export interface ConversationHubConfig {
   postPersister: PostPersister;
   /** Override clock for tests. */
   now?: () => number;
+  /** Override process factory for tests. */
+  startProcess?: typeof startClaudeProcess;
 }
 
 interface ConversationEntry {
   conversationId: string;
   state: ConversationState;
-  runner: ClaudeRunnerHandle | null;
-  claudeSessionId?: string;
+  proc: ClaudeProcessHandle | null;
+  claudeSessionId: string | null;
+  /** Dispatched user messages whose turn hasn't opened (no `system:init` yet). */
+  pendingTurns: number;
+  /** True when turn output has streamed since the last `result` line. */
+  activitySinceResult: boolean;
   /**
-   * Monotonic id of the most recently dispatched turn. A runner's callbacks
-   * carry the id they were started with; once a newer turn supersedes them
-   * (the prior turn finished but its process is still alive), the stale
-   * callbacks check this and become no-ops instead of mutating the entry.
+   * Whether a `system:init` arrived since the last `result`. A result that
+   * arrives without one belongs to a dispatched turn that failed before
+   * opening (early CLI error), so it must release a pending count — otherwise
+   * the conversation reads busy forever while the client transcript reads
+   * idle.
    */
-  activeTurnId: number;
+  initSeenSinceResult: boolean;
+  /**
+   * Set by cancel(); cleared by the next `result` line (the interrupted
+   * turn's terminal) or process exit — NOT by a dispatch, so a new message
+   * racing the cancel can't make the interrupted turn read as "completed" or
+   * defuse the SIGTERM escalation while the interrupt is still unanswered.
+   */
+  cancelPending: boolean;
+  /**
+   * Background Bash tasks the agent has started that haven't reached a
+   * terminal `task_notification` yet. A pending task means the process will
+   * re-invoke the agent later, so the sandbox must be kept alive even though
+   * no turn is running — surfaced to the heartbeat via `hasPendingWork`.
+   */
+  outstandingTaskIds: Set<string>;
+  /** Serializes spawn/teardown so two dispatches can't race a respawn. */
+  opChain: Promise<void>;
+}
+
+interface RunnerOpts {
+  cwd?: string;
+  env?: Record<string, string>;
+  appendSystemPrompt?: string;
 }
 
 export interface DispatchInput {
   conversationId: string;
   prompt: string;
   /**
-   * If set, runs `claude -p ... --resume <id>`. Must point at an existing
-   * session JSONL on disk, OR be combined with `bootstrapJsonl` so the
-   * supervisor synthesizes the file from prior persisted events first.
+   * The Claude session this conversation owns. The backend supplies it on
+   * every dispatch (derived deterministically at conversation creation, or
+   * the stored id for older conversations). If absent — only possible from a
+   * not-yet-redeployed backend's first-turn dispatch — the hub generates one;
+   * that old backend still runs the first-write-wins event capture, and even
+   * without it the new backend's legacy path reconstructs the session from
+   * persisted events under a derived id.
    */
   claudeSessionId?: string;
+  /**
+   * True when a Claude session for this conversation has existed before (the
+   * backend checks its persisted events for any line carrying a session_id).
+   * Decides `--resume` vs `--session-id` at spawn. This deliberately comes
+   * from the backend rather than a supervisor-side existence check on the
+   * session file: right after a sandbox resume the snapshot restore can lag,
+   * so a filesystem probe races it — observed as `--session-id` being chosen
+   * for an existing session, which the CLI rejects with "already in use".
+   */
+  sessionHasHistory?: boolean;
   /**
    * Verbatim JSONL lines from prior `ResearchConversationEvents`, in seq order.
    * If non-empty, the hub writes them to the Claude Code session dir before
    * spawning so `--resume` finds the history. Each entry is one line of text.
+   * The write replaces any file already at that path: the backend only ships
+   * a bootstrap when the on-disk file can't be trusted (fresh rebuild — where
+   * any file present came from a stale base snapshot — or a legacy
+   * conversation with a just-derived id), so the reconstruction wins.
+   * Ignored when the conversation's process is already running (the live
+   * process owns the session file).
    */
   bootstrapJsonl?: string[];
 }
 
+/**
+ * Ship a supervisor-synthesized terminal `result` for a turn that can't end
+ * normally (process crash, cancel flush, sandbox restart). Uses the
+ * `interrupted` subtype, which in-flight derivations treat as closing every
+ * outstanding user turn; `writeBootstrapJsonl` strips result lines, so it
+ * never lands back in Claude's resume context.
+ */
+export function enqueueSyntheticInterruptedResult(
+  postPersister: PostPersister,
+  conversationId: string,
+  message: string,
+  nowMs: number,
+): void {
+  postPersister.enqueue(conversationId, {
+    rawJsonl: JSON.stringify({
+      type: "result",
+      subtype: FLUSH_RESULT_SUBTYPE,
+      is_error: true,
+      result: message,
+    }),
+    kind: "result",
+    claudeMessageUuid: null,
+    supervisorEmittedAt: new Date(nowMs).toISOString(),
+  });
+}
+
 export function createConversationHub(config: ConversationHubConfig) {
   const now = config.now ?? (() => Date.now());
+  const startProcess = config.startProcess ?? startClaudeProcess;
   const conversations = new Map<string, ConversationEntry>();
+  let interruptCounter = 0;
 
   function getOrInit(conversationId: string): ConversationEntry {
     const existing = conversations.get(conversationId);
@@ -59,14 +184,36 @@ export function createConversationHub(config: ConversationHubConfig) {
     const entry: ConversationEntry = {
       conversationId,
       state: { conversationId, status: "idle" },
-      runner: null,
-      activeTurnId: 0,
+      proc: null,
+      claudeSessionId: null,
+      pendingTurns: 0,
+      activitySinceResult: false,
+      initSeenSinceResult: false,
+      cancelPending: false,
+      outstandingTaskIds: new Set(),
+      opChain: Promise.resolve(),
     };
     conversations.set(conversationId, entry);
     return entry;
   }
 
-  function emit(entry: ConversationEntry, line: ParsedJsonlLine, turnId: number) {
+  function isBusy(entry: ConversationEntry): boolean {
+    return entry.pendingTurns > 0 || entry.activitySinceResult;
+  }
+
+  function refreshStatus(entry: ConversationEntry, terminal?: ConversationState["status"]) {
+    if (isBusy(entry)) {
+      if (entry.state.status !== "running") {
+        entry.state = { conversationId: entry.conversationId, status: "running", startedAt: now() };
+      }
+      return;
+    }
+    if (terminal && entry.state.status === "running") {
+      entry.state = { ...entry.state, status: terminal, endedAt: now() };
+    }
+  }
+
+  function emit(entry: ConversationEntry, line: ParsedJsonlLine) {
     const persistKind = mapKindForPersistence(line.kind);
     if (persistKind) {
       config.postPersister.enqueue(entry.conversationId, {
@@ -78,125 +225,255 @@ export function createConversationHub(config: ConversationHubConfig) {
       });
     }
 
-    // The `result` line is the turn's terminal signal — emitted once when the
-    // turn is done, independent of whether the process then exits (a backgrounded
-    // child can keep it alive). Completion is tracked here, not at process exit.
-    // Guarded so a superseded runner's late output can't complete a newer turn.
-    if (line.kind === "result" && entry.activeTurnId === turnId && entry.state.status === "running") {
-      entry.state = { ...entry.state, status: "completed", endedAt: now() };
+    const subtype = systemSubtypeOf(line);
+
+    if (line.kind === "system" && line.parsed) {
+      if (subtype === TURN_OPENING_SYSTEM_SUBTYPE) {
+        // A turn opened; if one of ours was queued, it's (presumably) this
+        // one. See the module doc for why init — not result — consumes the
+        // pending count.
+        entry.pendingTurns = Math.max(0, entry.pendingTurns - 1);
+        entry.initSeenSinceResult = true;
+      }
+      // `task_started` / `task_notification` bracket a background Bash task's
+      // lifetime. `task_updated` is deliberately ignored (can fire on
+      // non-terminal transitions), and a notification carrying an explicitly
+      // in-progress status keeps the task counted.
+      const taskId = line.parsed.task_id;
+      if (typeof taskId === "string") {
+        if (subtype === "task_started") entry.outstandingTaskIds.add(taskId);
+        if (subtype === "task_notification") {
+          const status = line.parsed.status;
+          if (typeof status !== "string" || !NON_TERMINAL_TASK_STATUSES.has(status)) {
+            entry.outstandingTaskIds.delete(taskId);
+          }
+        }
+      }
     }
 
-    if (line.sessionId && !entry.claudeSessionId) {
-      entry.claudeSessionId = line.sessionId;
+    if (line.kind === "result") {
+      // One `result` per turn — dispatched, queued, or a background-task
+      // re-invocation. Turn-end for busy purposes; the conversation may still
+      // have queued turns pending. An init-less result is a dispatched turn
+      // that failed before opening: release its pending count here, since no
+      // init ever will. (Re-invocation results can't take this branch — every
+      // re-invocation opens with its own init.)
+      if (!entry.initSeenSinceResult) {
+        entry.pendingTurns = Math.max(0, entry.pendingTurns - 1);
+      }
+      entry.initSeenSinceResult = false;
+      entry.activitySinceResult = false;
+      const wasCancel = entry.cancelPending;
+      entry.cancelPending = false;
+      if (wasCancel && entry.pendingTurns > 0) {
+        // The cancel interrupted a turn while other dispatched messages were
+        // still queued on stdin. Whether the CLI runs or drops queued
+        // messages after an interrupt is version-dependent, so close them out
+        // now — a cancel means "stop everything outstanding". If the CLI does
+        // run one anyway, its init/activity re-raise busy state.
+        entry.pendingTurns = 0;
+        enqueueSyntheticInterruptedResult(
+          config.postPersister,
+          entry.conversationId,
+          "Turn cancelled.",
+          now(),
+        );
+      }
+      refreshStatus(entry, wasCancel ? "cancelled" : "completed");
+      return;
     }
+
+    if (isTurnActivity(line.kind, subtype)) {
+      entry.activitySinceResult = true;
+      refreshStatus(entry);
+    }
+  }
+
+  /**
+   * Ensure the conversation's long-lived process exists, spawning (or
+   * respawning after a crash/kill) if needed. Serialized per conversation via
+   * `opChain` and always awaits the prior process's full exit first — the
+   * single-writer invariant for the session file.
+   */
+  async function ensureProcess(
+    entry: ConversationEntry,
+    input: DispatchInput,
+    runnerOpts: RunnerOpts,
+  ): Promise<{ ok: true } | { ok: false; reason: string }> {
+    if (entry.proc?.alive()) return { ok: true };
+
+    const previous = entry.proc;
+    if (previous) {
+      await previous.done;
+      if (entry.proc === previous) entry.proc = null;
+    }
+
+    const claudeSessionId = entry.claudeSessionId ?? input.claudeSessionId ?? randomUUID();
+    entry.claudeSessionId = claudeSessionId;
+
+    let sessionExists = input.sessionHasHistory ?? false;
+
+    if (input.bootstrapJsonl && input.bootstrapJsonl.length > 0) {
+      try {
+        await writeBootstrapJsonl(
+          { claudeSessionId, cwd: runnerOpts.cwd },
+          input.bootstrapJsonl.map((line) => ({ payload: line })),
+        );
+        sessionExists = true;
+      } catch (err) {
+        // eslint-disable-next-line no-console
+        console.error(
+          `[hub] bootstrap write failed for conv=${entry.conversationId} session=${claudeSessionId}:`,
+          err,
+        );
+        return { ok: false, reason: "bootstrap_failed" };
+      }
+    }
+
+    const proc = startProcess({
+      conversationId: entry.conversationId,
+      claudeSessionId,
+      sessionMode: sessionExists ? "resume" : "new",
+      appendSystemPrompt: runnerOpts.appendSystemPrompt,
+      cwd: runnerOpts.cwd,
+      env: runnerOpts.env,
+      onLine: (line) => emit(entry, line),
+      onExit: ({ code }) => {
+        if (entry.proc !== proc) return;
+        entry.proc = null;
+        if (isBusy(entry)) {
+          // The process died mid-turn (crash, OOM, cancel escalation). Close
+          // the dangling turn(s) with a synthetic terminal `result` so
+          // clients aren't stuck on "running".
+          const interrupted = entry.cancelPending;
+          enqueueSyntheticInterruptedResult(
+            config.postPersister,
+            entry.conversationId,
+            interrupted
+              ? "Turn cancelled."
+              : `Turn interrupted: the agent process exited unexpectedly${code !== null ? ` (code ${code})` : ""}.`,
+            now(),
+          );
+          entry.pendingTurns = 0;
+          entry.activitySinceResult = false;
+          refreshStatus(entry, interrupted ? "cancelled" : "errored");
+        }
+        entry.initSeenSinceResult = false;
+        entry.cancelPending = false;
+        // No process, no future re-invocation: pending tasks can't keep the
+        // sandbox alive any more (orphaned task processes die with the sandbox).
+        entry.outstandingTaskIds.clear();
+      },
+      onError: (err) => {
+        // eslint-disable-next-line no-console
+        console.error(`[hub] runner error conv=${entry.conversationId}:`, err);
+      },
+      onStderr: (chunk) => {
+        // eslint-disable-next-line no-console
+        console.error(`[hub] claude stderr conv=${entry.conversationId}: ${chunk}`);
+      },
+    });
+    entry.proc = proc;
+    if (!proc.alive()) {
+      entry.proc = null;
+      return { ok: false, reason: "spawn_failed" };
+    }
+    return { ok: true };
   }
 
   async function dispatch(
     input: DispatchInput,
-    runnerOpts?: { cwd?: string; env?: Record<string, string> },
+    runnerOpts?: RunnerOpts,
   ): Promise<{ accepted: boolean; reason?: string }> {
     const entry = getOrInit(input.conversationId);
-    if (entry.runner && entry.state.status === "running") {
-      return { accepted: false, reason: "already running" };
-    }
-    if (entry.runner) {
-      // The previous turn reached a terminal status but its process is still
-      // alive (a backgrounded child is holding it open). Starting the next turn
-      // is safe; the runner reference is replaced below.
-      // eslint-disable-next-line no-console
-      console.warn(`[hub] conv=${input.conversationId} starting turn with a live prior runner (status=${entry.state.status})`);
-    }
+    const opts = runnerOpts ?? {};
 
-    if (input.claudeSessionId && input.bootstrapJsonl && input.bootstrapJsonl.length > 0) {
-      try {
-        await writeBootstrapJsonl(
-          { claudeSessionId: input.claudeSessionId, cwd: runnerOpts?.cwd },
-          input.bootstrapJsonl.map((line) => ({ payload: line })),
-        );
-      } catch (err) {
-        // eslint-disable-next-line no-console
-        console.error(
-          `[hub] bootstrap write failed for conv=${input.conversationId} session=${input.claudeSessionId}:`,
-          err,
-        );
-        return { accepted: false, reason: "bootstrap_failed" };
+    // A turn may already be running — that's fine. The message is written to
+    // the live process's stdin; Claude Code queues it and runs it as its own
+    // turn after the current one (verified empirically; see the design notes
+    // in claudeRunner.ts).
+    let result: { accepted: boolean; reason?: string } = { accepted: true };
+    const run = entry.opChain.then(async () => {
+      const ensured = await ensureProcess(entry, input, opts);
+      if (!ensured.ok) {
+        result = { accepted: false, reason: ensured.reason };
+        return;
       }
-    }
 
-    const turnId = entry.activeTurnId + 1;
-    entry.activeTurnId = turnId;
-    entry.state = { conversationId: input.conversationId, status: "running", startedAt: now() };
-    entry.claudeSessionId = input.claudeSessionId ?? entry.claudeSessionId;
+      let sent = entry.proc!.sendUserMessage(input.prompt);
+      if (!sent) {
+        // The process's stdin is gone but it may not have fully exited. Tear
+        // it down and make one respawn attempt; the session file has
+        // everything up to the last completed turn. (Capture the handle:
+        // onExit nulls entry.proc, possibly synchronously.)
+        const dead = entry.proc!;
+        dead.kill("SIGKILL");
+        await dead.done;
+        const respawned = await ensureProcess(entry, input, opts);
+        sent = respawned.ok && entry.proc!.sendUserMessage(input.prompt);
+      }
+      if (!sent) {
+        result = { accepted: false, reason: "process_unavailable" };
+        return;
+      }
 
-    // Persist the user's turn now, from the prompt we already hold, rather than
-    // waiting for Claude to echo it. Claude Code only re-emits the user message
-    // bundled with its first model output — seconds later, and scaling with turn
-    // complexity (it withholds the echo until inference produces its first
-    // streamed message), so we'd otherwise have no record of the user's turn
-    // until then. Emitting it here, before the runner starts, gives it the
-    // turn's lowest seq and keeps the supervisor the single writer shipping it
-    // through the durable queue → backend webhook. `claudeMessageUuid: null`
-    // lets the persister synthesize a stable `sup:<localId>` idempotency key.
-    config.postPersister.enqueue(input.conversationId, {
-      rawJsonl: JSON.stringify({
-        type: "user",
-        message: { role: "user", content: input.prompt },
-        parent_tool_use_id: null,
-      }),
-      kind: "user",
-      claudeMessageUuid: null,
-      supervisorEmittedAt: new Date(now()).toISOString(),
+      // Persist the user's turn only after it has been handed to the process:
+      // a failed dispatch ships nothing, so the backend's error response and
+      // the transcript agree (the client re-sends without creating a
+      // duplicate). Claude never echoes the message itself (no
+      // --replay-user-messages), and the send→enqueue window is synchronous,
+      // so the user event still precedes any of the turn's output in seq
+      // order. `claudeMessageUuid: null` lets the persister synthesize a
+      // stable `sup:<localId>` idempotency key.
+      config.postPersister.enqueue(input.conversationId, {
+        rawJsonl: JSON.stringify({
+          type: "user",
+          message: { role: "user", content: input.prompt },
+          parent_tool_use_id: null,
+        }),
+        kind: "user",
+        claudeMessageUuid: null,
+        supervisorEmittedAt: new Date(now()).toISOString(),
+      });
+      entry.pendingTurns += 1;
+      refreshStatus(entry);
     });
-
-    const runner = startClaudeRunner({
-      conversationId: input.conversationId,
-      prompt: input.prompt,
-      claudeSessionId: input.claudeSessionId,
-      cwd: runnerOpts?.cwd,
-      env: runnerOpts?.env,
-      onLine: (line) => emit(entry, line, turnId),
-      onExit: ({ code }) => {
-        // A runner superseded by a newer turn must not touch the entry.
-        if (entry.activeTurnId !== turnId) return;
-        // Backstop for turns that exit without ever emitting a `result` (crash,
-        // kill). A turn already moved to a terminal status by `emit` (the normal
-        // case) or by `cancel` is left untouched.
-        if (entry.state.status === "running") {
-          entry.state = {
-            ...entry.state,
-            status: code === 0 ? "completed" : "errored",
-            endedAt: now(),
-          };
-        }
-        entry.runner = null;
-      },
-      onError: (err) => {
-        // eslint-disable-next-line no-console
-        console.error(`[hub] runner error conv=${input.conversationId}:`, err);
-      },
-      onStderr: (chunk) => {
-        // eslint-disable-next-line no-console
-        console.error(`[hub] claude stderr conv=${input.conversationId}: ${chunk}`);
-      },
-    });
-    entry.runner = runner;
-    return { accepted: true };
+    entry.opChain = run.then(noop, noop);
+    await run;
+    return result;
   }
 
+  /**
+   * Cancel the in-flight turn via the stream-json `interrupt` control
+   * request: the CLI aborts the turn, records "[Request interrupted by
+   * user]" in the session, and emits a normal `result` — process stays alive
+   * for the next turn. Escalates to SIGTERM/SIGKILL if no `result` arrives
+   * within the grace period (`cancelPending` still set); a result arriving
+   * for ANY turn clears `cancelPending` and defuses the escalation, so a new
+   * turn dispatched after a successful interrupt can't be killed by the
+   * stale timer. The killed process is respawned lazily by the next dispatch
+   * via `--resume`.
+   */
   async function cancel(conversationId: string): Promise<void> {
     const entry = conversations.get(conversationId);
-    if (!entry || !entry.runner) return;
-    // Only an in-progress turn can be cancelled. A completed turn whose process
-    // is still alive (a backgrounded child) must not be torn down here.
-    if (entry.state.status !== "running") return;
-    const cancelledRunner = entry.runner;
-    entry.state = { ...entry.state, status: "cancelled" };
-    cancelledRunner.cancel("SIGTERM");
-    // SIGKILL fallback if still running after grace period — but only if this is
-    // still the same runner, so a turn dispatched in the meantime isn't killed.
-    setTimeout(() => {
-      if (entry.runner === cancelledRunner) cancelledRunner.cancel("SIGKILL");
-    }, 5_000);
+    if (!entry || !entry.proc?.alive() || !isBusy(entry)) return;
+    const proc = entry.proc;
+    entry.cancelPending = true;
+    const requestId = `interrupt-${++interruptCounter}`;
+    const wrote = proc.interrupt(requestId);
+    const escalate = () => {
+      if (entry.proc !== proc || !proc.alive()) return;
+      if (!entry.cancelPending) return; // a result arrived since cancel; interrupt landed
+      proc.kill("SIGTERM");
+      setTimeout(() => {
+        if (entry.proc === proc && proc.alive()) proc.kill("SIGKILL");
+      }, CANCEL_SIGKILL_GRACE_MS).unref();
+    };
+    if (!wrote) {
+      escalate();
+      return;
+    }
+    setTimeout(escalate, CANCEL_INTERRUPT_GRACE_MS).unref();
   }
 
   function snapshot(): {
@@ -208,18 +485,50 @@ export function createConversationHub(config: ConversationHubConfig) {
     return { conversations: states, concurrencyCount: running };
   }
 
+  /**
+   * True while the sandbox must be kept alive for agent work: a turn is
+   * running, or a background task is pending whose completion will re-invoke
+   * the agent. Drives the heartbeat's `turnRunning` (which re-arms the idle
+   * timeout and defers session rolls) and the /status snapshot (which gates
+   * environment saves).
+   */
+  function hasPendingWork(): boolean {
+    return [...conversations.values()].some(
+      (e) => isBusy(e) || (e.proc?.alive() === true && e.outstandingTaskIds.size > 0),
+    );
+  }
+
+  /** Graceful teardown for supervisor shutdown: end stdin-fed processes. */
+  async function shutdown(): Promise<void> {
+    const procs = [...conversations.values()]
+      .map((e) => e.proc)
+      .filter((p): p is ClaudeProcessHandle => p !== null && p.alive());
+    for (const proc of procs) proc.kill("SIGTERM");
+    await Promise.all(procs.map((p) => p.done));
+  }
+
   return {
     dispatch,
     cancel,
     snapshot,
+    hasPendingWork,
+    shutdown,
   };
+}
+
+function noop(): void {}
+
+function systemSubtypeOf(line: ParsedJsonlLine): string | undefined {
+  const subtype = line.parsed?.subtype;
+  return typeof subtype === "string" ? subtype : undefined;
 }
 
 /**
  * Translate the parser-detected kind into one of the backend's accepted
  * persistence kinds. Returns null for kinds we drop on the floor:
- *  - "unknown" — unrecognized line shape; not persisted to keep the
- *               persistence schema strict. Backend can reject these explicitly.
+ *  - "unknown" — unrecognized line shape (incl. `control_response` acks and
+ *               `rate_limit_event`); not persisted to keep the persistence
+ *               schema strict. Backend can reject these explicitly.
  *
  * `result` is persisted because it's the only line Claude Code emits exactly
  * once per turn regardless of how many intermediate events the turn produced;

--- a/packages/lesswrong/server/research/sandbox/supervisor/index.ts
+++ b/packages/lesswrong/server/research/sandbox/supervisor/index.ts
@@ -29,7 +29,7 @@ import { homedir } from "node:os";
 import * as path from "node:path";
 import { spawn } from "node:child_process";
 import type { Server } from "node:http";
-import { createConversationHub } from "./conversationHub";
+import { createConversationHub, enqueueSyntheticInterruptedResult } from "./conversationHub";
 import { createPostPersister, PostPersister } from "./postPersister";
 import { startSupervisor, SupervisorDeps } from "./server";
 import { startHeartbeat } from "./heartbeat";
@@ -38,8 +38,6 @@ import { buildScriptBootEnv, researchBinPath } from "./devServer";
 import { startAuthProxy } from "./authProxy";
 import { AGENT_CWD } from "../sandboxLayout";
 
-const CLAUDE_MD_PATH = path.join(homedir(), ".claude", "CLAUDE.md");
-
 // init.sh runs non-blocking (it doesn't gate boot or the agent's turn), so this
 // is only a hung-process reaper, not a latency budget. Allow several minutes so a
 // legitimate per-boot dependency reconcile (`npm install` after a pull whose
@@ -47,26 +45,27 @@ const CLAUDE_MD_PATH = path.join(homedir(), ".claude", "CLAUDE.md");
 const INIT_SCRIPT_TIMEOUT_MS = 5 * 60 * 1000;
 
 /**
- * Substitute session placeholders in the agent's CLAUDE.md so Claude Code's
- * auto-loaded system prompt knows what project and conversation the agent is
- * scoped to. Run at boot, *after* the backend's overlay write and *before* any
- * `claude` subprocess. Best-effort: a missing/unwritable file just logs.
+ * Per-conversation context appended to Claude Code's default system prompt
+ * (`--append-system-prompt`) at process spawn. This replaces the old scheme of
+ * substituting `{{...}}` placeholders into the overlaid CLAUDE.md at boot:
+ * the values are per-conversation constants known from env, and keeping them
+ * out of the on-disk file means a re-launch can never observe a stale fill.
+ * The static agent instructions still ship as CLAUDE.md and are auto-loaded.
  */
-function fillClaudeMdTemplate(env: { projectId: string; conversationId: string }): void {
-  try {
-    const template = fs.readFileSync(CLAUDE_MD_PATH, "utf8");
-    const filled = template
-      .replace(/\{\{RESEARCH_PROJECT_ID\}\}/g, env.projectId)
-      .replace(/\{\{RESEARCH_CONVERSATION_ID\}\}/g, env.conversationId);
-    if (filled !== template) {
-      fs.writeFileSync(CLAUDE_MD_PATH, filled, "utf8");
-    }
-  } catch (err) {
-    // eslint-disable-next-line no-console
-    console.warn(
-      `[supervisor] could not fill CLAUDE.md template: ${err instanceof Error ? err.message : String(err)}`,
-    );
-  }
+function buildAppendSystemPrompt(env: { projectId: string; conversationId: string }): string {
+  return [
+    `You are working in research project \`${env.projectId}\`. All`,
+    `\`research-tool\` calls are scoped to this project automatically (the`,
+    `bearer token pins it server-side, so cross-project requests are`,
+    `rejected). You can't pivot to a different project from this sandbox.`,
+    ``,
+    `Your current conversation id is \`${env.conversationId}\`. If fetched`,
+    `document markdown, a \`fetch-conversation\` result, an \`@[conv:...]\``,
+    `mention, or an \`%%% agent-block conversationId="..." %%%\` placeholder`,
+    `refers to this same id, treat it as this conversation, including text you`,
+    `may have written earlier in the same task. Do not mistake it for an`,
+    `independent prior/sibling conversation.`,
+  ].join("\n");
 }
 
 interface SupervisorEnv {
@@ -179,18 +178,12 @@ async function selfHealDanglingTurn(
     // supervisor, the "incomplete" turn is the live just-dispatched one, not an
     // orphan — emitting a synthetic terminal would falsely close it. Skip.
     if (isTurnRunning()) return;
-    const line = JSON.stringify({
-      type: "result",
-      subtype: "interrupted",
-      is_error: true,
-      result: "Turn interrupted by a sandbox restart.",
-    });
-    postPersister.enqueue(env.conversationId, {
-      rawJsonl: line,
-      kind: "result",
-      claudeMessageUuid: null,
-      supervisorEmittedAt: new Date().toISOString(),
-    });
+    enqueueSyntheticInterruptedResult(
+      postPersister,
+      env.conversationId,
+      "Turn interrupted by a sandbox restart.",
+      Date.now(),
+    );
   } catch (err) {
     // eslint-disable-next-line no-console
     console.warn(`[supervisor] dangling-turn self-heal failed: ${(err as Error).message}`);
@@ -199,7 +192,10 @@ async function selfHealDanglingTurn(
 
 export async function bootSupervisor() {
   const env = readEnv();
-  fillClaudeMdTemplate({ projectId: env.projectId, conversationId: env.conversationId });
+  const appendSystemPrompt = buildAppendSystemPrompt({
+    projectId: env.projectId,
+    conversationId: env.conversationId,
+  });
 
   const postPersister = createPostPersister({
     backendBaseUrl: env.backendBaseUrl,
@@ -247,6 +243,7 @@ export async function bootSupervisor() {
           conversationId: req.conversationId,
           prompt: req.prompt,
           claudeSessionId: req.claudeSessionId,
+          sessionHasHistory: req.sessionHasHistory,
           bootstrapJsonl: req.bootstrapJsonl,
         },
         {
@@ -254,6 +251,12 @@ export async function bootSupervisor() {
           // session-bootstrap JSONL path is derived from, so `--resume` finds
           // the synthesized history on a fresh sandbox.
           cwd: AGENT_CWD,
+          appendSystemPrompt,
+          // Spawn-time env for the long-lived claude process. The agent token
+          // is minted per dispatch but only the one in effect at spawn is
+          // visible to the process; that's safe because its TTL (6h) exceeds
+          // the sandbox session lifetime cap (5h), so a spawn-time token
+          // always outlives the process that received it.
           env: {
             // Put `~/.research/bin` (where the overlay drops the research-tool
             // binary) ahead of the system PATH so the agent can invoke
@@ -277,7 +280,11 @@ export async function bootSupervisor() {
       return {
         conversations: snap.conversations,
         concurrencyCount: snap.concurrencyCount,
-        turnRunning: snap.conversations.some((c) => c.status === "running"),
+        // Includes pending background tasks, matching the heartbeat: the
+        // /status consumer that matters is saveEnvironment's quiesce gate,
+        // and snapshotting stops the sandbox — which would kill a pending
+        // task and its promised re-invocation.
+        turnRunning: hub.hasPendingWork(),
         pendingEvents: postPersister.pendingCount(),
       };
     },
@@ -315,7 +322,10 @@ export async function bootSupervisor() {
     sandboxId: env.sandboxId,
     backendBaseUrl: env.backendBaseUrl,
     authToken: env.callbackToken,
-    getTurnRunning: () => hub.snapshot().conversations.some((c) => c.status === "running"),
+    // Includes pending background tasks, not just running turns: a finished
+    // task re-invokes the agent inside the long-lived claude process, so the
+    // sandbox must not idle-stop (or roll) out from under it.
+    getTurnRunning: () => hub.hasPendingWork(),
     getLastDevActivityAt: () => lastDevActivityAt,
   });
 
@@ -325,6 +335,10 @@ export async function bootSupervisor() {
     authProxy.close();
     devControl.close();
     devServer.stop();
+    // Stop the long-lived claude process(es) first: a kill mid-turn enqueues a
+    // synthetic terminal `result` (see the hub's onExit), which the drain below
+    // then ships — so a turn cut short by sandbox stop isn't left dangling.
+    await hub.shutdown();
     await postPersister.drain();
     process.exit(0);
   };

--- a/packages/lesswrong/server/research/sandbox/supervisor/postPersister.ts
+++ b/packages/lesswrong/server/research/sandbox/supervisor/postPersister.ts
@@ -46,7 +46,11 @@ export interface BackendEvent {
   kind: "user" | "assistant" | "tool_use" | "tool_result" | "thinking" | "system" | "error" | "result";
   /** ID from the JSONL line if present, null otherwise. Used for dedupe. */
   claudeMessageUuid: string | null;
-  /** Optional, sent for cross-checking against conversation.claudeSessionId. */
+  /**
+   * The session id from the JSONL line, if present. Informational: the
+   * backend validates the field's shape but no longer consumes it (session
+   * ids are assigned at conversation creation, not captured from events).
+   */
   claudeSessionId?: string;
   /** ISO-8601; backend falls back to its own clock if absent. */
   supervisorEmittedAt?: string;

--- a/packages/lesswrong/server/research/sandbox/supervisor/server.ts
+++ b/packages/lesswrong/server/research/sandbox/supervisor/server.ts
@@ -58,15 +58,23 @@ export interface SupervisorDeps {
 export interface DispatchRequest {
   conversationId: string;
   prompt: string;
-  /** If set, --resume <claudeSessionId>. */
+  /** The Claude session this conversation owns. */
   claudeSessionId?: string;
+  /**
+   * True when a Claude session for this conversation already exists
+   * (backend-derived from persisted events). Picks `--resume` over
+   * `--session-id` at spawn; see DispatchInput.sessionHasHistory.
+   */
+  sessionHasHistory?: boolean;
   /** Synthesized JSONL lines to seed the session dir before --resume. */
   bootstrapJsonl?: string[];
   /** References attached as part of the user turn (file paths, doc handles, etc.). */
   references?: unknown[];
   /**
    * Agent-scoped sandbox-callback bearer minted by the backend per dispatch
-   * (≤30min TTL). The supervisor passes this — not its own supervisor-scoped
+   * (6h TTL — deliberately longer than the 5h sandbox session cap, so the
+   * token a long-lived claude process received at spawn always outlives it).
+   * The supervisor passes this — not its own supervisor-scoped
    * `CALLBACK_TOKEN` — to the Claude Code subprocess as
    * `RESEARCH_BACKEND_TOKEN`, so `research-tool` calls hit endpoints that
    * require an agent scope (e.g. `documents/:id` GET, edit-doc).
@@ -189,6 +197,7 @@ function parseDispatchRequest(body: Record<string, unknown>): DispatchRequest | 
     prompt: body.prompt,
   };
   if (typeof body.claudeSessionId === "string") out.claudeSessionId = body.claudeSessionId;
+  if (typeof body.sessionHasHistory === "boolean") out.sessionHasHistory = body.sessionHasHistory;
   if (Array.isArray(body.bootstrapJsonl)) {
     out.bootstrapJsonl = body.bootstrapJsonl.filter((s): s is string => typeof s === "string");
   }

--- a/packages/lesswrong/server/research/sessionReconstruction.ts
+++ b/packages/lesswrong/server/research/sessionReconstruction.ts
@@ -1,6 +1,23 @@
+import { v5 as uuidv5 } from "uuid";
 import { isPlainRecord } from "@/components/research/conversationEventFormat";
 
 const SANDBOX_CWD = "/vercel/sandbox";
+
+/** Fixed UUIDv5 namespace for deriving Claude session ids from conversation ids. */
+const CLAUDE_SESSION_ID_NAMESPACE = "48734f38-9434-422d-b942-88b21da4fac2";
+
+/**
+ * The Claude session id a conversation owns, derived deterministically from
+ * its id (the CLI requires a UUID; conversation ids are 17-char random
+ * strings). Set on the conversation row at creation and passed on every
+ * dispatch, so the supervisor never has to mint one and the backend never has
+ * to capture one back out of the event stream. Conversations created before
+ * this scheme keep their stored (captured) id; environment forks reuse the
+ * source conversation's id when its session file is on the snapshot.
+ */
+export function claudeSessionIdForConversation(conversationId: string): string {
+  return uuidv5(conversationId, CLAUDE_SESSION_ID_NAMESPACE);
+}
 const SESSION_JSONL_DROPPED_TYPES = new Set(["system", "result", "error"]);
 const MAINLINE_GROUP_KEY = "__mainline__";
 

--- a/packages/lesswrong/server/resolvers/researchResolvers.ts
+++ b/packages/lesswrong/server/resolvers/researchResolvers.ts
@@ -16,7 +16,10 @@ import { GraphQLError } from "graphql";
 import { isPlainRecord } from "@/components/research/conversationEventFormat";
 import { accessFilterSingle } from "@/lib/utils/schemaUtils";
 import { userIsAdmin } from "@/lib/vulcan-users/permissions";
-import { buildBootstrapJsonl } from "@/server/research/sessionReconstruction";
+import {
+  buildBootstrapJsonl,
+  claudeSessionIdForConversation,
+} from "@/server/research/sessionReconstruction";
 import {
   buildSystemReminderWrap,
   deriveLastInjectedActiveDocumentId,
@@ -83,7 +86,8 @@ async function dispatchTurnViaSupervisor(args: {
   projectId: string;
   userId: string;
   prompt: string;
-  claudeSessionId?: string;
+  claudeSessionId: string;
+  sessionHasHistory: boolean;
   bootstrapJsonl?: string[];
 }): Promise<void> {
   const { provisioned } = args;
@@ -108,6 +112,7 @@ async function dispatchTurnViaSupervisor(args: {
       conversationId: args.conversationId,
       prompt: args.prompt,
       claudeSessionId: args.claudeSessionId,
+      sessionHasHistory: args.sessionHasHistory,
       bootstrapJsonl: args.bootstrapJsonl,
       agentBackendToken,
     }),
@@ -282,6 +287,20 @@ export const researchResolversMutations = {
     }
 
     const _id = conversationId;
+
+    // An environment fork reuses the source conversation's session id when it
+    // can be recovered: the env snapshot's disk carries the source session
+    // file, so `--resume` under that id restores the branch history at full
+    // fidelity. (The id lives in the event payload's `session_id`, not the
+    // source conversation's `claudeSessionId` field — that field may lag.)
+    // Everything else — including a fork whose source id can't be recovered —
+    // gets the conversation's own deterministic session id.
+    const sourceEvent = environment?.sourceEventId
+      ? await context.ResearchConversationEvents.findOne({ _id: environment.sourceEventId })
+      : null;
+    const sourceSessionId = sourceEvent ? sessionIdFromPayload(sourceEvent.payload) : null;
+    const claudeSessionId = sourceSessionId ?? claudeSessionIdForConversation(_id);
+
     const now = new Date();
     try {
       await ResearchConversations.rawInsert({
@@ -293,7 +312,7 @@ export const researchResolversMutations = {
         baseEnvironmentId,
         runtime,
         title: null,
-        claudeSessionId: null,
+        claudeSessionId,
         lastActivityAt: now,
         createdAt: now,
       });
@@ -304,27 +323,22 @@ export const researchResolversMutations = {
       throw err;
     }
 
-    let firstTurnSessionOnDisk: { claudeSessionId: string } | undefined;
-    if (environment?.sourceEventId) {
-      const sourceEvent = await context.ResearchConversationEvents.findOne({
-        _id: environment.sourceEventId,
+    let bootstrapEvents: DbResearchConversationEvent[] | undefined;
+    if (sourceEvent) {
+      await context.repos.researchConversationEvents.backfillFromBranch({
+        sourceConversationId: sourceEvent.conversationId,
+        targetConversationId: _id,
+        targetUserId: currentUser._id,
+        targetProjectId: projectId,
+        branchSeq: sourceEvent.seq,
       });
-      if (sourceEvent) {
-        await context.repos.researchConversationEvents.backfillFromBranch({
-          sourceConversationId: sourceEvent.conversationId,
-          targetConversationId: _id,
-          targetUserId: currentUser._id,
-          targetProjectId: projectId,
-          branchSeq: sourceEvent.seq,
-        });
-        // The session id lives in the event payload (`session_id`), not the
-        // source conversation's `claudeSessionId` field — that field is captured
-        // async and may be stale if the env was saved right after a result.
-        const sessionId = sessionIdFromPayload(sourceEvent.payload);
-        if (sessionId) {
-          await ResearchConversations.rawUpdateOne({ _id }, { $set: { claudeSessionId: sessionId } });
-          firstTurnSessionOnDisk = { claudeSessionId: sessionId };
-        }
+      if (!sourceSessionId) {
+        // No session file to resume on the snapshot — synthesize one from the
+        // backfilled branch events so the fork still starts with its history.
+        bootstrapEvents = await context.ResearchConversationEvents.find(
+          { conversationId: _id },
+          { sort: { seq: 1 } },
+        ).fetch();
       }
     }
 
@@ -352,7 +366,13 @@ export const researchResolversMutations = {
       projectId,
       userId: currentUser._id,
       prompt: turnPrompt,
-      sessionOnDisk: firstTurnSessionOnDisk,
+      claudeSessionId,
+      // A fork that recovered its source session resumes the session file on
+      // the env snapshot; everything else is a brand-new session (a fork
+      // without a recoverable source id resumes via the synthesized bootstrap
+      // instead, which the supervisor accounts for on its own).
+      sessionHasHistory: !!sourceSessionId,
+      bootstrapEvents,
     });
 
     backgroundTask((async () => {
@@ -376,9 +396,8 @@ export const researchResolversMutations = {
     if (!prompt) throw new Error("prompt required");
 
     // Fetch history once: used for both the Claude `--resume` bootstrap
-    // (when a session id exists) and the system-reminder cadence check.
-    // Read before appending the new user turn so both consumers see
-    // history-up-to-now.
+    // and the system-reminder cadence check. Read before appending the new
+    // user turn so both consumers see history-up-to-now.
     const priorEvents = await context.ResearchConversationEvents.find(
       { conversationId: conv._id },
       { sort: { seq: 1 } },
@@ -395,15 +414,36 @@ export const researchResolversMutations = {
       context,
     });
 
+    // Legacy conversations (created before deterministic session ids) whose
+    // first-event capture never landed get a derived id now, persisted so
+    // later turns agree on it. Their derived id has no session file anywhere,
+    // so the bootstrap must run even on a warm sandbox.
+    const claudeSessionId = conv.claudeSessionId ?? claudeSessionIdForConversation(conv._id);
+    if (!conv.claudeSessionId) {
+      await ResearchConversations.rawUpdateOne({ _id: conv._id }, { $set: { claudeSessionId } });
+    }
+
     await dispatchToSandbox({
       context,
       conversationId: conv._id,
       projectId: conv.projectId,
       userId: conv.userId,
       prompt: turnPrompt,
-      resumeContext: conv.claudeSessionId
-        ? { claudeSessionId: conv.claudeSessionId, priorEvents }
-        : undefined,
+      claudeSessionId,
+      // "THIS session has run before" = some persisted event carries this
+      // exact session id (claude-emitted; supervisor-synthesized events have
+      // none). Matching the dispatched id — not just any session_id — matters
+      // for forks: their backfilled branch events carry the SOURCE
+      // conversation's session id, which must not make a fork whose own
+      // session never started claim history (--resume of a nonexistent
+      // session hard-fails). A conversation whose first turn never reached
+      // claude, or whose legacy id was just derived, correctly reads false —
+      // the shipped bootstrap is what makes those resumable.
+      sessionHasHistory: priorEvents.some(
+        (e) => sessionIdFromPayload(e.payload) === claudeSessionId,
+      ),
+      bootstrapEvents: priorEvents,
+      bootstrapEvenIfWarm: !conv.claudeSessionId,
     });
 
     // Only after a successful dispatch, so a failed turn leaves no advanced timestamp.
@@ -543,9 +583,16 @@ async function provisionSandboxOrWarming(
 
 /**
  * Provision (or resume) the conversation's persistent sandbox and dispatch one
- * turn to its supervisor. `resumeContext` is supplied when continuing an
- * existing conversation; it lets a rebuilt sandbox have its Claude session
- * reconstructed.
+ * turn to its supervisor.
+ *
+ * `bootstrapEvents` is the conversation's persisted history, shipped so a
+ * sandbox without the session file on disk can have the Claude session
+ * reconstructed. It's sent when the sandbox was freshly built (a rebuild
+ * after an expired snapshot, or a fork whose source session couldn't be
+ * recovered) — a warm resume still has the file on disk, so `--resume` reads
+ * it directly. `bootstrapEvenIfWarm` ships it regardless, for conversations
+ * whose session id was just derived and so can't have a file anywhere; the
+ * supervisor only writes the reconstruction when the file is actually absent.
  */
 async function dispatchToSandbox(args: {
   context: ResolverContext;
@@ -553,34 +600,23 @@ async function dispatchToSandbox(args: {
   projectId: string;
   userId: string;
   prompt: string;
-  resumeContext?: { claudeSessionId: string; priorEvents: DbResearchConversationEvent[] };
-  sessionOnDisk?: { claudeSessionId: string };
+  claudeSessionId: string;
+  /**
+   * Whether a Claude session for this conversation has ever actually run —
+   * forwarded to the supervisor, which uses it (not a filesystem probe, which
+   * races snapshot restore on a fresh resume) to pick `--resume` vs
+   * `--session-id`.
+   */
+  sessionHasHistory: boolean;
+  bootstrapEvents?: DbResearchConversationEvent[];
+  bootstrapEvenIfWarm?: boolean;
 }): Promise<void> {
   const provisioned = await provisionSandboxOrWarming(args.conversationId, args.context);
 
-  if (args.sessionOnDisk && provisioned.isFirstProvision) {
-    await dispatchTurnViaSupervisor({
-      provisioned,
-      conversationId: args.conversationId,
-      projectId: args.projectId,
-      userId: args.userId,
-      prompt: args.prompt,
-      claudeSessionId: args.sessionOnDisk.claudeSessionId,
-      bootstrapJsonl: undefined,
-    });
-    return;
-  }
-
-  // Reconstruct the Claude session only when the sandbox was freshly built (a
-  // rebuild after an expired snapshot). A warm resume still has the session
-  // file on disk, so `claude --resume` reads it directly.
-  let bootstrapJsonl: string[] | undefined;
-  if (provisioned.wasFreshlyCreated && args.resumeContext) {
-    bootstrapJsonl = buildBootstrapJsonl(
-      args.resumeContext.priorEvents,
-      args.resumeContext.claudeSessionId,
-    );
-  }
+  const shipBootstrap = provisioned.wasFreshlyCreated || args.bootstrapEvenIfWarm;
+  const bootstrapJsonl = shipBootstrap && args.bootstrapEvents?.length
+    ? buildBootstrapJsonl(args.bootstrapEvents, args.claudeSessionId)
+    : undefined;
 
   await dispatchTurnViaSupervisor({
     provisioned,
@@ -588,7 +624,8 @@ async function dispatchToSandbox(args: {
     projectId: args.projectId,
     userId: args.userId,
     prompt: args.prompt,
-    claudeSessionId: args.resumeContext?.claudeSessionId,
+    claudeSessionId: args.claudeSessionId,
+    sessionHasHistory: args.sessionHasHistory,
     bootstrapJsonl,
   });
 }

--- a/packages/lesswrong/server/scripts/buildResearchSandboxSnapshot.ts
+++ b/packages/lesswrong/server/scripts/buildResearchSandboxSnapshot.ts
@@ -5,6 +5,7 @@ import { randomId } from "@/lib/random";
 import SandboxBaselineSnapshots from "@/server/collections/sandboxBaselineSnapshots/collection";
 import {
   CLAUDE_MD_PATH,
+  PINNED_CLAUDE_CODE_VERSION,
   RESEARCH_TOOL_PATH,
   SUPERVISOR_PATH,
 } from "@/server/research/sandbox/sandboxLayout";
@@ -117,7 +118,10 @@ async function ensureNodeInstalled(sandbox: Sandbox): Promise<boolean> {
  *
  * Run `yarn research-supervisor-build` first to produce the supervisor bundle in
  * `sandbox/dist/`. Rebuild a runtime's snapshot whenever the supervisor source,
- * research-tool, or Claude Code changes.
+ * research-tool, or `PINNED_CLAUDE_CODE_VERSION` changes. (Existing sandboxes
+ * and saved environments don't need a rebuild for a Claude Code bump — the
+ * launch path reconciles their install to the pin — but fresh provisions
+ * shouldn't pay that upgrade cost, so keep the baselines current.)
  *
  * Requires Vercel auth in env (via `yarn repl` / `.env.local`: `VERCEL_OIDC_TOKEN`
  * from `vercel env pull`, or `VERCEL_TOKEN` + `VERCEL_TEAM_ID` + `VERCEL_PROJECT_ID`).
@@ -163,10 +167,10 @@ export async function buildResearchSandboxSnapshot(args: BuildResearchSandboxSna
     const installedNode = await ensureNodeInstalled(sandbox);
 
     // eslint-disable-next-line no-console
-    console.log("[snapshot] installing @anthropic-ai/claude-code (this may take a minute)…");
+    console.log(`[snapshot] installing @anthropic-ai/claude-code@${PINNED_CLAUDE_CODE_VERSION} (this may take a minute)…`);
     const installResult = await sandbox.runCommand({
       cmd: "npm",
-      args: ["install", "-g", "@anthropic-ai/claude-code"],
+      args: ["install", "-g", `@anthropic-ai/claude-code@${PINNED_CLAUDE_CODE_VERSION}`],
       // On the node* images npm's global prefix is already user-writable, but a
       // dnf-installed Node uses the system prefix (/usr), so a non-root `-g`
       // install would hit EACCES — run it as root there. claude lands on the
@@ -178,11 +182,14 @@ export async function buildResearchSandboxSnapshot(args: BuildResearchSandboxSna
       throw new Error(`npm install failed (exit ${installResult.exitCode}): ${stderr.slice(0, 1000)}`);
     }
 
-    const verify = await sandbox.runCommand({ cmd: "which", args: ["claude"] });
-    const which = (await verify.stdout()).trim();
-    if (verify.exitCode !== 0 || !which) {
+    const verify = await sandbox.runCommand({ cmd: "sh", args: ["-c", "claude --version"] });
+    const installedVersion = (await verify.stdout()).trim().split(" ")[0];
+    if (verify.exitCode !== 0 || installedVersion !== PINNED_CLAUDE_CODE_VERSION) {
       const stderr = await verify.stderr();
-      throw new Error(`claude binary not found after install: ${stderr || "(no stderr)"}`);
+      throw new Error(
+        `claude ${PINNED_CLAUDE_CODE_VERSION} not runnable after install ` +
+        `(got "${installedVersion || stderr || "(nothing)"}")`,
+      );
     }
 
     // Paths come from the shared sandboxLayout module so the baseline seed and

--- a/packages/lesswrong/unitTests/conversationHub.tests.ts
+++ b/packages/lesswrong/unitTests/conversationHub.tests.ts
@@ -1,0 +1,336 @@
+import { createConversationHub } from "../server/research/sandbox/supervisor/conversationHub";
+import {
+  ClaudeProcessHandle,
+  ClaudeProcessOptions,
+  startClaudeProcess,
+} from "../server/research/sandbox/supervisor/claudeRunner";
+import { createJsonlChunker } from "../server/research/sandbox/supervisor/jsonlParser";
+import { BackendEvent, PostPersister } from "../server/research/sandbox/supervisor/postPersister";
+
+interface FakeProcess {
+  opts: ClaudeProcessOptions;
+  handle: ClaudeProcessHandle;
+  sent: string[];
+  interrupts: string[];
+  kills: string[];
+  /** Feed one stdout line (an object; stringified through the real chunker). */
+  emit(payload: Record<string, unknown>): void;
+  /** Simulate process exit. */
+  exit(code: number | null): void;
+}
+
+function mkFakeFactory(opts?: { sendFailsForProcs?: number[] }): {
+  factory: typeof startClaudeProcess;
+  procs: FakeProcess[];
+} {
+  const procs: FakeProcess[] = [];
+  const factory: typeof startClaudeProcess = (procOpts) => {
+    const procIndex = procs.length;
+    const sendFails = opts?.sendFailsForProcs?.includes(procIndex) ?? false;
+    let exited = false;
+    let resolveDone: () => void;
+    const done = new Promise<void>((resolve) => {
+      resolveDone = resolve;
+    });
+    const chunker = createJsonlChunker();
+    const fake: FakeProcess = {
+      opts: procOpts,
+      sent: [],
+      interrupts: [],
+      kills: [],
+      emit(payload) {
+        for (const line of chunker.push(`${JSON.stringify(payload)}\n`)) {
+          procOpts.onLine(line);
+        }
+      },
+      exit(code) {
+        if (exited) return;
+        exited = true;
+        procOpts.onExit({ code, signal: null });
+        resolveDone!();
+      },
+      handle: {
+        conversationId: procOpts.conversationId,
+        claudeSessionId: procOpts.claudeSessionId,
+        pid: 1234,
+        alive: () => !exited,
+        sendUserMessage(content: string) {
+          if (exited || sendFails) return false;
+          fake.sent.push(content);
+          return true;
+        },
+        interrupt(requestId: string) {
+          if (exited) return false;
+          fake.interrupts.push(requestId);
+          return true;
+        },
+        kill(signal = "SIGTERM") {
+          fake.kills.push(signal);
+          fake.exit(null);
+        },
+        done,
+      },
+    };
+    procs.push(fake);
+    return fake.handle;
+  };
+  return { factory, procs };
+}
+
+function mkPersister(): { persister: PostPersister; events: BackendEvent[] } {
+  const events: BackendEvent[] = [];
+  const persister: PostPersister = {
+    enqueue(_conversationId, event) {
+      events.push(event);
+    },
+    recover() {},
+    async drain() {},
+    pendingCount: () => 0,
+  };
+  return { persister, events };
+}
+
+const init = { type: "system", subtype: "init", session_id: "sess-1", uuid: "u-init" };
+const assistantLine = {
+  type: "assistant",
+  message: { role: "assistant", content: [{ type: "text", text: "hi" }] },
+  uuid: "u-a",
+  session_id: "sess-1",
+};
+const resultLine = { type: "result", subtype: "success", uuid: "u-r", session_id: "sess-1" };
+
+function mkHub(factoryOpts?: { sendFailsForProcs?: number[] }) {
+  const { factory, procs } = mkFakeFactory(factoryOpts);
+  const { persister, events } = mkPersister();
+  const hub = createConversationHub({ postPersister: persister, startProcess: factory });
+  return { hub, procs, events };
+}
+
+function status(hub: { snapshot(): { conversations: { status: string }[] } }): string {
+  return hub.snapshot().conversations[0].status;
+}
+
+describe("conversationHub", () => {
+  it("spawns one long-lived process and reuses it across turns", async () => {
+    const { hub, procs } = mkHub();
+    const r1 = await hub.dispatch({ conversationId: "c1", prompt: "first", claudeSessionId: "sess-1" });
+    expect(r1.accepted).toBe(true);
+    expect(procs.length).toBe(1);
+    expect(procs[0].opts.sessionMode).toBe("new");
+    expect(procs[0].sent).toEqual(["first"]);
+
+    procs[0].emit(init);
+    procs[0].emit(assistantLine);
+    procs[0].emit(resultLine);
+    expect(status(hub)).toBe("completed");
+
+    const r2 = await hub.dispatch({ conversationId: "c1", prompt: "second", claudeSessionId: "sess-1" });
+    expect(r2.accepted).toBe(true);
+    expect(procs.length).toBe(1); // same process, no respawn
+    expect(procs[0].sent).toEqual(["first", "second"]);
+  });
+
+  it("resumes the session when the backend reports prior history", async () => {
+    const { hub, procs } = mkHub();
+    await hub.dispatch({
+      conversationId: "c1",
+      prompt: "continue",
+      claudeSessionId: "sess-1",
+      sessionHasHistory: true,
+    });
+    // No filesystem probe: the backend's word decides --resume vs --session-id
+    // (an existence check races snapshot restore on freshly-resumed sandboxes).
+    expect(procs[0].opts.sessionMode).toBe("resume");
+  });
+
+  it("accepts a dispatch mid-turn and stays running until the queued turn ends", async () => {
+    const { hub, procs } = mkHub();
+    await hub.dispatch({ conversationId: "c1", prompt: "one", claudeSessionId: "sess-1" });
+    procs[0].emit(init);
+    procs[0].emit(assistantLine);
+    expect(status(hub)).toBe("running");
+
+    const r = await hub.dispatch({ conversationId: "c1", prompt: "two", claudeSessionId: "sess-1" });
+    expect(r.accepted).toBe(true);
+    expect(procs[0].sent.length).toBe(2);
+
+    procs[0].emit(resultLine); // ends turn one; turn two still pending
+    expect(status(hub)).toBe("running");
+    procs[0].emit(init);
+    procs[0].emit(resultLine); // ends turn two
+    expect(status(hub)).toBe("completed");
+  });
+
+  it("goes busy again on a background-task re-invocation with no dispatch", async () => {
+    const { hub, procs } = mkHub();
+    await hub.dispatch({ conversationId: "c1", prompt: "go", claudeSessionId: "sess-1" });
+    procs[0].emit(init);
+    procs[0].emit(resultLine);
+    expect(status(hub)).toBe("completed");
+
+    // Task finishes later; the process re-invokes the agent: init arrives
+    // with no dispatch having happened.
+    procs[0].emit(init);
+    procs[0].emit(assistantLine);
+    expect(status(hub)).toBe("running");
+    procs[0].emit(resultLine);
+    expect(status(hub)).toBe("completed");
+  });
+
+  it("does not let a re-invocation's result consume a queued turn's pending count", async () => {
+    const { hub, procs } = mkHub();
+    await hub.dispatch({ conversationId: "c1", prompt: "go", claudeSessionId: "sess-1" });
+    procs[0].emit(init);
+    procs[0].emit(resultLine);
+
+    // Re-invocation running; user dispatches B mid-re-invocation.
+    procs[0].emit(init);
+    procs[0].emit(assistantLine);
+    await hub.dispatch({ conversationId: "c1", prompt: "queued", claudeSessionId: "sess-1" });
+
+    // The re-invocation's result must not make the conversation read idle
+    // while B is still queued on stdin.
+    procs[0].emit(resultLine);
+    expect(status(hub)).toBe("running");
+    expect(hub.hasPendingWork()).toBe(true);
+
+    procs[0].emit(init); // B starts
+    procs[0].emit(resultLine);
+    expect(status(hub)).toBe("completed");
+  });
+
+  it("releases the pending count when a dispatched turn fails before opening", async () => {
+    const { hub, procs } = mkHub();
+    await hub.dispatch({ conversationId: "c1", prompt: "go", claudeSessionId: "sess-1" });
+    expect(hub.hasPendingWork()).toBe(true);
+    // Early CLI failure: the turn's result arrives without any system:init.
+    // The pending count must not outlive it (the conversation would read
+    // busy forever while the client transcript reads idle).
+    procs[0].emit({ ...resultLine, subtype: "error_during_execution", is_error: true });
+    expect(hub.hasPendingWork()).toBe(false);
+    expect(status(hub)).toBe("completed");
+  });
+
+  it("reports pending work while a background task is outstanding", async () => {
+    const { hub, procs } = mkHub();
+    await hub.dispatch({ conversationId: "c1", prompt: "scrape", claudeSessionId: "sess-1" });
+    procs[0].emit(init);
+    procs[0].emit({ type: "system", subtype: "task_started", task_id: "t1", session_id: "sess-1", uuid: "u-t1" });
+    procs[0].emit(resultLine);
+    expect(status(hub)).toBe("completed");
+    expect(hub.hasPendingWork()).toBe(true); // task keeps the sandbox awake
+
+    // A notification with an explicitly in-progress status keeps it counted.
+    procs[0].emit({ type: "system", subtype: "task_notification", task_id: "t1", status: "running", session_id: "sess-1", uuid: "u-t2" });
+    expect(hub.hasPendingWork()).toBe(true);
+
+    procs[0].emit({ type: "system", subtype: "task_notification", task_id: "t1", status: "completed", session_id: "sess-1", uuid: "u-t3" });
+    expect(hub.hasPendingWork()).toBe(false);
+  });
+
+  it("persists the user turn at dispatch, before any process output", async () => {
+    const { hub, events } = mkHub();
+    await hub.dispatch({ conversationId: "c1", prompt: "hello", claudeSessionId: "sess-1" });
+    expect(events.length).toBe(1);
+    expect(events[0].kind).toBe("user");
+    expect(JSON.parse(events[0].rawJsonl).message.content).toBe("hello");
+  });
+
+  it("persists nothing and reports failure when the send cannot be completed", async () => {
+    const { hub, procs, events } = mkHub({ sendFailsForProcs: [0, 1] });
+    const r = await hub.dispatch({ conversationId: "c1", prompt: "hello", claudeSessionId: "sess-1" });
+    expect(r.accepted).toBe(false);
+    expect(r.reason).toBe("process_unavailable");
+    expect(procs.length).toBe(2); // one respawn attempt
+    expect(events.length).toBe(0); // no dangling user event for a failed dispatch
+  });
+
+  it("recovers a failed send by respawning once", async () => {
+    const { hub, procs, events } = mkHub({ sendFailsForProcs: [0] });
+    const r = await hub.dispatch({ conversationId: "c1", prompt: "hello", claudeSessionId: "sess-1" });
+    expect(r.accepted).toBe(true);
+    expect(procs.length).toBe(2);
+    expect(procs[1].sent).toEqual(["hello"]);
+    expect(events.length).toBe(1);
+  });
+
+  it("closes a crashed mid-turn process with a synthetic interrupted result and respawns on the next dispatch", async () => {
+    const { hub, procs, events } = mkHub();
+    await hub.dispatch({ conversationId: "c1", prompt: "go", claudeSessionId: "sess-1" });
+    procs[0].emit(init);
+    procs[0].emit(assistantLine);
+    procs[0].exit(137);
+
+    expect(status(hub)).toBe("errored");
+    const last = events[events.length - 1];
+    expect(last.kind).toBe("result");
+    expect(JSON.parse(last.rawJsonl).subtype).toBe("interrupted");
+
+    await hub.dispatch({ conversationId: "c1", prompt: "again", claudeSessionId: "sess-1" });
+    expect(procs.length).toBe(2);
+    expect(procs[1].opts.claudeSessionId).toBe("sess-1");
+    expect(procs[1].sent).toEqual(["again"]);
+  });
+
+  it("cancels via interrupt and reads the turn-end as cancelled", async () => {
+    const { hub, procs } = mkHub();
+    await hub.dispatch({ conversationId: "c1", prompt: "go", claudeSessionId: "sess-1" });
+    procs[0].emit(init);
+    procs[0].emit(assistantLine);
+
+    await hub.cancel("c1");
+    expect(procs[0].interrupts.length).toBe(1);
+    expect(procs[0].kills.length).toBe(0); // no escalation needed
+
+    procs[0].emit({ ...resultLine, subtype: "error_during_execution", is_error: true });
+    expect(status(hub)).toBe("cancelled");
+    expect(hub.hasPendingWork()).toBe(false);
+
+    // Process survived the cancel and accepts the next turn.
+    await hub.dispatch({ conversationId: "c1", prompt: "next", claudeSessionId: "sess-1" });
+    expect(procs.length).toBe(1);
+    expect(procs[0].sent).toEqual(["go", "next"]);
+  });
+
+  it("stays busy after a cancel issued before the turn produced output", async () => {
+    const { hub, procs } = mkHub();
+    await hub.dispatch({ conversationId: "c1", prompt: "go", claudeSessionId: "sess-1" });
+    // No output yet: busy comes solely from the pending dispatched turn.
+    await hub.cancel("c1");
+    expect(procs[0].interrupts.length).toBe(1);
+    // The cancel must not zero the pending count — otherwise the escalation
+    // path would read the conversation as already-interrupted and never fire.
+    expect(status(hub)).toBe("running");
+    expect(hub.hasPendingWork()).toBe(true);
+  });
+
+  it("flushes queued turns when a cancel's result arrives, even if a dispatch raced it", async () => {
+    const { hub, procs, events } = mkHub();
+    await hub.dispatch({ conversationId: "c1", prompt: "go", claudeSessionId: "sess-1" });
+    procs[0].emit(init);
+    procs[0].emit(assistantLine);
+
+    await hub.cancel("c1");
+    // A new message races the interrupt; it must not relabel the cancelled
+    // turn as completed, and its queued (possibly CLI-dropped) message gets
+    // flushed so the transcript can't dangle.
+    await hub.dispatch({ conversationId: "c1", prompt: "raced", claudeSessionId: "sess-1" });
+
+    procs[0].emit({ ...resultLine, subtype: "error_during_execution", is_error: true });
+    expect(status(hub)).toBe("cancelled");
+    const last = events[events.length - 1];
+    expect(last.kind).toBe("result");
+    expect(JSON.parse(last.rawJsonl).subtype).toBe("interrupted");
+    expect(hub.hasPendingWork()).toBe(false);
+  });
+
+  it("ignores cancel when idle", async () => {
+    const { hub, procs } = mkHub();
+    await hub.dispatch({ conversationId: "c1", prompt: "go", claudeSessionId: "sess-1" });
+    procs[0].emit(init);
+    procs[0].emit(resultLine);
+    await hub.cancel("c1");
+    expect(procs[0].interrupts.length).toBe(0);
+    expect(procs[0].kills.length).toBe(0);
+  });
+});

--- a/packages/lesswrong/unitTests/researchConversationEventFormat.tests.ts
+++ b/packages/lesswrong/unitTests/researchConversationEventFormat.tests.ts
@@ -13,28 +13,70 @@ describe("research conversation event formatting", () => {
   });
 
   describe("isTurnInFlight", () => {
+    const now = Date.parse("2026-06-09T12:00:00Z");
+    const recent = new Date(now - 10_000).toISOString();
+    const stale = new Date(now - (60 * 60 * 1000)).toISOString();
+
+    const user = { kind: "user", payload: {}, createdAt: recent };
+    const assistant = { kind: "assistant", payload: {} };
+    const result = { kind: "result", payload: {} };
+    const flushResult = { kind: "result", payload: { type: "result", subtype: "interrupted" } };
+    const errorEvent = { kind: "error", payload: {} };
+    const init = { kind: "system", payload: { type: "system", subtype: "init" } };
+    const taskNotification = { kind: "system", payload: { type: "system", subtype: "task_notification" } };
+
     it("is false for an empty transcript", () => {
-      expect(isTurnInFlight([])).toBe(false);
+      expect(isTurnInFlight([], now)).toBe(false);
     });
 
     it("is true for a user turn with no result yet", () => {
-      expect(isTurnInFlight([{ kind: "user" }, { kind: "assistant" }])).toBe(true);
+      expect(isTurnInFlight([user, assistant], now)).toBe(true);
     });
 
-    it("is false once every user turn has a matching result", () => {
-      expect(isTurnInFlight([{ kind: "user" }, { kind: "assistant" }, { kind: "result" }])).toBe(false);
+    it("is false once the turn has its result", () => {
+      expect(isTurnInFlight([user, init, assistant, result], now)).toBe(false);
     });
 
     it("is true again when a later turn opens", () => {
-      expect(isTurnInFlight([
-        { kind: "user" },
-        { kind: "result" },
-        { kind: "user" },
-      ])).toBe(true);
+      expect(isTurnInFlight([user, init, result, user], now)).toBe(true);
     });
 
-    it("ignores non-user/result kinds", () => {
-      expect(isTurnInFlight([{ kind: "thinking" }, { kind: "tool_use" }])).toBe(false);
+    it("is true during a background-task re-invocation (no user event)", () => {
+      expect(isTurnInFlight([user, init, result, taskNotification, init, assistant], now)).toBe(true);
+      expect(isTurnInFlight([user, init, result, taskNotification, init, assistant, result], now)).toBe(false);
+    });
+
+    it("does not drift when results outnumber user turns", () => {
+      // A re-invocation's extra result must not mask the next real turn.
+      expect(isTurnInFlight([user, init, result, init, assistant, result, user], now)).toBe(true);
+    });
+
+    it("treats non-init system events between turns as idle", () => {
+      expect(isTurnInFlight([user, init, result, taskNotification], now)).toBe(false);
+    });
+
+    it("keeps a recent queued user turn in flight past the running turn's result", () => {
+      // Message B dispatched mid-turn-A is persisted before A's result; the
+      // turn is still queued until B's own init arrives.
+      expect(isTurnInFlight([user, init, assistant, user, assistant, result], now)).toBe(true);
+      expect(isTurnInFlight([user, init, assistant, user, assistant, result, init], now)).toBe(true);
+    });
+
+    it("ages out an unstarted user turn so legacy transcripts can't wedge", () => {
+      // Old per-turn-supervisor conversations don't reliably have an init
+      // after every user event; a stale unstarted user turn reads idle.
+      const staleUser = { kind: "user", payload: {}, createdAt: stale };
+      expect(isTurnInFlight([staleUser, assistant, result], now)).toBe(false);
+    });
+
+    it("treats a synthetic interrupted result as flushing queued user turns", () => {
+      expect(isTurnInFlight([user, flushResult], now)).toBe(false);
+    });
+
+    it("does not count error events as turn activity", () => {
+      // Matches the supervisor: an out-of-turn error line must not wedge the
+      // conversation as busy forever.
+      expect(isTurnInFlight([user, init, result, errorEvent], now)).toBe(false);
     });
   });
 


### PR DESCRIPTION
Written by Claude
--------
## What

Fixes the production incident in conversation `oS9wN8dsNo8gdvZau` (project `qiLZ5inAqnuFxxQ2y`) where an agent permanently lost the turns that ran while its background scrape was pending.

**Root cause**: the per-turn supervisor treated the `result` line as turn-end while a background Bash task kept the `claude -p` process alive. User turns dispatched in the interim spawned concurrent `--resume` processes of the same session; when the task finished, the original process continued from its stale in-memory context and appended to the session file chained to its own pre-gap tail — forking the parentUuid chain and orphaning the interim turns from every future resume.

**Fix**: one long-lived `claude` stream-json process per conversation, stdin held open.
- Turns are fed as stream-json user messages; mid-turn sends queue natively (the 409 "already running" rejection is gone); background-task re-invocations share the same context as user turns — the bug class is structurally impossible.
- Cancel via the stream-json `interrupt` control request (graceful, session-consistent), with SIGTERM/SIGKILL escalation defused once any result lands.
- Busy state derives from the event stream (`system:init`-consumes-pending + activity-since-last-result), with an init-less `result` releasing its pending count. Pending background tasks keep the sandbox alive via the heartbeat and block environment saves.
- Session ids assigned deterministically at creation (uuidv5 of conversation id); `--resume` vs `--session-id` decided from backend-known history (a supervisor-side fs probe races lazy snapshot restore — observed in dev as `Session ID already in use`).
- Per-conversation context via `--append-system-prompt` instead of CLAUDE.md template-filling.
- Turn-in-flight derivation unified across supervisor / client / SQL via `lib/research/turnActivity.ts` (with a time-bounded queued-turn clause client-side; unbounded would wedge pre-init-era transcripts, verified against prod data).
- Model → `claude-fable-5`; Claude Code pinned at 2.1.170, installed into baselines and reconciled in-place at every sandbox launch (with post-install verification and stop-on-failure so a failed reconcile can't strand a supervisorless sandbox).

## Testing

- 75 unit tests passing (new suites for the conversation hub state machine and the in-flight derivation); `yarn tsc` clean.
- Two `/code-review` passes (7-angle + follow-up); all confirmed findings fixed, accepted-risk items documented in review threads.
- Manual browser testing on dev: basic round trip; mid-turn queueing; **the incident scenario** (background task + interim turn + re-invocation remembering both); cancel + immediate re-send surviving the escalation window; env-save blocked during pending tasks; legacy May-era conversation resumed with full memory after in-place CLI upgrade (2.1.160 → 2.1.170), answering on `claude-fable-5` under its original session id.

## Deploy notes

- No DB migrations. Backwards compatible with existing conversations (warm, stopped, and expired-snapshot states) and saved environments.
- After (or before) deploy, rebuild the **prod** baseline snapshots once per runtime: `yarn repl prod lw packages/lesswrong/server/scripts/buildResearchSandboxSnapshot.ts 'buildResearchSandboxSnapshot({ runtime: "node24" })'` (and `python3.13`). Not strictly required — launch-time reconcile upgrades stale baselines — but fresh provisions pay a ~30-60s npm install until rebuilt.
- Warm sandboxes keep running the old supervisor until they cycle (≤30min idle / 5h cap); mid-turn sends to those flash a send error during that window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1215574723837778) by [Unito](https://www.unito.io)
