### PR TITLE
Hopefully fix spotlight auto-advance cronjob

### DIFF
--- a/packages/lesswrong/server/spotlightCron.ts
+++ b/packages/lesswrong/server/spotlightCron.ts
@@ -2,9 +2,15 @@ import Spotlights from '../server/collections/spotlights/collection';
 
 const MS_IN_DAY = 1000 * 60 * 60 * 24;
 
-export async function updatePromotedSpotlightItem() {
-  const spotlights = await Spotlights.find({ draft: false }).fetch();
-  if (!spotlights.length) return;
+export interface SpotlightRotationItem {
+  _id: string;
+  lastPromotedAt: Date;
+  position: number;
+  duration: number;
+}
+
+export function getNextSpotlightPromotion(spotlights: SpotlightRotationItem[], now: Date) {
+  if (!spotlights.length) return null;
 
   // Ascending order
   const mostRecentlyPromotedSpotlights = [...spotlights].sort((first, second) => first.lastPromotedAt.valueOf() - second.lastPromotedAt.valueOf());
@@ -13,28 +19,31 @@ export async function updatePromotedSpotlightItem() {
   const [currentSpotlight] = mostRecentlyPromotedSpotlights.slice(-1);
   const [lastSpotlightByPosition] = positionAscOrderedSpotlights.slice(-1);
 
-  if (!currentSpotlight || !lastSpotlightByPosition) return;
+  if (!currentSpotlight || !lastSpotlightByPosition) return null;
 
-  const now = new Date();
   const lastPromotionDate = new Date(currentSpotlight.lastPromotedAt);
 
   const msSincePromotion = now.valueOf() - lastPromotionDate.valueOf();
   const daysSincePromotion = Math.floor(msSincePromotion / MS_IN_DAY);
 
   if (daysSincePromotion < currentSpotlight.duration) {
-    return;
+    return null;
   }
 
   const currentSpotlightPosition = currentSpotlight.position;
   const lastSpotlightPosition = lastSpotlightByPosition.position;
+  const currentSpotlightIndex = positionAscOrderedSpotlights.findIndex(spotlight => spotlight._id === currentSpotlight._id);
+
+  if (currentSpotlightIndex < 0) return null;
 
   // If we have any further spotlight items after the current one, promote the next one
   // Otherwise, roll over to the start
   const promoteIndex = lastSpotlightPosition > currentSpotlightPosition
-    ? positionAscOrderedSpotlights.indexOf(currentSpotlight) + 1
+    ? currentSpotlightIndex + 1
     : 0;
 
-  const { position: positionToPromote } = positionAscOrderedSpotlights[promoteIndex];
+  const spotlightToPromote = positionAscOrderedSpotlights[promoteIndex];
+  if (!spotlightToPromote) return null;
 
   // This, of course, is not exactly the timestamp at which we actually promote this spotlight item.
   // But doing it this way prevents a slow "walk" due to the cron job interval...
@@ -42,5 +51,29 @@ export async function updatePromotedSpotlightItem() {
   const newPromotionDate = new Date(lastPromotionDate);
   newPromotionDate.setDate(lastPromotionDate.getDate() + currentSpotlight.duration);
 
-  await Spotlights.rawUpdateOne({ position: positionToPromote, draft: false }, { $set: { lastPromotedAt: newPromotionDate } });
+  return {
+    spotlightId: spotlightToPromote._id,
+    newPromotionDate,
+  };
+}
+
+export async function updatePromotedSpotlightItem() {
+  const now = new Date();
+  const spotlights = await Spotlights.find({
+    draft: false,
+    deletedDraft: false,
+    lastPromotedAt: { $lt: now },
+  }).fetch();
+
+  const nextPromotion = getNextSpotlightPromotion(spotlights, now);
+  if (!nextPromotion) return;
+
+  await Spotlights.rawUpdateOne(
+    {
+      _id: nextPromotion.spotlightId,
+      draft: false,
+      deletedDraft: false,
+    },
+    { $set: { lastPromotedAt: nextPromotion.newPromotionDate } }
+  );
 }


### PR DESCRIPTION
> Found and patched a likely cause: the cron was rotating over draft: false spotlights, but the front-page query only displays draft: false, deletedDraft: false, and non-future lastPromotedAt spotlights. So an archived/deleted spotlight could be treated as current/next by the cron, making the visible spotlight appear stuck.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1215989128675346) by [Unito](https://www.unito.io)
