### PR TITLE
fix deploy/migrate actions breaking because unpinned node-gyp depends…

### DIFF
--- a/.github/actions/setupEnvironment/action.yaml
+++ b/.github/actions/setupEnvironment/action.yaml
@@ -4,7 +4,7 @@ inputs:
   node-version:
     description: 'Which version of NodeJS to use'
     required: false
-    default: 24.13
+    default: 24.15
 runs:
   using: composite
   steps:


### PR DESCRIPTION
… on proc-log@7.0.0 which wants newer node version


