### PR TITLE
Fix incorrect truncation/ellipsization of coauthor names in ultrafeed

### DIFF
--- a/packages/lesswrong/components/ultraFeed/UsersNameWithModal.tsx
+++ b/packages/lesswrong/components/ultraFeed/UsersNameWithModal.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import classNames from 'classnames';
 import UsersName from '../users/UsersName';
 import UltraFeedUserCard from '../ultraFeed/UltraFeedUserCard';
-import HoverOver from '../common/HoverOver';
+import LWTooltip from '../common/LWTooltip';
 import { userGetDisplayName, userGetProfileUrl } from '../../lib/collections/users/helpers';
 import { Link } from '../../lib/reactRouterWrapper';
 import { AnalyticsContext } from '../../lib/analyticsEvents';
@@ -94,13 +94,14 @@ const UsersNameWithModal = ({
   return (
     <AnalyticsContext pageElementContext="ultraFeedUserName" userIdDisplayed={user._id}>
       <span {...eventHandlers}>
-        <HoverOver
+        <LWTooltip
           title={<UltraFeedUserCard user={user} />}
           placement={tooltipPlacement}
           clickable
           disabledOnMobile
           flip
           popperClassName={classes.cardWrapper}
+          inlineBlock={false}
         >
           <Link
             to={profileUrl}
@@ -110,7 +111,7 @@ const UsersNameWithModal = ({
             {displayName}
             {showSubscribedIcon && <SubscriptionsIcon className={classes.subscribeIcon} />}
           </Link>
-        </HoverOver>
+        </LWTooltip>
       </span>
     </AnalyticsContext>
   );


### PR DESCRIPTION
This was caused by LWTooltip wrapping the username in an inline-block element, which interacted badly with the flexbox and overflow rules.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1215581025351512) by [Unito](https://www.unito.io)
