### PR TITLE
Derive supervisor busy-state from the CLI's authoritative session_state events

### DIFF
--- a/packages/lesswrong/server/research/sandbox/supervisor/claudeRunner.ts
+++ b/packages/lesswrong/server/research/sandbox/supervisor/claudeRunner.ts
@@ -111,7 +111,16 @@ export function startClaudeProcess(opts: ClaudeProcessOptions): ClaudeProcessHan
   try {
     proc = spawn(claudePath, args, {
       cwd,
-      env: { ...process.env, ...(opts.env ?? {}) },
+      env: {
+        ...process.env,
+        // Opt into authoritative `session_state_changed` events (idle/running/
+        // requires_action). The hub derives busy-state from these rather than
+        // inferring it from the turn stream — `idle` is the CLI's own
+        // turn-over signal and already accounts for queued messages and
+        // background-task re-invocations.
+        CLAUDE_CODE_EMIT_SESSION_STATE_EVENTS: "1",
+        ...(opts.env ?? {}),
+      },
       stdio: ["pipe", "pipe", "pipe"],
     });
   } catch (err) {

--- a/packages/lesswrong/server/research/sandbox/supervisor/conversationHub.ts
+++ b/packages/lesswrong/server/research/sandbox/supervisor/conversationHub.ts
@@ -18,20 +18,23 @@
  * Turn lifecycle: a dispatch writes one user message to the process's stdin.
  * Claude Code queues messages that arrive mid-turn and runs each as its own
  * turn (one `result` line per turn). Background-task completions re-invoke
- * the agent inside the same process with *no* dispatch — such turns begin
- * with a `system:init` line and also end with a `result`. Busy state is
- * therefore derived from the stream itself:
+ * the agent inside the same process with *no* dispatch.
  *
- *  - `pendingTurns` counts dispatched user messages whose turn hasn't
- *    *started* yet. It's decremented on `system:init` (the line that opens
- *    every turn), NOT on `result` — a result can belong to a background-task
- *    re-invocation that had no dispatch, and consuming a queued turn's count
- *    there would let the conversation read idle (and the sandbox get rolled)
- *    out from under a queued message. A re-invocation's init can still
- *    consume a queued turn's count, but that mislabels a much smaller window
- *    (the re-invocation itself is busy via activity) and re-rights itself at
- *    the queued turn's own init.
- *  - `activitySinceResult` is true while turn output is streaming.
+ * Busy state is read from the CLI's own `session_state_changed` events
+ * (enabled via `CLAUDE_CODE_EMIT_SESSION_STATE_EVENTS=1`): `running` /
+ * `requires_action` mean busy, `idle` means done. `idle` is the CLI's
+ * authoritative turn-over signal — it fires only after the turn's result
+ * flushes AND any background-task re-invocation completes — so it natively
+ * accounts for queued messages and re-invocations without us reconstructing
+ * the turn count. We deliberately do NOT keep a fallback inference from the
+ * turn stream: if the authoritative events stopped arriving, that's a broken
+ * assumption about the CLI we want to surface loudly, not paper over.
+ *
+ * `sessionState` is set to `running` optimistically on dispatch (to cover the
+ * sub-second window before the CLI's first event), then driven entirely by the
+ * events. A dispatch that arrives while a cancel is in flight is flagged
+ * (`dispatchedDuringCancel`) so its possibly-dropped turn gets a synthetic
+ * terminal result; see the `result` branch of `emit`.
  */
 import { randomUUID } from "node:crypto";
 import { ParsedJsonlLine, ClaudeEventKind } from "./jsonlParser";
@@ -39,17 +42,22 @@ import { ClaudeProcessHandle, startClaudeProcess } from "./claudeRunner";
 import { BackendEvent, PostPersister } from "./postPersister";
 import { writeBootstrapJsonl } from "./sessionBootstrap";
 import { ConversationState } from "./server";
-import {
-  isTurnActivity,
-  FLUSH_RESULT_SUBTYPE,
-  TURN_OPENING_SYSTEM_SUBTYPE,
-} from "../../../../lib/research/turnActivity";
+import { FLUSH_RESULT_SUBTYPE } from "../../../../lib/research/turnActivity";
 
 /** How long cancel waits for the interrupt control_request to end the turn
  * before escalating to SIGTERM (then SIGKILL). Interrupt normally lands in
  * single-digit seconds; the margin covers a turn stuck in a slow tool call. */
 const CANCEL_INTERRUPT_GRACE_MS = 10_000;
 const CANCEL_SIGKILL_GRACE_MS = 5_000;
+
+/** Subtype of the CLI's authoritative busy/idle event (see module doc). */
+const SESSION_STATE_SUBTYPE = "session_state_changed";
+
+type SessionState = "idle" | "running" | "requires_action";
+
+function parseSessionState(value: unknown): SessionState | null {
+  return value === "idle" || value === "running" || value === "requires_action" ? value : null;
+}
 
 /**
  * Task statuses that mean a background task has settled, taken from the Claude
@@ -75,18 +83,18 @@ interface ConversationEntry {
   state: ConversationState;
   proc: ClaudeProcessHandle | null;
   claudeSessionId: string | null;
-  /** Dispatched user messages whose turn hasn't opened (no `system:init` yet). */
-  pendingTurns: number;
-  /** True when turn output has streamed since the last `result` line. */
-  activitySinceResult: boolean;
   /**
-   * Whether a `system:init` arrived since the last `result`. A result that
-   * arrives without one belongs to a dispatched turn that failed before
-   * opening (early CLI error), so it must release a pending count — otherwise
-   * the conversation reads busy forever while the client transcript reads
-   * idle.
+   * The CLI's authoritative busy/idle state, from `session_state_changed`
+   * events; set to `running` optimistically on dispatch. `isBusy` is exactly
+   * `sessionState !== "idle"`.
    */
-  initSeenSinceResult: boolean;
+  sessionState: SessionState;
+  /**
+   * The terminal status to record once the session next goes `idle`
+   * (`completed`, or `cancelled`/`errored` after a cancel/crash). Drives the
+   * client-facing `state.status`, which stays `running` until idle.
+   */
+  terminalReason: ConversationState["status"];
   /**
    * Set by cancel(); cleared by the next `result` line (the interrupted
    * turn's terminal) or process exit — NOT by a dispatch, so a new message
@@ -94,6 +102,12 @@ interface ConversationEntry {
    * defuse the SIGTERM escalation while the interrupt is still unanswered.
    */
   cancelPending: boolean;
+  /**
+   * Whether a user message was dispatched while a cancel was in flight. Such a
+   * turn may be dropped by the CLI on interrupt, so on the cancel's `result` we
+   * emit a synthetic terminal result to keep its transcript turn from dangling.
+   */
+  dispatchedDuringCancel: boolean;
   /**
    * Background Bash tasks the agent has started that haven't reached a terminal
    * status yet (see `updateOutstandingTasks` for the terminal signals). A
@@ -189,10 +203,10 @@ export function createConversationHub(config: ConversationHubConfig) {
       state: { conversationId, status: "idle" },
       proc: null,
       claudeSessionId: null,
-      pendingTurns: 0,
-      activitySinceResult: false,
-      initSeenSinceResult: false,
+      sessionState: "idle",
+      terminalReason: "completed",
       cancelPending: false,
+      dispatchedDuringCancel: false,
       outstandingTaskIds: new Set(),
       opChain: Promise.resolve(),
     };
@@ -201,7 +215,13 @@ export function createConversationHub(config: ConversationHubConfig) {
   }
 
   function isBusy(entry: ConversationEntry): boolean {
-    return entry.pendingTurns > 0 || entry.activitySinceResult;
+    return entry.sessionState !== "idle";
+  }
+
+  /** Apply an authoritative `session_state_changed` event. */
+  function applySessionState(entry: ConversationEntry, state: SessionState) {
+    entry.sessionState = state;
+    refreshStatus(entry, state === "idle" ? entry.terminalReason : undefined);
   }
 
   function refreshStatus(entry: ConversationEntry, terminal?: ConversationState["status"]) {
@@ -217,6 +237,17 @@ export function createConversationHub(config: ConversationHubConfig) {
   }
 
   function emit(entry: ConversationEntry, line: ParsedJsonlLine) {
+    const subtype = systemSubtypeOf(line);
+
+    // `session_state_changed` is the CLI's authoritative busy/idle signal — our
+    // control input, not transcript content, so it drives `sessionState` and is
+    // not persisted.
+    if (line.kind === "system" && subtype === SESSION_STATE_SUBTYPE) {
+      const state = parseSessionState(line.parsed?.state);
+      if (state) applySessionState(entry, state);
+      return;
+    }
+
     const persistKind = mapKindForPersistence(line.kind);
     if (persistKind) {
       config.postPersister.enqueue(entry.conversationId, {
@@ -228,40 +259,21 @@ export function createConversationHub(config: ConversationHubConfig) {
       });
     }
 
-    const subtype = systemSubtypeOf(line);
-
     if (line.kind === "system" && line.parsed) {
-      if (subtype === TURN_OPENING_SYSTEM_SUBTYPE) {
-        // A turn opened; if one of ours was queued, it's (presumably) this
-        // one. See the module doc for why init — not result — consumes the
-        // pending count.
-        entry.pendingTurns = Math.max(0, entry.pendingTurns - 1);
-        entry.initSeenSinceResult = true;
-      }
       updateOutstandingTasks(entry, subtype, line.parsed);
     }
 
     if (line.kind === "result") {
-      // One `result` per turn — dispatched, queued, or a background-task
-      // re-invocation. Turn-end for busy purposes; the conversation may still
-      // have queued turns pending. An init-less result is a dispatched turn
-      // that failed before opening: release its pending count here, since no
-      // init ever will. (Re-invocation results can't take this branch — every
-      // re-invocation opens with its own init.)
-      if (!entry.initSeenSinceResult) {
-        entry.pendingTurns = Math.max(0, entry.pendingTurns - 1);
-      }
-      entry.initSeenSinceResult = false;
-      entry.activitySinceResult = false;
+      // One `result` per turn. Busy/idle is owned by `session_state_changed`
+      // (the conversation may still have a re-invocation or queued turn to go,
+      // so a result is not by itself turn-over); here we only record how the
+      // turn ended and flush a cancelled-and-possibly-dropped queued turn.
       const wasCancel = entry.cancelPending;
       entry.cancelPending = false;
-      if (wasCancel && entry.pendingTurns > 0) {
-        // The cancel interrupted a turn while other dispatched messages were
-        // still queued on stdin. Whether the CLI runs or drops queued
-        // messages after an interrupt is version-dependent, so close them out
-        // now — a cancel means "stop everything outstanding". If the CLI does
-        // run one anyway, its init/activity re-raise busy state.
-        entry.pendingTurns = 0;
+      if (wasCancel && entry.dispatchedDuringCancel) {
+        // A message was dispatched while the cancel was in flight; the CLI may
+        // drop it on interrupt, so close its turn out so the transcript can't
+        // dangle. (If the CLI does run it, its own result supersedes this.)
         enqueueSyntheticInterruptedResult(
           config.postPersister,
           entry.conversationId,
@@ -269,13 +281,11 @@ export function createConversationHub(config: ConversationHubConfig) {
           now(),
         );
       }
-      refreshStatus(entry, wasCancel ? "cancelled" : "completed");
+      entry.dispatchedDuringCancel = false;
+      entry.terminalReason = wasCancel ? "cancelled" : "completed";
+      // Applies only once the session is idle; stays "running" if more is coming.
+      refreshStatus(entry, entry.terminalReason);
       return;
-    }
-
-    if (isTurnActivity(line.kind, subtype)) {
-      entry.activitySinceResult = true;
-      refreshStatus(entry);
     }
   }
 
@@ -331,10 +341,15 @@ export function createConversationHub(config: ConversationHubConfig) {
       onExit: ({ code }) => {
         if (entry.proc !== proc) return;
         entry.proc = null;
-        if (isBusy(entry)) {
-          // The process died mid-turn (crash, OOM, cancel escalation). Close
-          // the dangling turn(s) with a synthetic terminal `result` so
-          // clients aren't stuck on "running".
+        const wasBusy = isBusy(entry);
+        // The process is gone: no more events will arrive, so force the session
+        // idle ourselves (the only place we set state without an event).
+        entry.sessionState = "idle";
+        if (wasBusy) {
+          // It died mid-turn (crash, OOM, cancel escalation). Close the
+          // dangling turn with a synthetic terminal `result` so clients aren't
+          // stuck on "running", and record the terminal status (now applied,
+          // since the session reads idle).
           const interrupted = entry.cancelPending;
           enqueueSyntheticInterruptedResult(
             config.postPersister,
@@ -344,12 +359,11 @@ export function createConversationHub(config: ConversationHubConfig) {
               : `Turn interrupted: the agent process exited unexpectedly${code !== null ? ` (code ${code})` : ""}.`,
             now(),
           );
-          entry.pendingTurns = 0;
-          entry.activitySinceResult = false;
-          refreshStatus(entry, interrupted ? "cancelled" : "errored");
+          entry.terminalReason = interrupted ? "cancelled" : "errored";
+          refreshStatus(entry, entry.terminalReason);
         }
-        entry.initSeenSinceResult = false;
         entry.cancelPending = false;
+        entry.dispatchedDuringCancel = false;
         // No process, no future re-invocation: pending tasks can't keep the
         // sandbox alive any more (orphaned task processes die with the sandbox).
         entry.outstandingTaskIds.clear();
@@ -425,7 +439,12 @@ export function createConversationHub(config: ConversationHubConfig) {
         claudeMessageUuid: null,
         supervisorEmittedAt: new Date(now()).toISOString(),
       });
-      entry.pendingTurns += 1;
+      // Mark busy optimistically: we've handed the CLI work, and its first
+      // `session_state_changed` (running) may lag the send by a beat. A dispatch
+      // racing an in-flight cancel is flagged so its turn can be flushed if the
+      // CLI drops it (see the `result` branch of `emit`).
+      if (entry.cancelPending) entry.dispatchedDuringCancel = true;
+      entry.sessionState = "running";
       refreshStatus(entry);
     });
     entry.opChain = run.then(noop, noop);
@@ -449,6 +468,7 @@ export function createConversationHub(config: ConversationHubConfig) {
     if (!entry || !entry.proc?.alive() || !isBusy(entry)) return;
     const proc = entry.proc;
     entry.cancelPending = true;
+    entry.dispatchedDuringCancel = false;
     const requestId = `interrupt-${++interruptCounter}`;
     const wrote = proc.interrupt(requestId);
     const escalate = () => {

--- a/packages/lesswrong/unitTests/conversationHub.tests.ts
+++ b/packages/lesswrong/unitTests/conversationHub.tests.ts
@@ -98,6 +98,8 @@ const assistantLine = {
   session_id: "sess-1",
 };
 const resultLine = { type: "result", subtype: "success", uuid: "u-r", session_id: "sess-1" };
+// The CLI's authoritative turn-over signal (CLAUDE_CODE_EMIT_SESSION_STATE_EVENTS).
+const stateIdle = { type: "system", subtype: "session_state_changed", state: "idle", uuid: "u-si", session_id: "sess-1" };
 
 function mkHub(factoryOpts?: { sendFailsForProcs?: number[] }) {
   const { factory, procs } = mkFakeFactory(factoryOpts);
@@ -122,6 +124,7 @@ describe("conversationHub", () => {
     procs[0].emit(init);
     procs[0].emit(assistantLine);
     procs[0].emit(resultLine);
+    procs[0].emit(stateIdle); // CLI's authoritative turn-over
     expect(status(hub)).toBe("completed");
 
     const r2 = await hub.dispatch({ conversationId: "c1", prompt: "second", claudeSessionId: "sess-1" });
@@ -143,7 +146,7 @@ describe("conversationHub", () => {
     expect(procs[0].opts.sessionMode).toBe("resume");
   });
 
-  it("accepts a dispatch mid-turn and stays running until the queued turn ends", async () => {
+  it("stays busy until the CLI reports idle, not at the first result", async () => {
     const { hub, procs } = mkHub();
     await hub.dispatch({ conversationId: "c1", prompt: "one", claudeSessionId: "sess-1" });
     procs[0].emit(init);
@@ -154,69 +157,62 @@ describe("conversationHub", () => {
     expect(r.accepted).toBe(true);
     expect(procs[0].sent.length).toBe(2);
 
-    procs[0].emit(resultLine); // ends turn one; turn two still pending
-    expect(status(hub)).toBe("running");
-    procs[0].emit(init);
-    procs[0].emit(resultLine); // ends turn two
-    expect(status(hub)).toBe("completed");
-  });
-
-  it("goes busy again on a background-task re-invocation with no dispatch", async () => {
-    const { hub, procs } = mkHub();
-    await hub.dispatch({ conversationId: "c1", prompt: "go", claudeSessionId: "sess-1" });
-    procs[0].emit(init);
-    procs[0].emit(resultLine);
-    expect(status(hub)).toBe("completed");
-
-    // Task finishes later; the process re-invokes the agent: init arrives
-    // with no dispatch having happened.
-    procs[0].emit(init);
-    procs[0].emit(assistantLine);
-    expect(status(hub)).toBe("running");
-    procs[0].emit(resultLine);
-    expect(status(hub)).toBe("completed");
-  });
-
-  it("does not let a re-invocation's result consume a queued turn's pending count", async () => {
-    const { hub, procs } = mkHub();
-    await hub.dispatch({ conversationId: "c1", prompt: "go", claudeSessionId: "sess-1" });
-    procs[0].emit(init);
-    procs[0].emit(resultLine);
-
-    // Re-invocation running; user dispatches B mid-re-invocation.
-    procs[0].emit(init);
-    procs[0].emit(assistantLine);
-    await hub.dispatch({ conversationId: "c1", prompt: "queued", claudeSessionId: "sess-1" });
-
-    // The re-invocation's result must not make the conversation read idle
-    // while B is still queued on stdin.
+    // A turn's result is NOT turn-over: more work (the queued turn) is coming,
+    // and the CLI hasn't reported idle.
     procs[0].emit(resultLine);
     expect(status(hub)).toBe("running");
     expect(hub.hasPendingWork()).toBe(true);
-
-    procs[0].emit(init); // B starts
+    procs[0].emit(init);
     procs[0].emit(resultLine);
+    expect(hub.hasPendingWork()).toBe(true); // still no idle event
+
+    procs[0].emit(stateIdle);
+    expect(status(hub)).toBe("completed");
+    expect(hub.hasPendingWork()).toBe(false);
+  });
+
+  it("stays busy through a background-task re-invocation until idle (no wedge)", async () => {
+    // Regression for the pendingTurns wedge: turn 1 launches a background task;
+    // after turn 1's result the task settles and re-invokes the agent (an init
+    // with no dispatch), then more turns run. Only the CLI's `idle` ends it —
+    // and it must end cleanly, not stick busy forever.
+    const { hub, procs } = mkHub();
+    await hub.dispatch({ conversationId: "c1", prompt: "go", claudeSessionId: "sess-1" });
+    procs[0].emit(init);
+    procs[0].emit(resultLine); // turn 1 result, but session not idle (task pending)
+    expect(hub.hasPendingWork()).toBe(true);
+
+    procs[0].emit(init); // background-task re-invocation, no dispatch
+    procs[0].emit(assistantLine);
+    procs[0].emit(resultLine);
+    expect(hub.hasPendingWork()).toBe(true);
+
+    procs[0].emit(stateIdle);
+    expect(hub.hasPendingWork()).toBe(false);
     expect(status(hub)).toBe("completed");
   });
 
-  it("releases the pending count when a dispatched turn fails before opening", async () => {
+  it("ends busy when the CLI goes idle even if a turn fails before opening", async () => {
     const { hub, procs } = mkHub();
     await hub.dispatch({ conversationId: "c1", prompt: "go", claudeSessionId: "sess-1" });
     expect(hub.hasPendingWork()).toBe(true);
-    // Early CLI failure: the turn's result arrives without any system:init.
-    // The pending count must not outlive it (the conversation would read
-    // busy forever while the client transcript reads idle).
+    // Early CLI failure: an error result, then the CLI reports idle.
     procs[0].emit({ ...resultLine, subtype: "error_during_execution", is_error: true });
+    procs[0].emit(stateIdle);
     expect(hub.hasPendingWork()).toBe(false);
     expect(status(hub)).toBe("completed");
   });
 
   it("reports pending work while a background task is outstanding", async () => {
+    // A background agent/workflow can let the session report idle while it
+    // keeps running, so `outstandingTaskIds` keeps the sandbox awake
+    // independently of `sessionState`.
     const { hub, procs } = mkHub();
     await hub.dispatch({ conversationId: "c1", prompt: "scrape", claudeSessionId: "sess-1" });
     procs[0].emit(init);
     procs[0].emit({ type: "system", subtype: "task_started", task_id: "t1", session_id: "sess-1", uuid: "u-t1" });
     procs[0].emit(resultLine);
+    procs[0].emit(stateIdle); // session idle, but the task is still outstanding
     expect(status(hub)).toBe("completed");
     expect(hub.hasPendingWork()).toBe(true); // task keeps the sandbox awake
 
@@ -237,6 +233,7 @@ describe("conversationHub", () => {
     procs[0].emit(init);
     procs[0].emit({ type: "system", subtype: "task_started", task_id: "t1", task_type: "local_bash", session_id: "sess-1", uuid: "u-t1" });
     procs[0].emit(resultLine);
+    procs[0].emit(stateIdle);
     expect(hub.hasPendingWork()).toBe(true);
 
     // A non-terminal update (here, the task being backgrounded) keeps it counted.
@@ -254,6 +251,7 @@ describe("conversationHub", () => {
     procs[0].emit(init);
     procs[0].emit({ type: "system", subtype: "task_started", task_id: "t1", task_type: "local_bash", session_id: "sess-1", uuid: "u-t1" });
     procs[0].emit(resultLine);
+    procs[0].emit(stateIdle);
 
     // `running` / `paused` are non-terminal and must not clear the task.
     procs[0].emit({ type: "system", subtype: "task_updated", task_id: "t1", patch: { status: "running" }, session_id: "sess-1", uuid: "u-t2" });
@@ -321,6 +319,7 @@ describe("conversationHub", () => {
     expect(procs[0].kills.length).toBe(0); // no escalation needed
 
     procs[0].emit({ ...resultLine, subtype: "error_during_execution", is_error: true });
+    procs[0].emit(stateIdle);
     expect(status(hub)).toBe("cancelled");
     expect(hub.hasPendingWork()).toBe(false);
 
@@ -333,11 +332,10 @@ describe("conversationHub", () => {
   it("stays busy after a cancel issued before the turn produced output", async () => {
     const { hub, procs } = mkHub();
     await hub.dispatch({ conversationId: "c1", prompt: "go", claudeSessionId: "sess-1" });
-    // No output yet: busy comes solely from the pending dispatched turn.
+    // No idle event yet: the dispatch's optimistic `running` keeps it busy, so
+    // the cancel proceeds (isBusy gate) and the escalation timer can fire.
     await hub.cancel("c1");
     expect(procs[0].interrupts.length).toBe(1);
-    // The cancel must not zero the pending count — otherwise the escalation
-    // path would read the conversation as already-interrupted and never fire.
     expect(status(hub)).toBe("running");
     expect(hub.hasPendingWork()).toBe(true);
   });
@@ -355,10 +353,13 @@ describe("conversationHub", () => {
     await hub.dispatch({ conversationId: "c1", prompt: "raced", claudeSessionId: "sess-1" });
 
     procs[0].emit({ ...resultLine, subtype: "error_during_execution", is_error: true });
-    expect(status(hub)).toBe("cancelled");
+    // The flush (a synthetic interrupted result for the raced turn) fires on
+    // the cancelled turn's result, before the session reports idle.
     const last = events[events.length - 1];
     expect(last.kind).toBe("result");
     expect(JSON.parse(last.rawJsonl).subtype).toBe("interrupted");
+    procs[0].emit(stateIdle);
+    expect(status(hub)).toBe("cancelled");
     expect(hub.hasPendingWork()).toBe(false);
   });
 
@@ -367,6 +368,7 @@ describe("conversationHub", () => {
     await hub.dispatch({ conversationId: "c1", prompt: "go", claudeSessionId: "sess-1" });
     procs[0].emit(init);
     procs[0].emit(resultLine);
+    procs[0].emit(stateIdle);
     await hub.cancel("c1");
     expect(procs[0].interrupts.length).toBe(0);
     expect(procs[0].kills.length).toBe(0);


### PR DESCRIPTION
Written by Claude
--------
## Problem

The supervisor inferred per-conversation busy-state (`isBusy` → `turnRunning`, which gates environment saves and idle rolls) from a `pendingTurns` counter: `+1` per dispatch, `−1` per `system:init`. That assumes a 1:1 dispatch↔`init` correspondence, but the stream violates it — a **background-task re-invocation emits an `init` with no dispatch**, and the `max(0, …)` floor turns the unmatched decrement into a permanent `+1`. The conversation then reads busy forever (no in-flight turn), blocking saves. Observed in prod: a "vercel login" background task re-invoked the agent, and a later queued dispatch made the off-by-one permanent (`status: "running"` for 20+ min after the last `result`, no events between).

The init/result stream fundamentally can't reconstruct this accurately: a dispatched-turn `init` and a re-invocation `init` are byte-identical.

## Fix

Stop inferring; read the CLI's **authoritative** signal. Spawn the agent with `CLAUDE_CODE_EMIT_SESSION_STATE_EVENTS=1` and track `session_state_changed` (`idle` | `running` | `requires_action`). `idle` is the CLI's turn-over signal — it fires only after the result flushes **and** any background-task re-invocation completes — so it natively accounts for queued messages and re-invocations.

- `isBusy` is now exactly `sessionState !== "idle"`, set to `running` optimistically on dispatch to cover the sub-second window before the first event.
- **No fallback inference from the turn stream.** If the authoritative events stop arriving, that's a broken assumption about the CLI we want to surface loudly, not silently mask.

### Verified empirically (Claude Code 2.1.181, our pinned version)

A turn that spawns a background Bash task emits, in order:
`STATE running` → `init` → `task_started` → `RESULT` → `task_updated(completed)` → `init` (re-invocation) → `RESULT` → `STATE idle`. The single `idle` lands only after the background re-invocation completes — exactly the case `pendingTurns` mishandled.

## What changed

- Removed `pendingTurns`, `initSeenSinceResult`, `activitySinceResult`, and the init-decrement logic (and the earlier timestamp-bounded band-aid this supersedes).
- Cancel-flush (synthetic terminal result for a queued turn the CLI may drop on interrupt) now keys off a `dispatchedDuringCancel` flag instead of the counter.
- `status` becomes terminal (`completed`/`cancelled`/`errored`) when the session goes `idle` (`terminalReason`); it stays `running` until then.
- `session_state_changed` is control state, not transcript content → **not persisted**.
- Background-task keep-alive (`outstandingTaskIds`, from #12595) is **unchanged** — it still covers background agents that report the session idle while they continue.

## Tests

Rewrote the `conversationHub` suite to drive busy/idle via `session_state_changed` (16 passing), including a regression test that a background-task re-invocation followed by more turns ends cleanly on `idle` (no wedge), and that a turn `result` is *not* by itself turn-over. Authoritative `yarn tsc` clean; supervisor bundle builds.

## Deploy note

This depends on the opt-in env var being honored, which is the case at the pinned 2.1.181. Existing sandboxes pick it up when they next resume (the supervisor relaunches with the new bundle + env).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
