### PR TITLE
Fix topAdjusted sort: async view pipeline + on-demand karma inflation fetch

### DIFF
--- a/packages/lesswrong/lib/collections/comments/newSchema.ts
+++ b/packages/lesswrong/lib/collections/comments/newSchema.ts
@@ -464,7 +464,7 @@ const schema = {
       canRead: ["guests"],
       resolver: async (comment, args, context) => {
         const { currentUser, Comments } = context;
-        const params = viewTermsToQuery(CommentsViews, {
+        const params = await viewTermsToQuery(CommentsViews, {
           view: "shortformLatestChildren",
           topLevelCommentId: comment._id,
         }, undefined, context);

--- a/packages/lesswrong/lib/collections/notifications/views.ts
+++ b/packages/lesswrong/lib/collections/notifications/views.ts
@@ -10,10 +10,6 @@ declare global {
   }
 }
 
-// Not annotated as ViewFunction (which would widen the return type to
-// include Promise): notificationResolvers and the notificationCount route
-// call this directly and rely on it being synchronous. The CollectionViewSet
-// constructor below still checks assignability.
 export const defaultNotificationsView = (terms: NotificationsViewTerms) => {
   // const alignmentForum = forumTypeSetting.get() === 'AlignmentForum' ? {af: true} : {}
   return {

--- a/packages/lesswrong/lib/collections/notifications/views.ts
+++ b/packages/lesswrong/lib/collections/notifications/views.ts
@@ -10,7 +10,11 @@ declare global {
   }
 }
 
-export const defaultNotificationsView: ViewFunction<"Notifications"> = (terms: NotificationsViewTerms) => {
+// Not annotated as ViewFunction (which would widen the return type to
+// include Promise): notificationResolvers and the notificationCount route
+// call this directly and rely on it being synchronous. The CollectionViewSet
+// constructor below still checks assignability.
+export const defaultNotificationsView = (terms: NotificationsViewTerms) => {
   // const alignmentForum = forumTypeSetting.get() === 'AlignmentForum' ? {af: true} : {}
   return {
     selector: {

--- a/packages/lesswrong/lib/collections/posts/karmaInflation.ts
+++ b/packages/lesswrong/lib/collections/posts/karmaInflation.ts
@@ -9,10 +9,6 @@ export const nullKarmaInflationSeries: TimeSeries = {
     interval: 1,
     values: [1]
 }
-let karmaInflationCache: TimeSeries = nullKarmaInflationSeries
-
-export const getKarmaInflationSeries = () => karmaInflationCache;
-export const setKarmaInflationSeries = (newKarmaInflationSeries: TimeSeries) => { karmaInflationCache = newKarmaInflationSeries };
 
 /**
  * 

--- a/packages/lesswrong/lib/collections/posts/newSchema.ts
+++ b/packages/lesswrong/lib/collections/posts/newSchema.ts
@@ -3536,7 +3536,7 @@ const schema = {
           Partial<Pick<DbComment, "contents">>;
 
         const comments: CommentForSideComments[] = await Comments.find({
-          ...getDefaultViewSelector(CommentsViews, context),
+          ...await getDefaultViewSelector(CommentsViews, context),
           postId: post._id,
           ...(cacheIsValid && {
             _id: {
@@ -3839,7 +3839,7 @@ const schema = {
         const timeCutoff = new Date(lastCommentedOrNow.getTime() - (maxAgeHours * oneHourInMs));
         const loaderName = af ? "recentCommentsAf" : "recentComments";
         const filter = {
-          ...getDefaultViewSelector(CommentsViews, context),
+          ...await getDefaultViewSelector(CommentsViews, context),
           score: { $gt: 0 },
           draft: false,
           deletedPublic: false,
@@ -4039,7 +4039,7 @@ const schema = {
         const { Comments } = context;
         const firstComment = await Comments.findOne(
           {
-            ...getDefaultViewSelector(CommentsViews, context),
+            ...await getDefaultViewSelector(CommentsViews, context),
             postId: post._id,
             // This actually forces `deleted: false` by combining with the default view selector
             deletedPublic: false,

--- a/packages/lesswrong/lib/collections/posts/views.ts
+++ b/packages/lesswrong/lib/collections/posts/views.ts
@@ -1,5 +1,6 @@
 import moment from 'moment';
-import { getKarmaInflationSeries, timeSeriesIndexExpr } from './karmaInflation';
+import { timeSeriesIndexExpr, TimeSeries } from './karmaInflation';
+import { getKarmaInflationSeries } from '@/server/karmaInflation/cache';
 import type { FilterMode, FilterSettings, FilterTag } from '../../filterSettings';
 import { adminAccountSetting, isAF, isEAForum, defaultVisibilityTags, openThreadTagIdSetting, startHerePostIdSetting } from '@/lib/instanceSettings';
 import { frontpageTimeDecayExpr, postScoreModifiers, timeDecayExpr } from '../../scoring';
@@ -9,6 +10,7 @@ import { getPositiveVoteThreshold, QUICK_REVIEW_SCORE_THRESHOLD, reviewExcludedP
 import isEmpty from 'lodash/isEmpty';
 import pick from 'lodash/pick';
 import { visitorGetsDynamicFrontpage } from '../../betas';
+import { getWithCustomLoader } from '@/lib/loaders';
 import { TupleSet, UnionOf } from '@/lib/utils/typeGuardUtils';
 import { CollectionViewSet } from '../../../lib/views/collectionViewSet';
 import type { ApolloClient } from '@apollo/client';
@@ -103,6 +105,18 @@ export const sortings: Record<PostSortingMode,MongoSelector<DbPost>> = {
   recentComments: { lastCommentedAt: -1 }
 }
 
+async function getVisitorActivity(context: ResolverContext): Promise<DbUserActivity|null> {
+  const { currentUser, clientId } = context;
+  if ((currentUser || clientId) && (isEAForum() || visitorGetsDynamicFrontpage(currentUser))) {
+    if (currentUser) {
+      return await context.UserActivities.findOne({visitorId: currentUser._id, type: 'userId'});
+    } else if (clientId) {
+      return await context.UserActivities.findOne({visitorId: clientId, type: 'clientId'});
+    }
+  }
+  return null;
+}
+
 /**
  * @summary Base parameters that will be common to all other view unless specific properties are overwritten
  *
@@ -112,7 +126,7 @@ export const sortings: Record<PostSortingMode,MongoSelector<DbPost>> = {
  * as it is *inclusive*. The parameters callback that handles it outputs
  * ~ $lt: before.endOf('day').
  */
-function defaultView(terms: PostsViewTerms, _: ApolloClient, context?: ResolverContext) {
+async function defaultView(terms: PostsViewTerms, _: ApolloClient, context?: ResolverContext) {
   const validFields: any = pick(terms, 'userId', 'groupId', 'af','question', 'authorIsUnreviewed');
   // Also valid fields: before, after, curatedAfter, timeField (select on postedAt), excludeEvents, and
   // karmaThreshold (selects on baseScore).
@@ -163,8 +177,16 @@ function defaultView(terms: PostsViewTerms, _: ApolloClient, context?: ResolverC
       )
     }
   }
+  // Started before the visitorActivity fetch below so the two can overlap
+  const pendingKarmaInflationSeries = terms.sortedBy === 'topAdjusted' ? getKarmaInflationSeries() : null;
+
   if (terms.filterSettings) {
-    const filterParams = filterSettingsToParams(terms.filterSettings, terms, context);
+    const visitorActivity = context
+      ? await getWithCustomLoader(context, "visitorActivityLoader", "_",
+          async () => [await getVisitorActivity(context)]
+        )
+      : null;
+    const filterParams = filterSettingsToParams(terms.filterSettings, terms, visitorActivity, context);
     params = {
       selector: { ...params.selector, ...filterParams.selector },
       options: { ...params.options, ...filterParams.options },
@@ -180,8 +202,8 @@ function defaultView(terms: PostsViewTerms, _: ApolloClient, context?: ResolverC
     };
   }
   if (terms.sortedBy) {
-    if (terms.sortedBy === 'topAdjusted') {
-      params.syntheticFields = { ...params.syntheticFields, ...buildInflationAdjustedField() }
+    if (pendingKarmaInflationSeries) {
+      params.syntheticFields = { ...params.syntheticFields, ...buildInflationAdjustedField(await pendingKarmaInflationSeries) }
     }
 
     if ((sortings as AnyBecauseTodo)[terms.sortedBy]) {
@@ -263,8 +285,7 @@ const getFrontpageFilter = (filterSettings: FilterSettings): {filter: any, softF
   }
 }
 
-export function buildInflationAdjustedField(): any {
-  const karmaInflationSeries = getKarmaInflationSeries();
+export function buildInflationAdjustedField(karmaInflationSeries: TimeSeries): any {
   return {
     karmaInflationAdjustedScore: {
       $multiply: [
@@ -289,7 +310,7 @@ export function buildInflationAdjustedField(): any {
   }
 }
 
-function filterSettingsToParams(filterSettings: FilterSettings, terms: PostsViewTerms, context?: ResolverContext): any {
+function filterSettingsToParams(filterSettings: FilterSettings, terms: PostsViewTerms, visitorActivity: DbUserActivity|null, context?: ResolverContext): any {
   // We get the default tag relevance from the database config
   const tagFilterSettingsWithDefaults: FilterTag[] = filterSettings.tags?.map(t =>
     t.filterMode === "TagDefault" ? {
@@ -353,7 +374,7 @@ function filterSettingsToParams(filterSettings: FilterSettings, terms: PostsView
         activityHalfLifeHours: terms.algoActivityHalfLifeHours,
         activityWeight: terms.algoActivityWeight,
         overrideActivityFactor: terms.algoActivityFactor,
-      }, context) : timeDecayExpr()
+      }, visitorActivity) : timeDecayExpr()
     ]}
   }
   

--- a/packages/lesswrong/lib/collections/tags/newSchema.ts
+++ b/packages/lesswrong/lib/collections/tags/newSchema.ts
@@ -565,7 +565,7 @@ const schema = {
         const lastCommentTime = (tagCommentType === "SUBFORUM" ? tag.lastSubforumCommentAt : tag.lastCommentedAt) ?? undefined;
         const timeCutoff = moment(lastCommentTime).subtract(maxAgeHours, "hours").toDate();
         const comments = await Comments.find({
-          ...getDefaultViewSelector(CommentsViews, context),
+          ...await getDefaultViewSelector(CommentsViews, context),
           tagId: tag._id,
           score: { $gt: 0 },
           draft: false,

--- a/packages/lesswrong/lib/scoring.ts
+++ b/packages/lesswrong/lib/scoring.ts
@@ -44,7 +44,7 @@ type TimeDecayExprProps = {
   overrideActivityFactor?: number
 }
 
-export const frontpageTimeDecayExpr = (props: TimeDecayExprProps, context: ResolverContext) => {
+export const frontpageTimeDecayExpr = (props: TimeDecayExprProps, visitorActivity: DbUserActivity|null) => {
   const {
     startingAgeHours,
     decayFactorSlowest,
@@ -63,7 +63,7 @@ export const frontpageTimeDecayExpr = (props: TimeDecayExprProps, context: Resol
 
   // See lib/collections/useractivities/collection.ts for a high-level overview
   const activityFactor = overrideActivityFactor ??
-    calculateActivityFactor(context?.visitorActivity?.activityArray, activityHalfLifeHours)
+    calculateActivityFactor(visitorActivity?.activityArray, activityHalfLifeHours)
 
   // Higher timeDecayFactor => more recency bias
   const timeDecayFactor = Math.min(

--- a/packages/lesswrong/lib/types/collectionTypes.ts
+++ b/packages/lesswrong/lib/types/collectionTypes.ts
@@ -104,7 +104,7 @@ type ViewFunction<N extends CollectionNameString = CollectionNameString> = (
   terms: ViewTermsByCollectionName[N],
   apolloClient?: ApolloClient,
   context?: ResolverContext,
-) => ViewQueryAndOptions<N>;
+) => ViewQueryAndOptions<N> | Promise<ViewQueryAndOptions<N>>;
 
 
 type ViewQueryAndOptions<
@@ -335,15 +335,6 @@ interface ResolverContext extends CollectionsByName {
   userId: string|null,
   clientId: string|null,
   currentUser: DbUser|null,
-
-  /**
-   * Hack to make visitorActivity acceptable to posts-list resolvers, in a
-   * non-async context. If missing from the ResolverContext, this hasn't been
-   * queried; if present and null, it's been queried but there's no activity
-   * data. If present it's the return value of getUserActivity.
-   */
-  visitorActivity?: DbUserActivity|null,
-
   locale: string,
   isSSR: boolean,
   isGreaterWrong: boolean,

--- a/packages/lesswrong/lib/utils/viewUtils.ts
+++ b/packages/lesswrong/lib/utils/viewUtils.ts
@@ -42,33 +42,33 @@ export function viewTermsToQuery<N extends CollectionNameString>(
  * a query that doesn't pass through the views system, you probably want to use
  * this selector as a starting point.
  */
-export function getDefaultViewSelector<N extends CollectionNameString>(
+export async function getDefaultViewSelector<N extends CollectionNameString>(
   viewSet: CollectionViewSet<N, Record<string, ViewFunction<N>>>,
   resolverContext: ResolverContext
 ) {
   // Downcast the generic to avoid a very expensive but useless type inference that indexes over all view terms by collection
-  const viewQuery = viewTermsToQuery<CollectionNameString>(viewSet, {}, undefined, resolverContext)
+  const viewQuery = await viewTermsToQuery<CollectionNameString>(viewSet, {}, undefined, resolverContext)
   return replaceSpecialFieldSelectors(viewQuery.selector);
 }
 
-export function mergeWithDefaultViewSelector<N extends CollectionNameString>(
+export async function mergeWithDefaultViewSelector<N extends CollectionNameString>(
   viewSet: CollectionViewSet<N, Record<string, ViewFunction<N>>>,
   selector: MongoSelector<ObjectsByCollectionName[N]>,
   resolverContext: ResolverContext
 ) {
-  return mergeSelectors(getDefaultViewSelector(viewSet, resolverContext), selector);
+  return mergeSelectors(await getDefaultViewSelector(viewSet, resolverContext), selector);
 }
 
 /**
  * Given a set of terms describing a view, translate them into a mongodb selector
  * and options, which is ready to execute (but don't execute it yet).
  */
-function getParameters<N extends CollectionNameString>(
+async function getParameters<N extends CollectionNameString>(
   viewSet: CollectionViewSet<N, Record<string, ViewFunction<N>>>,
   terms: ViewTermsByCollectionName[N],
   apolloClient?: any,
   context?: ResolverContext
-): MergedViewQueryAndOptions<ObjectsByCollectionName[N]> {
+): Promise<MergedViewQueryAndOptions<ObjectsByCollectionName[N]>> {
   const logger = loggerConstructor(`views-${viewSet.collectionName.toLowerCase()}-${terms.view?.toLowerCase() ?? 'default'}`)
   logger('getParameters(), terms:', terms);
 
@@ -80,7 +80,7 @@ function getParameters<N extends CollectionNameString>(
   const defaultView = viewSet.getDefaultView();
 
   if (defaultView) {
-    const defaultParameters = defaultView(terms, apolloClient, context);
+    const defaultParameters = await defaultView(terms, apolloClient, context);
     const newSelector = mergeSelectors(parameters.selector, defaultParameters.selector);
     parameters = {
       ...merge(parameters, defaultParameters),
@@ -93,7 +93,7 @@ function getParameters<N extends CollectionNameString>(
   // handle view option
   if (terms.view && viewSet.getView(terms.view)) {
     const viewFn = viewSet.getView(terms.view)!;
-    const view = viewFn(terms, apolloClient, context);
+    const view = await viewFn(terms, apolloClient, context);
     let mergedParameters = mergeSelectors(parameters, view);
 
     if (

--- a/packages/lesswrong/server/karmaInflation/cache.ts
+++ b/packages/lesswrong/server/karmaInflation/cache.ts
@@ -1,0 +1,33 @@
+import { DatabaseMetadata } from "../collections/databaseMetadata/collection";
+import { nullKarmaInflationSeries, TimeSeries } from "../../lib/collections/posts/karmaInflation";
+
+const KARMA_INFLATION_CACHE_TTL_MS = 60 * 60 * 1000;
+let cachedSeries: TimeSeries = nullKarmaInflationSeries;
+let cacheExpiresAt = 0;
+let pendingFetch: Promise<TimeSeries> | null = null;
+
+async function fetchKarmaInflationSeries(): Promise<TimeSeries> {
+  try {
+    const metadata = await DatabaseMetadata.findOne({ name: "karmaInflationSeries" });
+    cachedSeries = metadata?.value ?? nullKarmaInflationSeries;
+    cacheExpiresAt = Date.now() + KARMA_INFLATION_CACHE_TTL_MS;
+    return cachedSeries;
+  } finally {
+    pendingFetch = null;
+  }
+}
+
+/**
+ * The karma inflation series is recomputed nightly (see refreshKarmaInflation)
+ * and stored in DatabaseMetadata; here we fetch it on demand and cache it
+ * in memory per server instance.
+ */
+export function getKarmaInflationSeries(): TimeSeries | Promise<TimeSeries> {
+  if (Date.now() < cacheExpiresAt) {
+    return cachedSeries;
+  }
+  if (!pendingFetch) {
+    pendingFetch = fetchKarmaInflationSeries();
+  }
+  return pendingFetch;
+}

--- a/packages/lesswrong/server/karmaInflation/cron.ts
+++ b/packages/lesswrong/server/karmaInflation/cron.ts
@@ -1,8 +1,6 @@
-import { DatabaseMetadata } from "../../server/collections/databaseMetadata/collection";
-import { nullKarmaInflationSeries, setKarmaInflationSeries, TimeSeries } from '../../lib/collections/posts/karmaInflation';
+import type { TimeSeries } from '../../lib/collections/posts/karmaInflation';
 import PostsRepo from '../repos/PostsRepo';
 import DatabaseMetadataRepo from '../repos/DatabaseMetadataRepo';
-import { backgroundTask } from "../utils/backgroundTask";
 
 const AVERAGING_WINDOW_MS = 1000 * 60 * 60 * 24 * 28; // 28 days
 
@@ -42,22 +40,12 @@ export async function refreshKarmaInflation() {
     values: values
   };
 
-  // insert the new series into the db
+  // insert the new series into the db; web servers pick it up via the TTL
+  // cache in getKarmaInflationSeries
   try {
     await new DatabaseMetadataRepo().upsertKarmaInflationSeries(karmaInflationSeries);
   } catch (err) {
     // eslint-disable-next-line no-console
     console.error(err);
   }
-
-  // TODO: fix this to work in serverless world; right now it's setting a global state variable
-  // refresh the cache after every update
-  // it's a bit wasteful to immediately go and fetch the thing we just calculated from the db again,
-  // but seeing as this is a cron job it doesn't really matter
-  await refreshKarmaInflationCache();
-}
-
-export async function refreshKarmaInflationCache() {
-  const karmaInflationSeries = await DatabaseMetadata.findOne({ name: "karmaInflationSeries" });
-  setKarmaInflationSeries(karmaInflationSeries?.value || nullKarmaInflationSeries);
 }

--- a/packages/lesswrong/server/recombee/client.ts
+++ b/packages/lesswrong/server/recombee/client.ts
@@ -253,8 +253,8 @@ const helpers = {
     const filteredStickiedPostTerms = { ...stickiedPostTerms, filterSettings };
 
     const postPromises = [curatedPostTerms, filteredStickiedPostTerms]
-      .map(terms => viewTermsToQuery(PostsViews, terms, undefined, context))
-      .map(postsQuery => context.Posts.find(postsQuery.selector, postsQuery.options, { _id: 1 }).fetch());
+      .map(terms => viewTermsToQuery(PostsViews, terms, undefined, context)
+        .then(postsQuery => context.Posts.find(postsQuery.selector, postsQuery.options, { _id: 1 }).fetch()));
 
     const [curatedPosts, stickiedPosts] = await Promise.all(postPromises);
 
@@ -339,7 +339,7 @@ const helpers = {
     return interleavedPosts;
   },
 
-  getNativeLatestPostsPromise(hybridArgs: HybridRecombeeConfiguration, limit: number, fixedArmCount: number, excludedPostIds: string[], context: ResolverContext) {
+  async getNativeLatestPostsPromise(hybridArgs: HybridRecombeeConfiguration, limit: number, fixedArmCount: number, excludedPostIds: string[], context: ResolverContext) {
     const loadMoreCount = hybridArgs.loadMore?.loadMoreCount;
     const loadMoreCountArg = loadMoreCount ? { offset: loadMoreCount * fixedArmCount } : {};
     const hiddenPostIds = context.currentUser?.hiddenPostsMetadata?.map(metadata => metadata.postId) ?? [];
@@ -359,7 +359,7 @@ const helpers = {
       ...loadMoreCountArg,
     };
 
-    const postsQuery = viewTermsToQuery(PostsViews, postsTerms, undefined, context);
+    const postsQuery = await viewTermsToQuery(PostsViews, postsTerms, undefined, context);
 
     return performQueryFromViewParameters(context.Posts, postsTerms, postsQuery);
   },

--- a/packages/lesswrong/server/recommendations.ts
+++ b/packages/lesswrong/server/recommendations.ts
@@ -134,11 +134,12 @@ const getInclusionSelector = (algorithm: DefaultRecommendationsAlgorithm) => {
 
 // A filter (mongodb selector) for which posts should be considered at all as
 // recommendations.
-const recommendablePostFilter = (algorithm: DefaultRecommendationsAlgorithm, resolverContext: ResolverContext) => {
+const recommendablePostFilter = async (algorithm: DefaultRecommendationsAlgorithm, resolverContext: ResolverContext) => {
+  const defaultViewSelector = await getDefaultViewSelector(PostsViews, resolverContext);
   let recommendationFilter = {
     // Gets the selector from the default Posts view, which includes things like
     // excluding drafts and deleted posts
-    ...getDefaultViewSelector(PostsViews, resolverContext),
+    ...defaultViewSelector,
 
     // Only consider recommending posts if they hit the minimum base score. This has a big
     // effect on the size of the recommendable-post set, which needs to not be
@@ -165,7 +166,7 @@ const recommendablePostFilter = (algorithm: DefaultRecommendationsAlgorithm, res
       $or: [
         recommendationFilter,
         {
-          ...getDefaultViewSelector(PostsViews, resolverContext), // Ensure drafts are still excluded
+          ...defaultViewSelector, // Ensure drafts are still excluded
           defaultRecommendation: true,
           ...(algorithm.af ? {af: true} : {}),
         },
@@ -197,7 +198,7 @@ const allRecommendablePosts = async ({currentUser, algorithm, resolverContext}: 
         {},
         {joinHook},
       ),
-      recommendablePostFilter(algorithm, resolverContext),
+      await recommendablePostFilter(algorithm, resolverContext),
     ),
     {},
     {projection: scoreRelevantFields},

--- a/packages/lesswrong/server/repos/DatabaseMetadataRepo.ts
+++ b/packages/lesswrong/server/repos/DatabaseMetadataRepo.ts
@@ -10,18 +10,6 @@ export default class DatabaseMetadataRepo extends AbstractRepo<"DatabaseMetadata
     super(DatabaseMetadata);
   }
 
-  private getByName(name: string): Promise<DbDatabaseMetadata | null> {
-    // We use getRawDb here as this may be executed during server startup
-    // before the collection is properly initialized
-    return this.getRawDb().oneOrNone(`
-      -- DatabaseMetadataRepo.getByName
-      SELECT * from "DatabaseMetadata" WHERE "name" = $1
-    `,
-      [name],
-      `DatabaseMetadata.${name}`,
-    );
-  }
-  
   async getByNames(names: string[]): Promise<Array<DbDatabaseMetadata|null>> {
     const results = (await this.any(`
       -- DatabaseMetadataRepo.getByName
@@ -87,18 +75,6 @@ export default class DatabaseMetadataRepo extends AbstractRepo<"DatabaseMetadata
       WHERE "name" = $2
     `, [userId, metadataName]);
     return this.getGivingSeasonHearts(electionName);
-  }
-
-  getServerSettings(): Promise<DbDatabaseMetadata | null> {
-    return this.getByName("serverSettings");
-  }
-
-  getPublicSettings(): Promise<DbDatabaseMetadata | null> {
-    return this.getByName("publicSettings");
-  }
-
-  getDatabaseId(): Promise<DbDatabaseMetadata | null> {
-    return this.getByName("databaseId");
   }
 
   upsertKarmaInflationSeries(karmaInflationSeries: TimeSeries): Promise<null> {

--- a/packages/lesswrong/server/resolvers/defaultResolvers.ts
+++ b/packages/lesswrong/server/resolvers/defaultResolvers.ts
@@ -1,6 +1,6 @@
 import { getMultiResolverName, getSingleResolverName } from "@/lib/crud/utils";
 import { collectionNameToTypeName } from "@/lib/generated/collectionTypeNames";
-import { isEAForum, maxAllowedApiSkip } from "@/lib/instanceSettings";
+import { maxAllowedApiSkip } from "@/lib/instanceSettings";
 import { asyncFilter } from "@/lib/utils/asyncUtils";
 import { logGroupConstructor, loggerConstructor } from "@/lib/utils/logging";
 import { describeTerms, viewTermsToQuery } from "@/lib/utils/viewUtils";
@@ -15,9 +15,6 @@ import isEqual from "lodash/isEqual";
 import { getCollectionAccessFilter } from "../permissions/accessFilters";
 import { getSqlClientOrThrow } from "../sql/sqlClient";
 import { CollectionViewSet } from "@/lib/views/collectionViewSet";
-import UserActivities from "../collections/useractivities/collection";
-import { visitorGetsDynamicFrontpage } from "@/lib/betas";
-import { getWithCustomLoader } from "@/lib/loaders";
 import { enableCustomSqlResolvers } from "../sql/ProjectionContext";
 
 
@@ -168,23 +165,11 @@ export const getDefaultResolvers = <N extends CollectionNameString>(
 
     // get currentUser and Users collection from context
     const { currentUser }: {currentUser: DbUser|null} = context;
-    
-    // HACK: If this is a post query, the default view sometimes uses
-    // `context.visitorActivity`, to adjust the time-decay constant, but it isn't
-    // async so can't await the required DB fetch. So if this is a query on the
-    // Posts collection, add that to the context now.
-    // (This was previously in computeContextFromUser, which was much more
-    // costly since it adds a DB roundtrip to the start of every request.)
-    if (collectionName === "Posts" && 'filterSettings' in terms && terms.filterSettings && !('visitorActivity' in context)) {
-      context.visitorActivity = await getWithCustomLoader(context, "visitorActivityLoader", "_",
-        async () => [await getUserActivity(currentUser, context.clientId)]
-      );
-    }
 
     // Get selector and options from terms and perform Mongo query
     // Downcasts terms because there are collection-specific terms but this function isn't collection-specific
     // Also downcast the generic to avoid a very expensive but useless type inference that indexes over all view terms by collection
-    const parameters = viewTermsToQuery<CollectionNameString>(viewSet, terms, {}, context);
+    const parameters = await viewTermsToQuery<CollectionNameString>(viewSet, terms, {}, context);
 
     // get fragment from GraphQL AST
     const fragmentInfo = getFragmentInfo(info, "results", typeName);
@@ -430,13 +415,3 @@ export const performQueryFromViewParameters = async <N extends CollectionNameStr
   }
 }
 
-async function getUserActivity(user: DbUser|null, clientId: string|null): Promise<DbUserActivity|null> {
-  if ((user || clientId) && (isEAForum() || visitorGetsDynamicFrontpage(user))) {
-    if (user) {
-      return await UserActivities.findOne({visitorId: user._id, type: 'userId'});
-    } else if (clientId) {
-      return await UserActivities.findOne({visitorId: clientId, type: 'clientId'});
-    }
-  }
-  return null;
-}

--- a/packages/lesswrong/server/resolvers/postResolvers.ts
+++ b/packages/lesswrong/server/resolvers/postResolvers.ts
@@ -408,7 +408,7 @@ export const postGqlQueries = {
   },
   async HomepageCommunityEventPosts(root: void, { eventType }: { eventType: string }, context: ResolverContext) {
     const { Posts, currentUser } = context
-    const defaultPostSelector = getDefaultViewSelector(PostsViews, context)
+    const defaultPostSelector = await getDefaultViewSelector(PostsViews, context)
 
     const timeRange = 5 * 30 * 24 * 60 * 60 * 1000 // 5 months
     const posts = await Posts.find({

--- a/packages/lesswrong/server/resolvers/tagResolvers.ts
+++ b/packages/lesswrong/server/resolvers/tagResolvers.ts
@@ -96,7 +96,7 @@ interface TagUpdates {
   documentDeletions: CategorizedDeletionEvent[];
 }
 
-function getRootCommentsInTimeBlockSelector(before: Date, after: Date, context: ResolverContext): MongoSelector<DbComment> {
+function getRootCommentsInTimeBlockSelector(before: Date, after: Date, context: ResolverContext): Promise<MongoSelector<DbComment>> {
   return mergeWithDefaultViewSelector(CommentsViews, {
     deleted: false,
     postedAt: {$lt: before, $gt: after},
@@ -550,7 +550,7 @@ export const tagResolversGraphQLQueries = {
       return [];
     }
     
-    const rootCommentsSelector = getRootCommentsInTimeBlockSelector(before, after, context);
+    const rootCommentsSelector = await getRootCommentsInTimeBlockSelector(before, after, context);
 
     // Get
     // - revisions to tags, lenses, and summaries in the given time interval

--- a/packages/lesswrong/server/rss.ts
+++ b/packages/lesswrong/server/rss.ts
@@ -52,7 +52,7 @@ export const servePostRSS = async (terms: RSSTerms,) => {
   }
 
   const context = createAnonymousContext();
-  const parameters = viewTermsToQuery(PostsViews, terms, undefined, context);
+  const parameters = await viewTermsToQuery(PostsViews, terms, undefined, context);
   delete parameters['options']['sort']['sticky'];
 
   parameters.options.limit = 10;
@@ -109,7 +109,7 @@ export const serveCommentRSS = async (terms: RSSTerms, req: NextRequest) => {
   const feed = new RSS(getMeta(url));
   const context = await getContextFromReqAndRes({req, isSSR: false});
 
-  let parameters = viewTermsToQuery(CommentsViews, terms, undefined, context);
+  let parameters = await viewTermsToQuery(CommentsViews, terms, undefined, context);
   parameters.options.limit = 50;
   const commentsCursor = await Comments.find(parameters.selector, parameters.options).fetch();
   const restrictedComments = await accessFilterMultiple(null, 'Comments', commentsCursor, context) as DbComment[];

--- a/packages/lesswrong/server/scripts/generateInflationAdjustedKarmaReport.ts
+++ b/packages/lesswrong/server/scripts/generateInflationAdjustedKarmaReport.ts
@@ -1,5 +1,5 @@
 import { Posts } from "../../server/collections/posts/collection";
-import { getKarmaInflationSeries } from "../../lib/collections/posts/karmaInflation";
+import { getKarmaInflationSeries } from "../karmaInflation/cache";
 import { buildInflationAdjustedField } from "../../lib/collections/posts/views";
 import { postGetPageUrl } from "../../lib/collections/posts/helpers";
 import fs from 'fs';
@@ -8,7 +8,7 @@ const RELATIVE_TO = '2023-07-01T00:00:00.000Z';
 
 // Exported to allow running manually with "yarn repl"
 export const generateInflationAdjustedKarmaReport = async ({threshold = 100, relativeTo = RELATIVE_TO}: {threshold?: number, relativeTo?: string}) => {
-  const karmaInflationSeries = getKarmaInflationSeries();
+  const karmaInflationSeries = await getKarmaInflationSeries();
 
   // Get threshold in inflation adjusted karma
   const relativeToIdx = Math.floor((new Date(relativeTo).getTime() - karmaInflationSeries.start) / karmaInflationSeries.interval);
@@ -18,7 +18,7 @@ export const generateInflationAdjustedKarmaReport = async ({threshold = 100, rel
   // Get all posts with required fields
   const pipeline = [
     {
-      $addFields: buildInflationAdjustedField()
+      $addFields: buildInflationAdjustedField(karmaInflationSeries)
     },
     {
       $project: {

--- a/packages/lesswrong/server/serverMain.ts
+++ b/packages/lesswrong/server/serverMain.ts
@@ -2,7 +2,6 @@
 import { scheduleQueueProcessing } from './cache/swr';
 // import { initLegacyRoutes } from '@/lib/routes';
 import { startupSanityChecks } from './startupSanityChecks';
-import { refreshKarmaInflationCache } from './karmaInflation/cron';
 // import { addLegacyRssRoutes } from './legacy-redirects/routes';
 // import { initReviewWinnerCache } from './resolvers/reviewWinnerResolvers';
 import { serverCaptureEvent as captureEvent } from '@/server/analytics/serverAnalyticsWriter';
@@ -40,7 +39,6 @@ export async function runServerOnStartupFunctions() {
   scheduleQueueProcessing();
   // initLegacyRoutes();
   backgroundTask(startupSanityChecks());
-  backgroundTask(refreshKarmaInflationCache());
   // addLegacyRssRoutes();
   // backgroundTask(initReviewWinnerCache());
   backgroundTask(updateStripeIntentsCache());

--- a/packages/lesswrong/server/tableOfContents.ts
+++ b/packages/lesswrong/server/tableOfContents.ts
@@ -32,7 +32,7 @@ async function getTocCommentsServer(document: DbPost, context: ResolverContext) 
   const { Comments } = context;
 
   const commentSelector: any = {
-    ...getDefaultViewSelector(CommentsViews, context),
+    ...await getDefaultViewSelector(CommentsViews, context),
     answer: false,
     draft: false,
     parentAnswerId: null,

--- a/packages/lesswrong/server/utils/feedUtil.ts
+++ b/packages/lesswrong/server/utils/feedUtil.ts
@@ -48,7 +48,7 @@ export function viewBasedSubquery<
     doQuery: async (limit: number, cutoff: SortKeyType): Promise<Partial<ObjectsByCollectionName[N]>[]> => {
       const viewSet = allViews[collection.collectionName] as CollectionViewSet<N, Record<string, ViewFunction<N>>>;
       const selectorWithDefaults = includeDefaultSelector
-        ? mergeWithDefaultViewSelector(viewSet, selector, context)
+        ? await mergeWithDefaultViewSelector(viewSet, selector, context)
         : selector;
       const results = await queryWithCutoff({context, collection, selector, limit, cutoffField: sortField, cutoff, sortDirection});
       return await accessFilterMultiple(context.currentUser, collection.collectionName, results, context);
@@ -227,7 +227,7 @@ async function queryWithCutoff<N extends CollectionNameString>({
   // TODO: figure out how to get the appropriate collection's default view piped through here without going through allViews, if possible
   const viewSet: CollectionViewSet<CollectionNameString, any> = allViews[collectionName];
   const mergedSelector = mergeSelectors(
-    getDefaultViewSelector(viewSet, context),
+    await getDefaultViewSelector(viewSet, context),
     selector,
     cutoffSelector
   )

--- a/packages/lesswrong/stubs/server/karmaInflation/cache.ts
+++ b/packages/lesswrong/stubs/server/karmaInflation/cache.ts
@@ -1,0 +1,5 @@
+import type { TimeSeries } from "../../../lib/collections/posts/karmaInflation";
+
+export function getKarmaInflationSeries(): TimeSeries | Promise<TimeSeries> {
+  throw new Error("getKarmaInflationSeries can only be run on the server");
+}


### PR DESCRIPTION
Written by Claude
------
## Bug

A user reported that sorting tag pages by "Top (Inflation Adjusted)" (`?sortedBy=topAdjusted`) produces the same ordering as plain "Top". Confirmed: since the NextJS cutover, the karma inflation series was only ever loaded into its module-global cache by `runServerOnStartupFunctions`, which nothing in the production app calls anymore (the nightly cron refreshed only its own lambda's cache). Web instances were stuck on the null series (`values: [1]`), so `karmaInflationAdjustedScore = baseScore * 1`. (See the old TODO at `karmaInflation/cron.ts`: "fix this to work in serverless world".)

## Fix

Instead of warming a global from some other request-path hook (easy to bypass by accident), this makes the view pipeline support async view functions so views can fetch what they need themselves:

- `ViewFunction` may now return a `Promise`; `viewTermsToQuery` / `getDefaultViewSelector` / `mergeWithDefaultViewSelector` are async. All 16 call sites updated; no individual `views.ts` files needed changes.
- The Posts default view fetches the karma inflation series via a new server-only module (`server/karmaInflation/cache.ts`, with a client stub) that has a 1-hour in-memory TTL cache backed by `DatabaseMetadata`. The cron job now just writes the series to the DB.
- The `visitorActivity` prefetch HACK in `defaultResolvers.ts` (which existed precisely because views couldn't await) moves into the Posts default view, and the value is passed explicitly down to `frontpageTimeDecayExpr` instead of being smuggled through a mutated `ResolverContext`. The `ResolverContext.visitorActivity` field is deleted.
- Cleanup: deleted the unused `getByName`/`getServerSettings`/`getPublicSettings`/`getDatabaseId` methods from `DatabaseMetadataRepo`.

## Intentional behavior change

Server-side callers of `viewTermsToQuery` outside the Posts multi resolver (notably recombee's magic-sort native-arm query, which passes `filterSettings`) previously computed `filteredScore` with no visitor-activity data (activity factor 0), because the prefetch hack only ran in the multi resolver. They now get real activity-based time decay, consistent with the multi-resolver path. This also fixes `topAdjusted` for RSS feeds for free.

## Verification

- `yarn tsc` clean; all 759 unit tests pass; `yarn generate` is a no-op; client-tsconfig check confirms the new server import resolves to its stub.
- Ran the tag-page query path against the dev DB for the `utopia` tag: `top` and `topAdjusted` now produce different orderings with sensible era-scaled adjusted scores (e.g. "Just another day in utopia", 148 karma from 2011, outranks "My favorite depiction of utopia", 183 karma from June 2026).

## Known non-fix

`feedUtil.ts`'s `selectorWithDefaults` / `includeDefaultSelector` flag is a no-op (dead since bdee5daa06 introduced it — the merged selector is never passed to `queryWithCutoff`, which merges the default view unconditionally). Left untouched here since honoring the flag would remove filtering from `includeDefaultSelector: false` feed subqueries; flagging for @jimrandomh to decide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1215697448053206) by [Unito](https://www.unito.io)
