### PR TITLE
Prevent iOS Safari auto-zoom on focused form inputs

### DIFF
--- a/packages/lesswrong/components/common/SearchBar.tsx
+++ b/packages/lesswrong/components/common/SearchBar.tsx
@@ -62,6 +62,12 @@ const styles = (theme: ThemeType): JssStyles => ({
       cursor: "text",
       borderRadius:5,
 
+      // Keep the input at >=16px on mobile so that iOS Safari doesn't auto-zoom
+      // the viewport when the field is focused.
+      [theme.breakpoints.down('sm')]: {
+        fontSize: 16,
+      },
+
       [theme.breakpoints.down('tiny')]: {
         backgroundColor: "#eee",
         zIndex: theme.zIndexes.searchBar,

--- a/packages/lesswrong/components/form-components/LocationFormComponent.tsx
+++ b/packages/lesswrong/components/form-components/LocationFormComponent.tsx
@@ -23,7 +23,10 @@ export const geoSuggestStyles = (theme: ThemeType): JssStyles => ({
     fontSize: 13,
     color: theme.palette.primary.main,
     [theme.breakpoints.down('sm')]: {
-      width: "100%"
+      width: "100%",
+      // Keep the input at >=16px on mobile so that iOS Safari doesn't auto-zoom
+      // the viewport when the field is focused.
+      fontSize: 16,
     },
   },
   "& .geosuggest__input:focus": {

--- a/packages/lesswrong/components/form-components/MuiTextField.tsx
+++ b/packages/lesswrong/components/form-components/MuiTextField.tsx
@@ -13,6 +13,9 @@ const styles = (theme: ThemeType): JssStyles => ({
     width: 350,
     [theme.breakpoints.down('sm')]: {
       width: "calc(100% - 30px)", // leaving 30px so that the "clear" button for select forms has room
+      // Keep the input at >=16px on mobile so that iOS Safari doesn't auto-zoom
+      // the viewport when the field is focused.
+      fontSize: "16px",
     },
   },
   fullWidth: {

--- a/packages/lesswrong/components/search/SearchPage.tsx
+++ b/packages/lesswrong/components/search/SearchPage.tsx
@@ -100,6 +100,11 @@ const styles = (theme: ThemeType): JssStyles => ({
       fontSize: 'inherit',
       "-webkit-appearance": "none",
       cursor: "text",
+      // Keep the input at >=16px on mobile so that iOS Safari doesn't auto-zoom
+      // the viewport when the field is focused.
+      [theme.breakpoints.down('sm')]: {
+        fontSize: 16,
+      },
     },
   }
 })

--- a/packages/lesswrong/components/search/UsersSearchInput.tsx
+++ b/packages/lesswrong/components/search/UsersSearchInput.tsx
@@ -8,7 +8,12 @@ const styles = (theme: ThemeType): JssStyles => ({
   input: {
     // this needs to be here because of Bootstrap. I am sorry :(
     padding: "6px 0 7px",
-    fontSize: "13px"
+    fontSize: "13px",
+    // Keep the input at >=16px on mobile so that iOS Safari doesn't auto-zoom
+    // the viewport when the field is focused.
+    [theme.breakpoints.down('sm')]: {
+      fontSize: "16px",
+    },
   }
 })
 


### PR DESCRIPTION
iOS Safari zooms the viewport when a focused input/textarea/select has a font-size below 16px. Several inputs were sized 13-15px, causing the page to zoom when tapped on mobile. Bump these to 16px at mobile breakpoints so desktop visuals are unchanged.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1216111935609259) by [Unito](https://www.unito.io)
