### PR TITLE
Allow unreviewed users to use post link sharing

### DIFF
--- a/packages/lesswrong/components/editor/PostSharingSettings.tsx
+++ b/packages/lesswrong/components/editor/PostSharingSettings.tsx
@@ -86,7 +86,7 @@ const PostSharingIcon: FC<{
   return <PersonAddIcon {...props} />;
 }
 
-const noSharePermissionTooltip = "You need at least 1 karma or to be approved by a mod to share";
+const noSharePermissionTooltip = "You need to be logged in to share";
 
 interface PostSharingSettingsProps {
   field: TypedFieldApi<SharingSettings, EditablePost, PostSubmitMeta>;

--- a/packages/lesswrong/components/posts/EditorSettingsSidebar.tsx
+++ b/packages/lesswrong/components/posts/EditorSettingsSidebar.tsx
@@ -1090,7 +1090,7 @@ function SharingPanel({ form, canShare, canEditCoauthors, flash, currentUser }: 
         </>}
       </> : (
         <div className={classes.disabledMessage}>
-          You need at least 1 karma to use sharing features
+          You need to be logged in to use sharing features
         </div>
       )}
     </div>

--- a/packages/lesswrong/lib/betas.ts
+++ b/packages/lesswrong/lib/betas.ts
@@ -7,7 +7,7 @@
 // Beta-feature test functions must handle the case where user is null.
 
 import { testServerSetting, isEAForum, isLWorAF, isLW, userIdsWithAccessToLlmChat } from './instanceSettings';
-import { isAdmin, userOverNKarmaOrApproved } from "./vulcan-users/permissions";
+import { isAdmin } from "./vulcan-users/permissions";
 import {isFriendlyUI} from '../themes/forumTheme'
 
 type BetaGate = (user: UsersCurrent | DbUser | null) => boolean;
@@ -26,7 +26,7 @@ const adminOrBeta = (user: UsersCurrent|DbUser|null): boolean => adminOnly(user)
 //////////////////////////////////////////////////////////////////////////////
 
 export const userCanCreateCommitMessages = moderatorOnly;
-export const userCanUseSharing = (user: UsersCurrent|DbUser|null): boolean => moderatorOnly(user) || userOverNKarmaOrApproved(1)(user);
+export const userCanUseSharing = (user: UsersCurrent|DbUser|null): boolean => !!user;
 export const userHasNewTagSubscriptions: BetaGate = (user) => isEAForum() ? shippedFeature(user) : disabled(user);
 export const userHasDefaultProfilePhotos = disabled
 


### PR DESCRIPTION
Ultimately, this restriction was motivated mostly by cost considerations (ckEditor charged us a dollar or something per collaborative document; now they're basically free).

Written by Claude
----
## Summary

Lets new, unreviewed users enable link sharing for their posts and send them to others. Previously this was restricted to moderators, reviewed users, or users with karma > 1.

## Changes

- **`lib/betas.ts`**: `userCanUseSharing` now returns `!!user` (any logged-in user) instead of `moderatorOnly(user) || userOverNKarmaOrApproved(1)(user)`. Removed the now-unused `userOverNKarmaOrApproved` import.
- **`components/editor/PostSharingSettings.tsx`**: Updated the disabled-state tooltip to "You need to be logged in to share".
- **`components/posts/EditorSettingsSidebar.tsx`**: Updated the disabled-state message to "You need to be logged in to use sharing features".

## Notes

- The restriction was only ever enforced client-side; the server schema (`sharingSettings`, `shareWithUsers`) already used `canCreate: ["members"]` / `canUpdate: [userOwns, ...]`, so no server/schema change or migration is needed.
- No `yarn generate` needed (no schemas, resolvers, or fragments changed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1215878153937804) by [Unito](https://www.unito.io)
