### PR TITLE
Fix link-editor crash when shortening link text

### DIFF
--- a/packages/lesswrong/components/lexical/plugins/FloatingLinkEditorPlugin/index.tsx
+++ b/packages/lesswrong/components/lexical/plugins/FloatingLinkEditorPlugin/index.tsx
@@ -473,6 +473,11 @@ function FloatingLinkEditor({
                       children[i].remove();
                     }
                     firstChild.setTextContent(editedLinkText);
+                    // The existing selection may point past the end of the
+                    // newly-shortened text node, which would make Lexical throw
+                    // "$getTextNodeOffset: invalid offset" while reconciling.
+                    // Re-anchor the selection to the rewritten text node.
+                    firstChild.select(editedLinkText.length, editedLinkText.length);
                   }
                 }
               }


### PR DESCRIPTION
When editing a link's text to something shorter, the stale RangeSelection could point past the end of the rewritten (now shorter) text node, causing Lexical to throw "$getTextNodeOffset: invalid offset" during reconciliation in dev builds (prod silently clamps). Re-anchor the selection to the rewritten text node so its offsets stay in bounds.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1216144089565990) by [Unito](https://www.unito.io)
