### PR TITLE
Fix editor crash when pasting Chrome triple-click selections into a blockquote

### DIFF
--- a/packages/lesswrong/components/editor/lexicalPlugins/codeBlock/CodeBlockPlugin.tsx
+++ b/packages/lesswrong/components/editor/lexicalPlugins/codeBlock/CodeBlockPlugin.tsx
@@ -39,7 +39,13 @@ function tryConvertTripleBackticksToCodeBlockInUpdateContext(): boolean {
   if ($isRootNode(anchorNode)) {
     return false;
   }
-  const block = anchorNode.getTopLevelElementOrThrow();
+  // getTopLevelElement returns null if the selection points at a node that
+  // is no longer attached under the root (e.g. after a failed update);
+  // don't throw on Enter in that case.
+  const block = anchorNode.getTopLevelElement();
+  if (!block) {
+    return false;
+  }
   const text = block.getTextContent();
   // Allow optional language (```js, ```python, etc)
   if (!/^```[\w-]*$/.test(text)) {

--- a/packages/lesswrong/components/editor/lexicalPlugins/quote/ContainerQuoteNode.ts
+++ b/packages/lesswrong/components/editor/lexicalPlugins/quote/ContainerQuoteNode.ts
@@ -133,6 +133,23 @@ const blockTags = new Set([
  * QuoteNode has a proper block child.
  */
 function convertBlockquoteElement(domNode: HTMLElement): DOMConversionOutput {
+  // Skip blockquotes with no content (no elements and no non-whitespace
+  // text). Chrome's clipboard serializer emits an empty <blockquote> when a
+  // selection ends at the start of a blockquote (e.g. triple-clicking the
+  // paragraph before it), and importing it would create a childless quote
+  // that can't be edited or escaped.
+  let hasContent = false;
+  for (let i = 0; i < domNode.childNodes.length; i++) {
+    const child = domNode.childNodes[i];
+    if (child.nodeType === 1 || (child.nodeType === 3 && child.textContent?.trim())) {
+      hasContent = true;
+      break;
+    }
+  }
+  if (!hasContent) {
+    return { node: null };
+  }
+
   const node = $createContainerQuoteNode();
 
   // Check if this blockquote has any block-level children
@@ -148,7 +165,7 @@ function convertBlockquoteElement(domNode: HTMLElement): DOMConversionOutput {
   if (!hasBlockChildren && domNode.childNodes.length > 0) {
     // Wrap inline content in a <p> element so Lexical's HTML importer
     // creates a ParagraphNode child for our shadow root
-    const wrapper = document.createElement('p');
+    const wrapper = domNode.ownerDocument.createElement('p');
     while (domNode.firstChild) {
       wrapper.appendChild(domNode.firstChild);
     }

--- a/packages/lesswrong/components/editor/lexicalPlugins/quote/ContainerQuotePlugin.tsx
+++ b/packages/lesswrong/components/editor/lexicalPlugins/quote/ContainerQuotePlugin.tsx
@@ -55,8 +55,15 @@ function $wrapRunInParagraph(nodes: LexicalNode[]): void {
  * block-level children for editing operations (Enter, Backspace, block-type
  * changes) to work correctly.
  */
-function $normalizeQuoteChildren(quoteNode: ContainerQuoteNode): void {
+export function $normalizeQuoteChildren(quoteNode: ContainerQuoteNode): void {
   const children = quoteNode.getChildren();
+
+  // A childless quote breaks editing operations (Enter inside it crashes
+  // Lexical's block-splitting logic), so give it an empty paragraph.
+  if (children.length === 0) {
+    quoteNode.append($createParagraphNode());
+    return;
+  }
 
   // Early return: if all children are already block-level, no mutation needed.
   if (!children.some((child) => $isInlineNode(child))) {

--- a/packages/lesswrong/unitTests/containerQuoteImport.tests.ts
+++ b/packages/lesswrong/unitTests/containerQuoteImport.tests.ts
@@ -1,0 +1,85 @@
+import { $getRoot, $isParagraphNode, type LexicalNode } from "lexical";
+import { ContainerQuoteNode, $createContainerQuoteNode, $isContainerQuoteNode } from "@/components/editor/lexicalPlugins/quote/ContainerQuoteNode";
+import { $normalizeQuoteChildren } from "@/components/editor/lexicalPlugins/quote/ContainerQuotePlugin";
+import { createHeadlessEditor } from "../../../app/api/agent/editorAgentUtil";
+import { runEditorUpdate, setupEditorWithHtml, walkLexicalNodes } from "./lexicalTestHelpers";
+
+function findQuoteNodes(editor: import("lexical").LexicalEditor): ContainerQuoteNode[] {
+  const quotes: ContainerQuoteNode[] = [];
+  editor.getEditorState().read(() => {
+    walkLexicalNodes($getRoot(), (node: LexicalNode) => {
+      if ($isContainerQuoteNode(node)) {
+        quotes.push(node);
+      }
+    });
+  });
+  return quotes;
+}
+
+describe("ContainerQuoteNode HTML import", () => {
+  it("drops an empty <blockquote> (Chrome triple-click clipboard payload)", async () => {
+    // Chrome serializes a triple-click selection that ends at the start of a
+    // following blockquote as: the paragraph, an empty <blockquote>, and an
+    // Apple-interchange-newline marker.
+    const editor = await setupEditorWithHtml(
+      `<meta charset='utf-8'><p style="margin-top: 1em;">Yes, this is something I can do.</p>` +
+      `<blockquote style="margin: 0px 0px 0px 12px;"></blockquote>` +
+      `<br class="Apple-interchange-newline">`
+    );
+
+    expect(findQuoteNodes(editor)).toHaveLength(0);
+    editor.getEditorState().read(() => {
+      expect($getRoot().getTextContent()).toContain("Yes, this is something I can do.");
+    });
+  });
+
+  it("drops a whitespace-only <blockquote>", async () => {
+    const editor = await setupEditorWithHtml(`<p>before</p><blockquote>\n   \n</blockquote><p>after</p>`);
+    expect(findQuoteNodes(editor)).toHaveLength(0);
+  });
+
+  it("drops an empty <blockquote> nested inside a non-empty one", async () => {
+    const editor = await setupEditorWithHtml(
+      `<blockquote><p>quoted text</p><blockquote></blockquote></blockquote>`
+    );
+
+    const quotes = findQuoteNodes(editor);
+    expect(quotes).toHaveLength(1);
+    editor.getEditorState().read(() => {
+      expect(quotes[0].getTextContent()).toBe("quoted text");
+    });
+  });
+
+  it("still imports a blockquote with inline content as a quote with a paragraph child", async () => {
+    const editor = await setupEditorWithHtml(`<blockquote>some <strong>inline</strong> content</blockquote>`);
+
+    const quotes = findQuoteNodes(editor);
+    expect(quotes).toHaveLength(1);
+    editor.getEditorState().read(() => {
+      const children = quotes[0].getChildren();
+      expect(children.length).toBeGreaterThan(0);
+      expect(children.every((child) => $isParagraphNode(child))).toBe(true);
+      expect(quotes[0].getTextContent()).toBe("some inline content");
+    });
+  });
+});
+
+describe("$normalizeQuoteChildren", () => {
+  it("gives a childless quote an empty paragraph so it stays editable", async () => {
+    const editor = createHeadlessEditor("ContainerQuoteImportTest");
+    const removeTransform = editor.registerNodeTransform(ContainerQuoteNode, $normalizeQuoteChildren);
+
+    await runEditorUpdate(editor, () => {
+      $getRoot().clear().append($createContainerQuoteNode());
+    });
+
+    const quotes = findQuoteNodes(editor);
+    expect(quotes).toHaveLength(1);
+    editor.getEditorState().read(() => {
+      const children = quotes[0].getChildren();
+      expect(children).toHaveLength(1);
+      expect($isParagraphNode(children[0])).toBe(true);
+    });
+    removeTransform();
+  });
+});


### PR DESCRIPTION
Written by Claude
------
## Bug

Repro ([Slack report](https://lworg.slack.com/archives/CJUN2UAFN/p1781231141320679)): copy a comment paragraph by triple-clicking it, reply, type `> ` to open a blockquote, paste, then try to Enter/Backspace your way out. The editor gets stuck in a broken state and Enter throws minified Lexical error #76 (then #67/#19 on subsequent keypresses).

## Root cause

When a triple-click selection ends at the start of a following blockquote (which is what triple-clicking a paragraph does when the next sibling is a blockquote), Chrome's clipboard serializer includes that blockquote as a completely empty `<blockquote></blockquote>`. `convertBlockquoteElement` only wraps blockquote contents in a `<p>` when child nodes exist, so the empty blockquote imported as a **childless** `ContainerQuoteNode` nested inside the user's quote — a state the editor can't handle:

- Enter with the selection on the childless quote crashes in Lexical's `RangeSelection.insertParagraph` → `$splitNodeAtPoint` (`append: attempting to append self`, minified #76)
- The failed update leaves the selection pointing at a detached node, so the next Enter crashed in `CodeBlockPlugin`'s triple-backtick handler via `getTopLevelElementOrThrow` (#67); prod also hit the lost-selection invariant (#19)
- Backspace had no valid merge target, so the cursor just hopped to the previous line

## Fix

1. **`ContainerQuoteNode.ts`**: drop blockquotes with no elements and no non-whitespace text at HTML import — an empty blockquote in pasted HTML is clipboard interchange junk, never intentional content. Also use `domNode.ownerDocument` instead of the global `document` in the inline-wrap path (required for headless import, e.g. in tests).
2. **`ContainerQuotePlugin.tsx`**: the `$normalizeQuoteChildren` transform now appends an empty paragraph to any childless quote that arises through other paths (other clipboard sources, collab states), so it stays editable instead of crashing.
3. **`CodeBlockPlugin.tsx`**: use `getTopLevelElement()` with a null check instead of `getTopLevelElementOrThrow()` in the Enter handler, so a corrupted selection can't cascade into a second crash.

## Validation

- Reproduced the original crash in the dev editor with the exact clipboard payload captured from a real Chrome paste; after the fix, the same paste yields just the quoted paragraph (plus the interchange-newline's empty quoted line), Enter exits the quote cleanly, and Backspace unwraps normally with no console errors.
- New unit tests in `containerQuoteImport.tests.ts` cover the Chrome clipboard payload, whitespace-only and nested-empty blockquotes, the still-working inline-content import path, and the childless-quote repair transform.
- `yarn tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1215690766445591) by [Unito](https://www.unito.io)
