### PR TITLE
Fix research sandbox saves blocked by stale background-task tracking

### DIFF
--- a/packages/lesswrong/server/research/sandbox/sandboxLayout.ts
+++ b/packages/lesswrong/server/research/sandbox/sandboxLayout.ts
@@ -34,7 +34,7 @@ export const CLAUDE_MD_PATH = `${CLAUDE_DIR}/CLAUDE.md`;
  * this, rebuild the baseline snapshots, and existing sandboxes reconcile on
  * their next launch.
  */
-export const PINNED_CLAUDE_CODE_VERSION = "2.1.170";
+export const PINNED_CLAUDE_CODE_VERSION = "2.1.181";
 
 /** The model the research agent runs (`claude --model ...`). Requires a CLI
  * version that knows the model family — see PINNED_CLAUDE_CODE_VERSION. */

--- a/packages/lesswrong/server/research/sandbox/supervisor/conversationHub.ts
+++ b/packages/lesswrong/server/research/sandbox/supervisor/conversationHub.ts
@@ -52,13 +52,15 @@ const CANCEL_INTERRUPT_GRACE_MS = 10_000;
 const CANCEL_SIGKILL_GRACE_MS = 5_000;
 
 /**
- * `task_notification` statuses that do NOT mean the task ended. The CLI's
- * task events are undocumented, so deletion from the outstanding set is the
- * default (a wedged-awake sandbox is bounded by the 5h session cap and the
- * liveness gate in `hasPendingWork`), and only an explicitly in-progress
- * status keeps the task counted.
+ * Task statuses that mean a background task has settled, taken from the Claude
+ * Code Agent SDK message types (`@anthropic-ai/claude-agent-sdk`): the union of
+ * `SDKTaskNotificationMessage.status` ({completed, failed, stopped}) and the
+ * terminal subset of `SDKTaskUpdatedMessage.patch.status` ({completed, failed,
+ * killed}). The SDK exports the same set as `TERMINAL_TASK_STATUSES`. Every
+ * other status (pending/running/paused) and statusless patches (e.g.
+ * `{is_backgrounded: true}`) are non-terminal and keep the task counted.
  */
-const NON_TERMINAL_TASK_STATUSES = new Set(["running", "pending", "queued", "in_progress", "started"]);
+const TERMINAL_TASK_STATUSES = new Set(["completed", "failed", "killed", "stopped"]);
 
 export interface ConversationHubConfig {
   postPersister: PostPersister;
@@ -93,10 +95,11 @@ interface ConversationEntry {
    */
   cancelPending: boolean;
   /**
-   * Background Bash tasks the agent has started that haven't reached a
-   * terminal `task_notification` yet. A pending task means the process will
-   * re-invoke the agent later, so the sandbox must be kept alive even though
-   * no turn is running — surfaced to the heartbeat via `hasPendingWork`.
+   * Background Bash tasks the agent has started that haven't reached a terminal
+   * status yet (see `updateOutstandingTasks` for the terminal signals). A
+   * pending task means the process may re-invoke the agent later, so the
+   * sandbox must be kept alive even though no turn is running — surfaced to the
+   * heartbeat via `hasPendingWork`.
    */
   outstandingTaskIds: Set<string>;
   /** Serializes spawn/teardown so two dispatches can't race a respawn. */
@@ -235,20 +238,7 @@ export function createConversationHub(config: ConversationHubConfig) {
         entry.pendingTurns = Math.max(0, entry.pendingTurns - 1);
         entry.initSeenSinceResult = true;
       }
-      // `task_started` / `task_notification` bracket a background Bash task's
-      // lifetime. `task_updated` is deliberately ignored (can fire on
-      // non-terminal transitions), and a notification carrying an explicitly
-      // in-progress status keeps the task counted.
-      const taskId = line.parsed.task_id;
-      if (typeof taskId === "string") {
-        if (subtype === "task_started") entry.outstandingTaskIds.add(taskId);
-        if (subtype === "task_notification") {
-          const status = line.parsed.status;
-          if (typeof status !== "string" || !NON_TERMINAL_TASK_STATUSES.has(status)) {
-            entry.outstandingTaskIds.delete(taskId);
-          }
-        }
-      }
+      updateOutstandingTasks(entry, subtype, line.parsed);
     }
 
     if (line.kind === "result") {
@@ -521,6 +511,50 @@ function noop(): void {}
 function systemSubtypeOf(line: ParsedJsonlLine): string | undefined {
   const subtype = line.parsed?.subtype;
   return typeof subtype === "string" ? subtype : undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function isTerminalTaskStatus(status: unknown): boolean {
+  return typeof status === "string" && TERMINAL_TASK_STATUSES.has(status);
+}
+
+/**
+ * Maintain `entry.outstandingTaskIds` from the agent's task lifecycle events: a
+ * background Bash task is added on `task_started` and removed once it settles.
+ * Its terminal signal arrives in one of two shapes (Agent SDK message types),
+ * and a background Bash task uses ONLY the second — it emits no
+ * `task_notification` (verified against Claude Code 2.1.170 and 2.1.181):
+ *   - `task_notification.status` ∈ TERMINAL_TASK_STATUSES
+ *   - `task_updated.patch.status` ∈ TERMINAL_TASK_STATUSES
+ * Non-terminal `task_updated` patches (status running/pending/paused, or an
+ * `is_backgrounded`/progress-only patch with no status) keep the task counted;
+ * anything still outstanding when the process exits is cleared in `onExit`.
+ */
+function updateOutstandingTasks(
+  entry: ConversationEntry,
+  subtype: string | undefined,
+  parsed: Record<string, unknown>,
+): void {
+  const taskId = parsed.task_id;
+  if (typeof taskId !== "string") return;
+
+  if (subtype === "task_started") {
+    entry.outstandingTaskIds.add(taskId);
+    return;
+  }
+  if (subtype === "task_notification" && isTerminalTaskStatus(parsed.status)) {
+    entry.outstandingTaskIds.delete(taskId);
+    return;
+  }
+  if (subtype === "task_updated") {
+    const patch = parsed.patch;
+    if (isRecord(patch) && isTerminalTaskStatus(patch.status)) {
+      entry.outstandingTaskIds.delete(taskId);
+    }
+  }
 }
 
 /**

--- a/packages/lesswrong/unitTests/conversationHub.tests.ts
+++ b/packages/lesswrong/unitTests/conversationHub.tests.ts
@@ -228,6 +228,44 @@ describe("conversationHub", () => {
     expect(hub.hasPendingWork()).toBe(false);
   });
 
+  it("clears a background task that finishes via task_updated with no task_notification", async () => {
+    // A backgrounded Bash task signals completion through a terminal
+    // `task_updated.patch.status` and emits no `task_notification` (verified
+    // against Claude Code 2.1.170 and 2.1.181).
+    const { hub, procs } = mkHub();
+    await hub.dispatch({ conversationId: "c1", prompt: "install deps", claudeSessionId: "sess-1" });
+    procs[0].emit(init);
+    procs[0].emit({ type: "system", subtype: "task_started", task_id: "t1", task_type: "local_bash", session_id: "sess-1", uuid: "u-t1" });
+    procs[0].emit(resultLine);
+    expect(hub.hasPendingWork()).toBe(true);
+
+    // A non-terminal update (here, the task being backgrounded) keeps it counted.
+    procs[0].emit({ type: "system", subtype: "task_updated", task_id: "t1", patch: { is_backgrounded: true }, session_id: "sess-1", uuid: "u-t2" });
+    expect(hub.hasPendingWork()).toBe(true);
+
+    // A terminal patch status settles it — without any task_notification.
+    procs[0].emit({ type: "system", subtype: "task_updated", task_id: "t1", patch: { status: "completed", end_time: 1 }, session_id: "sess-1", uuid: "u-t3" });
+    expect(hub.hasPendingWork()).toBe(false);
+  });
+
+  it("keeps a task counted while task_updated reports a non-terminal status", async () => {
+    const { hub, procs } = mkHub();
+    await hub.dispatch({ conversationId: "c1", prompt: "start proxy", claudeSessionId: "sess-1" });
+    procs[0].emit(init);
+    procs[0].emit({ type: "system", subtype: "task_started", task_id: "t1", task_type: "local_bash", session_id: "sess-1", uuid: "u-t1" });
+    procs[0].emit(resultLine);
+
+    // `running` / `paused` are non-terminal and must not clear the task.
+    procs[0].emit({ type: "system", subtype: "task_updated", task_id: "t1", patch: { status: "running" }, session_id: "sess-1", uuid: "u-t2" });
+    expect(hub.hasPendingWork()).toBe(true);
+    procs[0].emit({ type: "system", subtype: "task_updated", task_id: "t1", patch: { status: "paused" }, session_id: "sess-1", uuid: "u-t3" });
+    expect(hub.hasPendingWork()).toBe(true);
+
+    // A failed task is terminal and clears it.
+    procs[0].emit({ type: "system", subtype: "task_updated", task_id: "t1", patch: { status: "failed", error: "boom" }, session_id: "sess-1", uuid: "u-t4" });
+    expect(hub.hasPendingWork()).toBe(false);
+  });
+
   it("persists the user turn at dispatch, before any process output", async () => {
     const { hub, events } = mkHub();
     await hub.dispatch({ conversationId: "c1", prompt: "hello", claudeSessionId: "sess-1" });


### PR DESCRIPTION
Written by Claude
------
## Problem

Trying to save a clean environment in a research project failed with *"Can't save an environment while a turn or background task is running"* even though nothing was actually running.

The supervisor's `outstandingTaskIds` set drives `hasPendingWork()` → `turnRunning`, which `saveEnvironment`'s quiesce gate uses to refuse a save while work is in flight. A background Bash task is added on `task_started` but was only removed on a terminal `task_notification`. However, a **backgrounded Bash task signals completion via a terminal `task_updated.patch.status` and emits no `task_notification` at all** (e.g. "Install npm dependencies", "Start reverse proxy"). Those tasks were never cleared, so `turnRunning` stayed `true` indefinitely — blocking saves and also silently deferring idle-stop / session rolls.

Across prod, **3 of 14** (~21%) task-running conversations carried this pattern.

Two compounding traps made it un-self-healing:
- `cancel()` early-returns when `!isBusy(entry)`, so the Cancel button is a no-op for a stale-task block.
- The heartbeat's `getTurnRunning` is also `hasPendingWork()`, so the sandbox kept re-arming its idle timeout and never rolled — the only thing that clears `outstandingTaskIds` is process exit.

## Root cause

The prior code assumed the task event protocol was undocumented and ignored `task_updated` wholesale (it had seen only its non-terminal `is_backgrounded`/progress forms). The protocol **is** documented in the Claude Code Agent SDK message types (`@anthropic-ai/claude-agent-sdk`): `SDKTaskUpdatedMessage.patch.status ∈ {pending,running,completed,failed,killed,paused}`, and the SDK exports the terminal set as `TERMINAL_TASK_STATUSES`.

## Fix

- `updateOutstandingTasks()` now honors **both** terminal shapes — `task_notification.status` and `task_updated.patch.status` — against the documented terminal set `{completed, failed, killed, stopped}`.
- Non-terminal patches (`running`/`pending`/`paused`, or `is_backgrounded`/progress-only) still keep the task counted, so **a genuinely-live task continues to block saves exactly as before** — only the false-positive is fixed.
- Replaced the guess-based `NON_TERMINAL_TASK_STATUSES` + "undocumented protocol" comments with the documented terminal set and SDK references.
- Bumped `PINNED_CLAUDE_CODE_VERSION` 2.1.170 → 2.1.181 (additive: upstream fixes for background agent/workflow result delivery and resume task-state restore). This does **not** change the background-Bash event shape and is not what fixes the bug.

## Verification

- Captured live `stream-json` from Claude Code **2.1.170** (prod transcript) and **2.1.181** (local headless run): a background Bash task terminates via `task_updated {patch:{status:"completed"}}` with **no** `task_notification` at both versions — confirming the bump doesn't alter the protocol and the fix is needed regardless.
- Unit tests: added coverage for clearing via terminal `task_updated` (no notification) and for staying counted through non-terminal `running`/`paused`. All 17 `conversationHub` tests pass; supervisor bundle builds.

## Deploy note

Bumping the pin only upgrades **existing** sandboxes on their next launch (via `reconcileClaudeCodeVersion`'s `npm install -g`). To bake 2.1.181 into **fresh** baselines, re-run `yarn research-sandbox-build-snapshot`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1215859744620317) by [Unito](https://www.unito.io)
