### PR TITLE
Make display equations horizontally scrollable

### DIFF
--- a/packages/lesswrong/components/contents/ContentItemBody.tsx
+++ b/packages/lesswrong/components/contents/ContentItemBody.tsx
@@ -35,9 +35,14 @@ type PassedThroughContentItemBodyProps = Pick<ContentItemBodyProps, "description
 export const rootTagShouldBeHorizontallyScrollable = (tagName: string, attribs: Record<string, AnyBecauseHard>): boolean => {
   if (['p','div','table','figure'].includes(tagName)) {
     return true;
+  } else if (tagName === "span") {
+    const classes = (attribs.className ?? "").split(" ");
+    return classes.includes("math-tex");
+  } else if (tagName === 'mjx-container') {
+    return attribs.display === 'true';
+  } else {
+    return false;
   }
-
-  return tagName === 'mjx-container' && attribs.display === 'true';
 }
 
 type SubstitutionsAttr = Array<{substitutionIndex: number, isSplitContinuation: boolean, invertColors?: boolean}>;

--- a/packages/lesswrong/components/contents/ContentItemBody.tsx
+++ b/packages/lesswrong/components/contents/ContentItemBody.tsx
@@ -32,6 +32,14 @@ type PassedThroughContentItemBodyProps = Pick<ContentItemBodyProps, "description
   bodyRef: React.RefObject<HTMLDivElement|null>,
 }
 
+export const rootTagShouldBeHorizontallyScrollable = (tagName: string, attribs: Record<string, AnyBecauseHard>): boolean => {
+  if (['p','div','table','figure'].includes(tagName)) {
+    return true;
+  }
+
+  return tagName === 'mjx-container' && attribs.display === 'true';
+}
+
 type SubstitutionsAttr = Array<{substitutionIndex: number, isSplitContinuation: boolean, invertColors?: boolean}>;
 
 /**
@@ -310,7 +318,7 @@ const ContentItemBodyInner = ({parsedHtml, passedThroughProps, root=false}: {
         );
       }
 
-      if (root && ['p','div','table','figure'].includes(TagName)) {
+      if (root && rootTagShouldBeHorizontallyScrollable(TagName, attribs)) {
         return <MaybeScrollableBlock TagName={TagName} attribs={attribs} bodyRef={passedThroughProps.bodyRef}>
           {result}
         </MaybeScrollableBlock>

--- a/packages/lesswrong/themes/stylePiping.ts
+++ b/packages/lesswrong/themes/stylePiping.ts
@@ -524,6 +524,9 @@ const baseBodyStyles = (theme: ThemeType) => ({
     textAlign: 'right',
     minWidth: 25,
   },
+  '& span.math-tex': {
+    display: "inline-block",
+  },
   '& code': {
     ...theme.typography.code
   },

--- a/packages/lesswrong/unitTests/contentItemBodyMathScroll.tests.ts
+++ b/packages/lesswrong/unitTests/contentItemBodyMathScroll.tests.ts
@@ -1,0 +1,18 @@
+import { rootTagShouldBeHorizontallyScrollable } from "@/components/contents/ContentItemBody";
+
+describe("rootTagShouldBeHorizontallyScrollable", () => {
+  it("wraps root-level MathJax display equations", () => {
+    expect(rootTagShouldBeHorizontallyScrollable("mjx-container", { display: "true" })).toBe(true);
+  });
+
+  it("does not wrap inline MathJax equations", () => {
+    expect(rootTagShouldBeHorizontallyScrollable("mjx-container", { display: "false" })).toBe(false);
+    expect(rootTagShouldBeHorizontallyScrollable("mjx-container", {})).toBe(false);
+  });
+
+  it("preserves existing scrollable root tags", () => {
+    expect(rootTagShouldBeHorizontallyScrollable("p", {})).toBe(true);
+    expect(rootTagShouldBeHorizontallyScrollable("table", {})).toBe(true);
+    expect(rootTagShouldBeHorizontallyScrollable("figure", {})).toBe(true);
+  });
+});


### PR DESCRIPTION
Slack thread: https://lworg.slack.com/archives/CJUN2UAFN/p1780104202989569
Github diff: https://github.com/ForumMagnum/ForumMagnum/compare/master...mobile-math-scroll
Preview deployment: https://baserates-test-git-mobile-math-scroll-lesswrong.vercel.app

The LLM's first attempt was unsuccessful, but I fixed it properly afterwards in the same branch.

Top-level elements in posts are checked for eligibility and, if eligible, wrapped in <MaybeScrollableBlock>, which checks their width and, if it's too wide to fit it on screen, adds horizontal scroll UI. Post `xiTBpBDwubnr4MLRe` had a top-level element

```
<span class="math-tex">
  <mjx-container ...>...</mjx-container>
</span>
```

This was likely introduced in a mathjax version upgrade, or something. There were two problems. First, the `span` isn't a block element, so it wasn't treated as eligible. The previous LLM commit checked for tagName mjx-container, but that was incorrect because it's the wrapper that gets checked, which is a span. And second, the <span> was `display:inline`, causing its width to be capped at the container width (so we couldn't detect the overflow).

Fix by making span.math-tex display:inline-block, and root .math-tex elements eligible for horiz scrolling.