### PR TITLE
Narrow agent suggestions in text-index space, making it mark-aware

### DIFF
--- a/app/api/agent/applyEditAtSelection.ts
+++ b/app/api/agent/applyEditAtSelection.ts
@@ -18,6 +18,11 @@ import {
 } from "./mapMarkdownToLexical";
 import { findMathSpansInMarkdown } from "@/lib/utils/mathTokens";
 import { renderAgentMarkdownToHtml, splitParagraphAtDisplayMath } from "./editorAgentUtil";
+import {
+  normalizeTracked,
+  resolveRawIndexToPoint,
+  type LocatedQuoteRange,
+} from "./textIndexQuoteLocator";
 import type MarkdownIt from "markdown-it";
 
 export interface FinalSelection {
@@ -43,8 +48,9 @@ export function $computeFinalSelection(
   focus: MarkdownSelectionPoint,
   quote: string,
   replacement: string,
+  range: LocatedQuoteRange | undefined,
 ): FinalSelection {
-  const narrowing = $computeNarrowing(anchor, focus, quote, replacement);
+  const narrowing = $computeNarrowing(anchor, focus, quote, replacement, range);
   if (!narrowing || narrowing.quote.length === 0) {
     return { anchor, focus, narrowedQuote: quote, narrowedReplacement: replacement };
   }
@@ -342,22 +348,32 @@ export function $computeNarrowing(
   focus: MarkdownSelectionPoint,
   quote: string,
   replacement: string,
+  range: LocatedQuoteRange | undefined,
 ): {
   anchor: MarkdownSelectionPoint
   focus: MarkdownSelectionPoint
   quote: string
   replacement: string
 } | null {
-  // `$collectPlainTextInRange` and `$advancePoint`/`$retreatPoint` walk
-  // sibling nodes, so across a block boundary they would silently collect
-  // the wrong text; cross-block edits use the full (un-narrowed) range.
+  if (!range) return null;
+  // Narrowed replacements are rendered as inline nodes, which assumes a
+  // single block's inline context; cross-block edits use the full range.
   if (!$pointsShareBlock(anchor, focus)) return null;
-  const matchedPlainText = $collectPlainTextInRange(anchor, focus);
-  if (matchedPlainText === null) return null;
+
+  const matchedText = range.projection.text.slice(range.rawStart, range.rawEnd);
+  const quoteMapping = buildPlainToMarkdownMapping(quote);
+
+  // Narrowing advances document positions by quote plain-text character
+  // counts, which is only sound when the two texts correspond 1:1 — true
+  // whenever the quote was taken verbatim from the read API. Quotes that
+  // diverge from the document in length (typographic folding, marker-blind
+  // matches over literal markers, spans across math tokens or footnote
+  // references) fall back to the full range.
+  if (quoteMapping.plainText.length !== matchedText.length) return null;
 
   // If the visible text is identical, the change is purely structural
   // (formatting, link URLs, etc.) — show the full range.
-  if (markdownQuoteToPlainText(replacement) === matchedPlainText) return null;
+  if (markdownQuoteToPlainText(replacement) === matchedText) return null;
 
   // Compare at the markdown level so that formatting/syntax changes
   // prevent narrowing past them. Then pull each boundary out of any math
@@ -369,15 +385,28 @@ export function $computeNarrowing(
 
   // Convert markdown offsets to plain-text character counts using the
   // quote's mapping (which has full regex context for links, math, etc.)
-  const quoteMapping = buildPlainToMarkdownMapping(quote);
   const ptAdvance = countPlainTextInPrefix(quoteMapping.toMarkdown, mdPrefixLen);
   const ptRetreat = countPlainTextInSuffix(quoteMapping.toMarkdown, quote.length, mdSuffixLen);
 
   if (ptAdvance === 0 && ptRetreat === 0) return null;
-  if (ptAdvance + ptRetreat > matchedPlainText.length) return null;
+  if (ptAdvance + ptRetreat > matchedText.length) return null;
 
-  const narrowedAnchor = $advancePoint(anchor, ptAdvance);
-  const narrowedFocus = $retreatPoint(focus, ptRetreat);
+  // Equal overall lengths still allow positional drift between the two
+  // sides (e.g. whitespace collapsed at different offsets). Verify that the
+  // narrowed slices agree under the matcher's own normalization before
+  // trusting the boundaries.
+  const narrowedDocText = matchedText.slice(ptAdvance, matchedText.length - ptRetreat);
+  const narrowedQuotePlain = quoteMapping.plainText.slice(ptAdvance, quoteMapping.plainText.length - ptRetreat);
+  if (normalizeTracked(narrowedDocText).text !== normalizeTracked(narrowedQuotePlain).text) return null;
+
+  const anchorIndex = range.rawStart + ptAdvance;
+  const focusIndex = range.rawEnd - ptRetreat;
+  const narrowedAnchor = resolveRawIndexToPoint(range.projection, anchorIndex, false);
+  // A narrowing that consumes the whole quote is a pure insertion: resolve
+  // the collapsed boundary once so both points are identical.
+  const narrowedFocus = anchorIndex === focusIndex
+    ? narrowedAnchor
+    : resolveRawIndexToPoint(range.projection, focusIndex, true);
   if (!narrowedAnchor || !narrowedFocus) return null;
 
   return {
@@ -472,94 +501,6 @@ function countPlainTextInSuffix(toMarkdown: number[], markdownLength: number, md
 }
 
 /**
- * Collect the plain text content between anchor and focus by walking
- * sibling text nodes. Must be called inside a Lexical read/update context.
- */
-function $collectPlainTextInRange(
-  anchor: MarkdownSelectionPoint,
-  focus: MarkdownSelectionPoint,
-): string | null {
-  if (anchor.type !== "text" || focus.type !== "text") return null;
-
-  const anchorNode = $getNodeByKey(anchor.key);
-  if (!$isTextNode(anchorNode)) return null;
-
-  if (anchor.key === focus.key) {
-    return anchorNode.getTextContent().slice(anchor.offset, focus.offset);
-  }
-
-  let result = anchorNode.getTextContent().slice(anchor.offset);
-  let current: LexicalNode | null = anchorNode.getNextSibling();
-  while (current) {
-    if (current.getKey() === focus.key) {
-      result += current.getTextContent().slice(0, focus.offset);
-      break;
-    }
-    result += current.getTextContent();
-    current = current.getNextSibling();
-  }
-  return result;
-}
-
-/**
- * Advance a text selection point forward by `chars` characters, crossing
- * into subsequent sibling nodes as needed.
- */
-function $advancePoint(
-  point: MarkdownSelectionPoint,
-  chars: number,
-): MarkdownSelectionPoint | null {
-  if (chars === 0) return point;
-  if (point.type !== "text") return null;
-
-  let remaining = chars;
-  let currentNode: LexicalNode | null = $getNodeByKey(point.key);
-  if (!currentNode) return null;
-  let currentOffset = point.offset;
-
-  while (remaining > 0) {
-    const textLen = currentNode.getTextContent().length;
-    const available = textLen - currentOffset;
-    if (remaining <= available) {
-      return { key: currentNode.getKey(), offset: currentOffset + remaining, type: "text" };
-    }
-    remaining -= available;
-    currentNode = currentNode.getNextSibling();
-    if (!currentNode) return null;
-    currentOffset = 0;
-  }
-  return { key: currentNode.getKey(), offset: currentOffset, type: "text" };
-}
-
-/**
- * Retreat a text selection point backward by `chars` characters, crossing
- * into preceding sibling nodes as needed.
- */
-function $retreatPoint(
-  point: MarkdownSelectionPoint,
-  chars: number,
-): MarkdownSelectionPoint | null {
-  if (chars === 0) return point;
-  if (point.type !== "text") return null;
-
-  let remaining = chars;
-  let currentNode: LexicalNode | null = $getNodeByKey(point.key);
-  if (!currentNode) return null;
-  let currentOffset = point.offset;
-
-  while (remaining > 0) {
-    if (remaining <= currentOffset) {
-      return { key: currentNode.getKey(), offset: currentOffset - remaining, type: "text" };
-    }
-    remaining -= currentOffset;
-    currentNode = currentNode.getPreviousSibling();
-    if (!currentNode) return null;
-    currentOffset = currentNode.getTextContent().length;
-  }
-  return { key: currentNode.getKey(), offset: currentOffset, type: "text" };
-}
-
-/**
  * Apply an "edit" mode replacement at an already-located selection: narrow to
  * the minimal diff, render the narrowed replacement markdown to inline nodes
  * (the caller supplies the `math-tex`-emitting markdown-it instance — post or
@@ -573,6 +514,7 @@ export function $applyEditModeReplacement({
   focus,
   quote,
   replacement,
+  range,
   markdownIt,
 }: {
   editor: LexicalEditor
@@ -580,9 +522,10 @@ export function $applyEditModeReplacement({
   focus: MarkdownSelectionPoint
   quote: string
   replacement: string
+  range: LocatedQuoteRange | undefined
   markdownIt: MarkdownIt
 }): { replaced: boolean, narrowedQuote: string, narrowedReplacement: string } {
-  const sel = $computeFinalSelection(anchor, focus, quote, replacement);
+  const sel = $computeFinalSelection(anchor, focus, quote, replacement, range);
   const inlineNodes = sel.narrowedReplacement.length > 0
     ? $htmlToInlineNodes(editor, renderAgentMarkdownToHtml(markdownIt, sel.narrowedReplacement))
     : [];

--- a/app/api/agent/replaceText/route.ts
+++ b/app/api/agent/replaceText/route.ts
@@ -10,7 +10,7 @@ import { createSuggestionThreadInCommentsDoc } from "../suggestionThreads";
 import { deriveAgentAuthor, waitForProviderFlush, withMainDocEditorSession, authorizeAgentDraftAccess, renderAgentMarkdownToHtml } from "../editorAgentUtil";
 
 import { markdownQuoteToPlainText, type MarkdownSelectionPoint } from "../mapMarkdownToLexical";
-import { $locateQuoteWithTextIndex } from "../textIndexQuoteLocator";
+import { $locateQuoteWithTextIndex, type LocatedQuoteRange } from "../textIndexQuoteLocator";
 import { replaceTextToolSchema, type ReplaceMode } from "../toolSchemas";
 import { captureException } from "@/lib/sentryWrapper";
 import { captureAgentApiEvent, captureAgentApiFailure } from "../captureAgentAnalytics";
@@ -263,6 +263,7 @@ export function $applySuggestionWithNarrowing({
   focus,
   quote,
   replacement,
+  range,
   suggestionId,
 }: {
   editor: LexicalEditor
@@ -270,9 +271,10 @@ export function $applySuggestionWithNarrowing({
   focus: MarkdownSelectionPoint
   quote: string
   replacement: string
+  range: LocatedQuoteRange | undefined
   suggestionId: string
 }): SuggestionNarrowingResult {
-  const narrowing = $computeNarrowing(anchor, focus, quote, replacement);
+  const narrowing = $computeNarrowing(anchor, focus, quote, replacement, range);
 
   if (!narrowing) {
     const replaced = $applySuggestionForSelection(editor, anchor, focus, replacement, suggestionId);
@@ -331,6 +333,7 @@ export async function replaceTextInMainDoc({
           if (mode === "edit") {
             const editResult = $applyEditModeReplacement({
               editor, anchor, focus, quote, replacement,
+              range: selectionResult.range,
               markdownIt: getMarkdownItForAgentPosts(),
             });
             replaced = editResult.replaced;
@@ -341,7 +344,9 @@ export async function replaceTextInMainDoc({
 
           suggestionId = randomId();
           const narrowingResult = $applySuggestionWithNarrowing({
-            editor, anchor, focus, quote, replacement, suggestionId,
+            editor, anchor, focus, quote, replacement,
+            range: selectionResult.range,
+            suggestionId,
           });
           replaced = narrowingResult.replaced;
           summaryQuote = narrowingResult.narrowedQuote;

--- a/app/api/agent/textIndexQuoteLocator.ts
+++ b/app/api/agent/textIndexQuoteLocator.ts
@@ -250,7 +250,7 @@ function elementPointAroundSegment(
  * well-formed match — normalized quotes are trimmed, so both boundaries map
  * to content characters — and resolve to null.
  */
-function resolveRawIndexToPoint(
+export function resolveRawIndexToPoint(
   projection: DocumentProjection,
   rawIndex: number,
   isFocus: boolean,
@@ -301,9 +301,25 @@ function $buildNormalizedDocument(): NormalizedDocument {
 
 type LocateOutcome = "found" | "not_found" | "ambiguous" | "empty";
 
+/**
+ * The matched range in document-projection space: the projection itself plus
+ * the raw [start, end) character range of the match within its text. Carried
+ * on successful locate results so that downstream narrowing can compute
+ * positions by index arithmetic instead of walking the node tree.
+ */
+export interface LocatedQuoteRange {
+  projection: DocumentProjection
+  rawStart: number
+  rawEnd: number
+}
+
+export interface TextIndexQuoteResult extends MarkdownQuoteSelectionResult {
+  range?: LocatedQuoteRange
+}
+
 interface LocateAttempt {
   outcome: LocateOutcome
-  result: MarkdownQuoteSelectionResult
+  result: TextIndexQuoteResult
 }
 
 /**
@@ -376,7 +392,13 @@ function locateInSearchSpace({
 
   return {
     outcome: "found",
-    result: { found: true, anchor, focus, matchedNodeKey: anchor.key },
+    result: {
+      found: true,
+      anchor,
+      focus,
+      matchedNodeKey: anchor.key,
+      range: { projection, rawStart, rawEnd },
+    },
   };
 }
 
@@ -425,7 +447,7 @@ function locateMarkerBlindQuote(
  * Must be called inside a Lexical read/update context; always searches the
  * whole document.
  */
-export function $locateQuoteWithTextIndex(markdownQuote: string): MarkdownQuoteSelectionResult {
+export function $locateQuoteWithTextIndex(markdownQuote: string): TextIndexQuoteResult {
   const { projection, normalizedDocument } = $buildNormalizedDocument();
   const normalizedQuote = normalizeTracked(projectQuoteToRenderedText(markdownQuote)).text;
 

--- a/app/api/research/agent/documents/replaceText/route.ts
+++ b/app/api/research/agent/documents/replaceText/route.ts
@@ -66,6 +66,7 @@ async function replaceTextInResearchDoc({
               focus: selectionResult.focus,
               quote,
               replacement,
+              range: selectionResult.range,
               markdownIt: getMarkdownItForResearch(),
             }).replaced;
           },

--- a/packages/lesswrong/server/typoSuggestions/applyTypoSuggestion.ts
+++ b/packages/lesswrong/server/typoSuggestions/applyTypoSuggestion.ts
@@ -316,6 +316,7 @@ function applyEditOffline(html: string, quote: string, replacement: string): Off
           focus: selectionResult.focus,
           quote,
           replacement,
+          range: selectionResult.range,
           markdownIt: getMarkdownItForAgentPosts(),
         }).replaced;
       },

--- a/packages/lesswrong/server/typoSuggestions/evaluateTypoReact.ts
+++ b/packages/lesswrong/server/typoSuggestions/evaluateTypoReact.ts
@@ -177,6 +177,7 @@ function computeNarrowedDiff(
         selectionResult.focus,
         quote,
         replacement,
+        selectionResult.range,
       );
       if (narrowing) {
         narrowedQuote = narrowing.quote;

--- a/packages/lesswrong/unitTests/replaceTextSuggestion.tests.ts
+++ b/packages/lesswrong/unitTests/replaceTextSuggestion.tests.ts
@@ -1,5 +1,6 @@
-import { $getRoot, $isElementNode, type LexicalEditor, type LexicalNode } from "lexical";
+import { $createRangeSelection, $getRoot, $isElementNode, type LexicalEditor, type LexicalNode } from "lexical";
 import { $generateHtmlFromNodes } from "@lexical/html";
+import { $wrapSelectionInMarkNode } from "@lexical/mark";
 import { $applySuggestionWithNarrowing } from "../../../app/api/agent/replaceText/route";
 import { $wrapBlockAsDeletionSuggestion } from "../../../app/api/agent/deleteBlock/route";
 import { $createMathNode } from "@/components/editor/lexicalPlugins/math/MathNode";
@@ -24,7 +25,7 @@ async function replaceTextAsSuggestion(
 
     const { anchor, focus } = result;
     const narrowingResult = $applySuggestionWithNarrowing({
-      editor, anchor, focus, quote, replacement, suggestionId: randomId(),
+      editor, anchor, focus, quote, replacement, range: result.range, suggestionId: randomId(),
     });
     replaced = narrowingResult.replaced;
   });
@@ -43,10 +44,28 @@ async function replaceTextInEditMode(
 
     replaced = $applyEditModeReplacement({
       editor, anchor: result.anchor, focus: result.focus, quote, replacement,
+      range: result.range,
       markdownIt: getMarkdownItForAgentPosts(),
     }).replaced;
   });
   return replaced;
+}
+
+/**
+ * Wrap the text matched by `quote` in a MarkNode, the way a comment thread
+ * anchors to a text range in the live editor.
+ */
+async function wrapQuoteInMark(editor: LexicalEditor, quote: string): Promise<void> {
+  await runEditorUpdate(editor, () => {
+    const target = $locateQuoteWithTextIndex(quote);
+    if (!target.found || !target.anchor || !target.focus) {
+      throw new Error(`wrapQuoteInMark: quote not found: ${quote}`);
+    }
+    const selection = $createRangeSelection();
+    selection.anchor.set(target.anchor.key, target.anchor.offset, target.anchor.type);
+    selection.focus.set(target.focus.key, target.focus.offset, target.focus.type);
+    $wrapSelectionInMarkNode(selection, false, randomId());
+  });
 }
 
 function getPlainTextContent(editor: LexicalEditor): string {
@@ -618,6 +637,88 @@ describe("replaceText narrowing preserves non-plain-text markdown changes", () =
     expect(deleteSuggestions[0].textContent).toBe("beta gamma");
     expect(insertSuggestions.length).toBe(1);
     expect(insertSuggestions[0].textContent).toBe("theta gamma");
+  });
+});
+
+describe("replaceText narrowing across comment-anchor marks", () => {
+  // Comment threads anchor to text by wrapping it in a MarkNode (an inline
+  // element), so a draft with comments has its paragraphs split into nested
+  // inline structure. Narrowing resolves positions through the document
+  // projection, which is flat over inline nesting, so marks anywhere in or
+  // around the match must not prevent a minimal diff.
+
+  it("narrows when the match starts inside a comment-anchor mark", async () => {
+    const editor = await setupEditorWithContent("Alpha beta gamma delta epsilon.");
+    await wrapQuoteInMark(editor, "Alpha");
+
+    const replaced = await replaceTextAsSuggestion(
+      editor,
+      "Alpha beta gamma delta",
+      "Alpha beta led delta",
+    );
+
+    expect(replaced).toBe(true);
+    const suggestions = getAllSuggestions(editor);
+    expect(suggestions).toEqual([
+      { type: "delete", textContent: "gamma" },
+      { type: "insert", textContent: "led" },
+    ]);
+  });
+
+  it("narrows when the narrowed range falls inside a comment-anchor mark", async () => {
+    const editor = await setupEditorWithContent("Alpha beta gamma delta epsilon.");
+    await wrapQuoteInMark(editor, "delta epsilon");
+
+    const replaced = await replaceTextAsSuggestion(
+      editor,
+      "gamma delta epsilon",
+      "gamma fish epsilon",
+    );
+
+    expect(replaced).toBe(true);
+    const suggestions = getAllSuggestions(editor);
+    expect(suggestions).toEqual([
+      { type: "delete", textContent: "delta" },
+      { type: "insert", textContent: "fish" },
+    ]);
+  });
+
+  it("narrows when a comment-anchor mark sits in the middle of the match", async () => {
+    const editor = await setupEditorWithContent("Alpha beta gamma delta epsilon.");
+    await wrapQuoteInMark(editor, "gamma");
+
+    const replaced = await replaceTextAsSuggestion(
+      editor,
+      "beta gamma delta",
+      "beta gamma fish",
+    );
+
+    expect(replaced).toBe(true);
+    const suggestions = getAllSuggestions(editor);
+    expect(suggestions).toEqual([
+      { type: "delete", textContent: "delta" },
+      { type: "insert", textContent: "fish" },
+    ]);
+  });
+
+  it("falls back to the full range when quote and document lengths diverge", async () => {
+    // The document has a one-character ellipsis where the quote (matched via
+    // NFKC normalization) has a three-character "...": positions no longer
+    // correspond 1:1, so narrowing must conservatively use the full range.
+    const editor = await setupEditorWithContent("Alpha beta… gamma delta.");
+
+    const replaced = await replaceTextAsSuggestion(
+      editor,
+      "beta... gamma",
+      "beta... led",
+    );
+
+    expect(replaced).toBe(true);
+    const suggestions = getAllSuggestions(editor);
+    expect(suggestions).toEqual([
+      { type: "delete", textContent: "beta… gamma" },
+      { type: "insert", textContent: "beta... led" },
+    ]);
   });
 });
 


### PR DESCRIPTION
Written by Claude
--------
## Problem

`$computeNarrowing` (which strips the common prefix/suffix between an agent's quote and replacement so suggestion diffs only cover the actual change) resolved its narrowed boundaries by walking sibling text nodes. Any inline element node in the matched range — most commonly a comment-thread anchor `MarkNode` — broke the walk and silently fell back to the full un-narrowed range. In practice: on a draft with comment threads near the edit, agent suggestions rendered as "delete everything quoted, insert the full replacement" instead of a minimal diff. (Found by making a live agent edit on a draft whose first sentence had a comment anchored to it; the same range walks also had a latent partial-collection bug when the walk never reached the focus node.)

## Fix

Narrowing now works in the text-index locator's own coordinate space rather than walking the tree:

- `$locateQuoteWithTextIndex` returns a new `range` field — the match's `[rawStart, rawEnd)` character range in the document projection plus the projection itself (it already computed both and discarded them).
- `$computeNarrowing` keeps all its markdown-space affix logic unchanged, but resolves the narrowed boundaries with index arithmetic through `resolveRawIndexToPoint`, which is transparent to inline nesting (marks, links) by construction.
- The sibling-walk helpers (`$collectPlainTextInRange`, `$advancePoint`, `$retreatPoint`) are deleted.

Two guards the old path lacked:

- **Count correspondence**: narrowing only proceeds when the quote's plain text and the matched document text have equal lengths (always true for quotes taken verbatim from the read API). Length-changing typographic folds, marker-blind matches, and spans across math tokens or footnote references now fall back conservatively to the full range — several of these could previously mis-narrow silently (e.g. footnote markers count ~14 plain chars against a zero-width node).
- **Normalized verification**: the narrowed document slice and narrowed quote slice must agree under `normalizeTracked`, catching positional drift within equal overall lengths (e.g. whitespace collapsed at different offsets).

The cross-block guard is retained, but its reason has changed: narrowed replacements render as inline nodes, which assumes a single block's context. Lifting that is a possible follow-up.

## Tests

New cases in `replaceTextSuggestion.tests.ts`: match starting inside a comment-anchor mark (the motivating regression), narrowed range falling entirely inside a mark, mark mid-match, and the length-divergence fallback. Full suite (45) plus the five adjacent editor/locator suites pass; `yarn tsc` clean. Net −31 lines of production code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)