### PR TITLE
Embed assistive MathML in server-rendered math

### DIFF
--- a/packages/lesswrong/server/editor/conversionUtils.ts
+++ b/packages/lesswrong/server/editor/conversionUtils.ts
@@ -16,6 +16,7 @@ import { TeX } from 'mathjax-full/js/input/tex.js';
 import { CHTML } from 'mathjax-full/js/output/chtml.js';
 import { type LiteAdaptor, liteAdaptor } from 'mathjax-full/js/adaptors/liteAdaptor.js';
 import { RegisterHTMLHandler } from 'mathjax-full/js/handlers/html.js';
+import { AssistiveMmlHandler } from 'mathjax-full/js/a11y/assistive-mml.js';
 import { AllPackages } from 'mathjax-full/js/input/tex/AllPackages.js';
 import { type LiteElement } from 'mathjax-full/js/adaptors/lite/Element';
 import IframeWidgetSrcdocs from '@/server/collections/iframeWidgetSrcdocs/collection';
@@ -460,7 +461,10 @@ function getMathjax3() {
 
   const adaptor = liteAdaptor();
   // eslint-disable-next-line babel/new-cap
-  RegisterHTMLHandler(adaptor);
+  const handler = RegisterHTMLHandler(adaptor);
+  // Embed assistive MathML, which helps screen readers and provides elements
+  // that don't require custom JS for RSS readers
+  AssistiveMmlHandler(handler);
 
   const tex = new TeX({
     packages: AllPackages,


### PR DESCRIPTION
renderMathInHtml inlines the MathJax CSS "so it's included in RSS feeds, external scrapers, etc.", but feed readers tend to strip unexpected content including <mjx-*> tags and <style> (allows clickjacking attacks).

Rendered MathJax is also hard for assistive readers to work with.

We can fix both by enabling the assistive MathML option, which adds a hidden <math> element which will be visible by default if the CSS is stripped, and which assistive readers understand how to read.

See: https://docs.mathjax.org/en/latest/web/components/accessibility.html#assistive-mml-component

Note: HTML is rendered at save time, so this won't automatically apply to existing posts.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1216232332510345) by [Unito](https://www.unito.io)
