### PR TITLE
Fix duplicate empty figcaption in lexical image export

### DIFF
--- a/packages/lesswrong/components/lexical/nodes/ImageNode.tsx
+++ b/packages/lesswrong/components/lexical/nodes/ImageNode.tsx
@@ -12,7 +12,6 @@ import type {
   DOMExportOutput,
   BaseSelection,
   EditorConfig,
-  LexicalEditor,
   LexicalNode,
   LexicalUpdateJSON,
   NodeKey,
@@ -26,10 +25,7 @@ import {$generateNodesFromDOM} from '@lexical/html';
 import {
   $applyNodeReplacement,
   $createParagraphNode,
-  $extendCaretToRange,
-  $getChildCaret,
   $getEditor,
-  $isElementNode,
   $setSelection,
   DecoratorNode,
   ElementNode,
@@ -105,6 +101,10 @@ export function $isCaptionNodeEmpty(node: ImageCaptionNode): boolean {
   return node.getTextContent().trim().length === 0;
 }
 
+function figcaptionHasContent(figcaption: HTMLElement): boolean {
+  return (figcaption.textContent ?? '').trim().length > 0;
+}
+
 export class ImageCaptionNode extends ElementNode {
   static getType(): string {
     return 'image-caption';
@@ -139,6 +139,9 @@ export class ImageCaptionNode extends ElementNode {
   }
 
   exportDOM(): DOMExportOutput {
+    if (this.isEmpty()) {
+      return {element: null};
+    }
     const element = document.createElement('figcaption');
     element.className = 'image-caption-container';
     return {element};
@@ -335,7 +338,7 @@ export class ImageNode extends ElementNode {
     return node;
   }
 
-  exportDOM(editor: LexicalEditor): DOMExportOutput {
+  exportDOM(): DOMExportOutput {
     const imgElement = document.createElement('img');
     // Set loading="lazy" BEFORE src so the browser defers the fetch until the
     // element is near the viewport. Since exportDOM elements live in a
@@ -365,11 +368,8 @@ export class ImageNode extends ElementNode {
     figureElement.setAttribute('class', classNames.join(' '));
     figureElement.appendChild(imgElement);
 
-    const figcaptionElement = buildCaptionElement(editor, this.getCaptionNode());
-    if (figcaptionElement) {
-      figureElement.appendChild(figcaptionElement);
-    }
-
+    // The figcaption is contributed by the ImageCaptionNode child during the
+    // normal export traversal; appending one here too would duplicate it.
     return {element: figureElement};
   }
 
@@ -393,7 +393,11 @@ export class ImageNode extends ElementNode {
                 return childNodes;
               }
 
-              const figcaption = node.querySelector('figcaption');
+              // Documents saved while exportDOM duplicated captions contain a
+              // spurious empty figcaption before the real one, so prefer the
+              // first figcaption with content.
+              const figcaptions = Array.from(node.querySelectorAll('figcaption'));
+              const figcaption = figcaptions.find(figcaptionHasContent) ?? figcaptions[0] ?? null;
               const figureElement = node as HTMLElement;
               const figureClassList = figureElement.classList;
               const hasCkImageClass = figureClassList.contains('image');
@@ -656,31 +660,6 @@ export class ImageNode extends ElementNode {
   ): boolean {
     return false;
   }
-}
-
-function buildCaptionElement(
-  editor: LexicalEditor,
-  captionNode: ImageCaptionNode | null,
-): HTMLElement | null {
-  if (!captionNode || captionNode.isEmpty()) {
-    return null;
-  }
-  const figcaptionElement = document.createElement('figcaption');
-  figcaptionElement.className = 'image-caption-container';
-  const fragment = document.createDocumentFragment();
-  for (const child of captionNode.getChildren()) {
-    const exportOutput = child.exportDOM(editor) as DOMExportOutput;
-    const childElement = exportOutput.element;
-    if (!childElement) {
-      continue;
-    }
-    const appended = exportOutput.after ? exportOutput.after(childElement) : childElement;
-    if (appended) {
-      fragment.appendChild(appended);
-    }
-  }
-  figcaptionElement.appendChild(fragment);
-  return figcaptionElement;
 }
 
 export function $createImageNode({

--- a/packages/lesswrong/unitTests/imageCaptionFigcaption.tests.ts
+++ b/packages/lesswrong/unitTests/imageCaptionFigcaption.tests.ts
@@ -1,0 +1,68 @@
+import { $getRoot, type LexicalEditor } from "lexical";
+import { $generateHtmlFromNodes } from "@lexical/html";
+import { withDomGlobals } from "@/server/editor/withDomGlobals";
+import { $isImageNode, type ImageNode } from "@/components/lexical/nodes/ImageNode";
+import { setupEditorWithHtml, walkLexicalNodes } from "./lexicalTestHelpers";
+
+const IMG_SRC = "https://example.com/image.png";
+
+function exportHtml(editor: LexicalEditor): string {
+  let html = "";
+  editor.getEditorState().read(() => {
+    html = withDomGlobals(() => $generateHtmlFromNodes(editor, null));
+  });
+  return html;
+}
+
+function countFigcaptions(html: string): number {
+  return (html.match(/<figcaption/g) ?? []).length;
+}
+
+function getFirstImageCaptionText(editor: LexicalEditor): string | null {
+  let captionText: string | null = null;
+  editor.getEditorState().read(() => {
+    walkLexicalNodes($getRoot(), (node) => {
+      if (captionText === null && $isImageNode(node)) {
+        captionText = (node as ImageNode).getCaptionNode()?.getTextContent() ?? null;
+      }
+    });
+  });
+  return captionText;
+}
+
+describe("image caption figcaption export/import", () => {
+  it("exports exactly one figcaption for a captioned image", async () => {
+    const editor = await setupEditorWithHtml(
+      `<figure class="image"><img src="${IMG_SRC}" alt=""><figcaption><p>My caption</p></figcaption></figure>`
+    );
+
+    const html = exportHtml(editor);
+    expect(countFigcaptions(html)).toBe(1);
+    expect(html).toContain("My caption");
+  });
+
+  it("exports no figcaption when the caption is empty", async () => {
+    const editor = await setupEditorWithHtml(
+      `<figure class="image"><img src="${IMG_SRC}" alt=""><figcaption><p></p></figcaption></figure>`
+    );
+
+    const html = exportHtml(editor);
+    expect(html).toContain("<figure");
+    expect(countFigcaptions(html)).toBe(0);
+  });
+
+  it("recovers the real caption from HTML with a spurious empty figcaption", async () => {
+    const editor = await setupEditorWithHtml(
+      `<figure class="image"><img src="${IMG_SRC}" alt="">` +
+      `<figcaption class="image-caption-container"><p></p></figcaption>` +
+      `<figcaption class="image-caption-container"><p>Real caption</p></figcaption>` +
+      `</figure>`
+    );
+
+    expect(getFirstImageCaptionText(editor)).toBe("Real caption");
+
+    const html = exportHtml(editor);
+    expect(countFigcaptions(html)).toBe(1);
+    expect(html).toContain("Real caption");
+  });
+});


### PR DESCRIPTION
Written by Claude
------
## Summary

New lexical posts were publishing a spurious empty `<figcaption><p></p></figcaption>` before the real figcaption on every captioned image (reported on [this post](https://www.lesswrong.com/posts/Bxju8Fmpo2eW4oj9t/how-far-apart-does-a-model-think-its-tokens-are)). The duplication was baked into the stored HTML at save time.

## Root cause

Commit 763c3e7805 (2026-01-16) converted `ImageNode` from a `DecoratorNode` to an `ElementNode` with an `ImageCaptionNode` child, but kept the old manual figcaption construction in `exportDOM`. The caption was then exported twice:

1. The manual `buildCaptionElement` path did a *shallow* export (calling `child.exportDOM()` on caption paragraphs without recursing into their text children), producing the empty `<figcaption><p></p></figcaption>`.
2. Lexical's standard `$appendNodesToHTML` traversal then exported the `ImageCaptionNode` child correctly, producing the real figcaption.

## Changes

- **Export:** delete `buildCaptionElement` and the manual append; the child traversal handles the figcaption. `ImageCaptionNode.exportDOM` now returns `{element: null}` when the caption is empty, preserving the prior "no figcaption for empty captions" behavior.
- **Import:** the figure conversion used `querySelector('figcaption')`, which on already-corrupted documents grabs the *empty* figcaption and silently drops the real caption text on re-edit. It now prefers the first figcaption with text content (falling back to the first), so affected posts self-heal on their next save instead of losing captions.
- Remove unused imports flagged in the same file.

## Testing

New unit tests (`imageCaptionFigcaption.tests.ts`) cover: single-figcaption export, empty-caption suppression, and caption recovery from corrupted HTML. All three fail against the pre-fix code and pass with the fix. `yarn tsc` is clean.

## Not included (possible follow-up)

Published revisions saved since ~2026-01-16 still contain the empty figcaption in stored HTML; the import fix prevents data loss on re-edit, but a migration stripping text-empty figcaptions from affected lexical revisions would be needed to clean up display on already-published posts that aren't re-saved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1215647468394194) by [Unito](https://www.unito.io)
