### PR TITLE
Fix agent-API quote anchors in ordered lists

### DIFF
--- a/app/api/agent/mapMarkdownToLexical.ts
+++ b/app/api/agent/mapMarkdownToLexical.ts
@@ -3,6 +3,7 @@ import {
   $getNodeByKey,
   $isDecoratorNode,
   $isElementNode,
+  $isLineBreakNode,
   $isTextNode,
   type LexicalEditor,
   type LexicalNode,
@@ -301,6 +302,7 @@ function alignNormalizedQuoteInRaw(
 // the following segment — hence the digit-safety of the `$…$` form — is known.
 type QuoteSegment =
   | { kind: "text", key: string, text: string }
+  | { kind: "linebreak", key: string, text: string }
   | { kind: "math", key: string, text: string, equation: string, inline: boolean };
 
 function findTextRangeInNodeByPlainQuote(
@@ -328,6 +330,15 @@ function findTextRangeInNodeByPlainQuote(
         kind: "text",
         key: currentNode.getKey(),
         text: currentNode.getTextContent(),
+      });
+      return;
+    }
+
+    if ($isLineBreakNode(currentNode)) {
+      segments.push({
+        kind: "linebreak",
+        key: currentNode.getKey(),
+        text: "\n",
       });
       return;
     }

--- a/packages/lesswrong/unitTests/commentOnDraftQuoteMatch.tests.ts
+++ b/packages/lesswrong/unitTests/commentOnDraftQuoteMatch.tests.ts
@@ -79,6 +79,39 @@ describe("commentOnDraft quote matching", () => {
     expect(getMarkedTextContent(editor, markId)).toBe("This is a test post.");
   });
 
+  it("attaches a mark when quote is within a non-first ordered list item", async () => {
+    const editor = await setupEditorWithContent(
+      "1. First item.\n2. Second item has the exact quoted phrase inside it."
+    );
+    const markId = randomId();
+    const { quoteFoundInDocument, markCreated } = await attachCommentMark(
+      editor,
+      "exact quoted phrase",
+      markId,
+    );
+
+    expect(quoteFoundInDocument).toBe(true);
+    expect(markCreated).toBe(true);
+    expect(getAllMarkIds(editor)).toContain(markId);
+    expect(getMarkedTextContent(editor, markId)).toBe("exact quoted phrase");
+  });
+
+  it("attaches a mark when structured quote includes an ordered list continuation paragraph", async () => {
+    const editor = await setupEditorWithContent(
+      "1. First item.\n\n   Continuation paragraph has the exact quoted phrase inside it.\n2. Second item."
+    );
+    const markId = randomId();
+    const { quoteFoundInDocument, markCreated } = await attachCommentMark(
+      editor,
+      "1. First item.\n\n   Continuation paragraph has the exact quoted phrase",
+      markId,
+    );
+
+    expect(quoteFoundInDocument).toBe(true);
+    expect(markCreated).toBe(true);
+    expect(getAllMarkIds(editor)).toContain(markId);
+  });
+
   it("attaches a mark when quote spans a link boundary", async () => {
     // Quote starts in plain text, crosses into a link's visible text, and
     // exits back into plain text.


### PR DESCRIPTION
Slack thread: https://lightconeinfrastructure.slack.com/archives/C0AJZV5RDL4/p1778673308308769
Github diff: https://github.com/ForumMagnum/ForumMagnum/compare/master...cursor/bot-task-discovery-da75
Preview deployment: https://baserates-test-git-cursor/bot-task-discovery-da75-lesswrong.vercel.app


