### PR TITLE
Switch research agent model to Claude Fable 5

### DIFF
--- a/packages/lesswrong/server/research/sandbox/sandboxLayout.ts
+++ b/packages/lesswrong/server/research/sandbox/sandboxLayout.ts
@@ -38,6 +38,6 @@ export const PINNED_CLAUDE_CODE_VERSION = "2.1.181";
 
 /** The model the research agent runs (`claude --model ...`). Requires a CLI
  * version that knows the model family — see PINNED_CLAUDE_CODE_VERSION. */
-// export const RESEARCH_AGENT_MODEL = "claude-fable-5";
-export const RESEARCH_AGENT_MODEL = "claude-opus-4-8";
+export const RESEARCH_AGENT_MODEL = "claude-fable-5";
+// export const RESEARCH_AGENT_MODEL = "claude-opus-4-8";
 


### PR DESCRIPTION
Flips `RESEARCH_AGENT_MODEL` in `sandboxLayout.ts` from `claude-opus-4-8` back to `claude-fable-5` (reversing the earlier revert-to-opus). This is the single source for the model passed to `claude --model` in the research sandbox supervisor; the pinned Claude Code CLI (2.1.181) already supports the Fable family.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1216227138391878) by [Unito](https://www.unito.io)
