### PR TITLE
Fix selection-lost crash on undo/redo in suggestion mode

### DIFF
--- a/packages/lesswrong/components/lexical/plugins/YjsUndoCursorPlugin/index.tsx
+++ b/packages/lesswrong/components/lexical/plugins/YjsUndoCursorPlugin/index.tsx
@@ -16,6 +16,7 @@ import { useEffect, useRef } from 'react';
 import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext';
 import {
   $getNodeByKey,
+  $getSelection,
   $isRangeSelection,
   $setSelection,
   COMMAND_PRIORITY_LOW,
@@ -55,6 +56,53 @@ export default function YjsUndoCursorPlugin(): null {
   const pendingHistoricActionRef = useRef<'undo' | 'redo' | null>(null);
 
   useEffect(() => {
+    /**
+     * Clear the current range selection before the Yjs UndoManager reverses a
+     * change. The reversal removes (and re-keys) nodes, and @lexical/yjs's sync
+     * update clones the pre-undo selection into the resulting editor state. If
+     * that selection points at a node the reversal removes, the clone dangles
+     * and Lexical throws from updateEditor:
+     *   "selection has been lost because the previously selected nodes have
+     *    been removed..."
+     *
+     * This bites, for example, after deleting from the very start of a
+     * paragraph in suggestion mode: the resulting collapsed selection is an
+     * element point on the paragraph (ProtonNode `selectPrevious()` falls back
+     * to `parent.select(0, 0)` when the delete suggestion is the first child),
+     * and an undo/redo/undo sequence ends up cloning it onto a removed node.
+     *
+     * Clearing the selection first means the sync update has nothing to dangle;
+     * the correct cursor is then restored from our selection-history stack in
+     * the update listener below. This runs at COMMAND_PRIORITY_LOW, before the
+     * UndoManager handler at COMMAND_PRIORITY_EDITOR, so it takes effect first.
+     *
+     * If the undo/redo turns out to be a no-op (nothing left in history), no
+     * HISTORIC update runs to restore the cursor, so we put the cleared
+     * selection back on the next microtask to avoid the cursor vanishing.
+     */
+    const $clearSelectionForHistory = (action: 'undo' | 'redo') => {
+      const current = $getSelection();
+      if (!$isRangeSelection(current)) {
+        return;
+      }
+      const saved = current.clone();
+      $setSelection(null);
+      queueMicrotask(() => {
+        // A HISTORIC undo/redo update consumes the action flag (see the update
+        // listener). If it's still set, the operation was a no-op and the
+        // cursor was never restored — so put the cleared selection back.
+        if (pendingHistoricActionRef.current !== action) {
+          return;
+        }
+        pendingHistoricActionRef.current = null;
+        editor.update(() => {
+          if ($selectionNodesExist(saved)) {
+            $setSelection(saved.clone());
+          }
+        });
+      });
+    };
+
     return mergeRegister(
       // Track local edits and save pre-edit selections
       editor.registerUpdateListener(({
@@ -143,6 +191,7 @@ export default function YjsUndoCursorPlugin(): null {
         UNDO_COMMAND,
         () => {
           pendingHistoricActionRef.current = 'undo';
+          $clearSelectionForHistory('undo');
           return false; // Don't consume — let the default handler perform the actual undo
         },
         COMMAND_PRIORITY_LOW,
@@ -153,6 +202,7 @@ export default function YjsUndoCursorPlugin(): null {
         REDO_COMMAND,
         () => {
           pendingHistoricActionRef.current = 'redo';
+          $clearSelectionForHistory('redo');
           return false;
         },
         COMMAND_PRIORITY_LOW,


### PR DESCRIPTION
Written by Claude
-----
In collaborative (Yjs) suggestion mode, deleting a range that includes the first character of a paragraph leaves the cursor as an element point on the paragraph (ProtonNode `selectPrevious()` falls back to `parent.select(0, 0)` when the delete suggestion is the first child). An undo/redo/undo sequence then drives the Yjs UndoManager reversal to clone that selection onto a node it has removed, and Lexical throws from updateEditor ("selection has been lost because the previously selected nodes have been removed...").

Clear the range selection in the UNDO/REDO command handlers (which run at COMMAND_PRIORITY_LOW, before the UndoManager handler at COMMAND_PRIORITY_EDITOR) so the reversal's sync update has no stale selection to clone. The correct cursor is then restored by the existing selection-history listener. A microtask restores the cleared selection if the undo/redo was a no-op, so the caret doesn't vanish when there is nothing to reverse.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1216066326879165) by [Unito](https://www.unito.io)
