### PR TITLE
Fix three editor bugs reported by Eliezer

### DIFF
--- a/packages/lesswrong/components/editor/lexicalPlugins/math/MathEditorPanel.tsx
+++ b/packages/lesswrong/components/editor/lexicalPlugins/math/MathEditorPanel.tsx
@@ -6,14 +6,6 @@ import { defineStyles, useStyles } from '../../../hooks/useStyles';
 import { renderEquation } from './loadMathJax';
 
 const styles = defineStyles('MathEditorPanel', (theme: ThemeType) => ({
-  overlay: {
-    position: 'fixed',
-    top: 0,
-    left: 0,
-    right: 0,
-    bottom: 0,
-    zIndex: 1000,
-  },
   panel: {
     position: 'absolute',
     zIndex: 1001,
@@ -74,11 +66,21 @@ const styles = defineStyles('MathEditorPanel', (theme: ThemeType) => ({
   },
 }));
 
+/**
+ * Position the panel is anchored to, in document (not viewport) coordinates,
+ * so that the panel scrolls together with the document.
+ */
+export interface MathEditorAnchor {
+  left: number;
+  bottom: number;
+  width: number;
+}
+
 interface MathEditorPanelProps {
   isOpen: boolean;
   initialEquation?: string;
   isInline: boolean;
-  anchorRect: DOMRect | null;
+  anchor: MathEditorAnchor | null;
   onSubmit: (equation: string, inline: boolean) => void;
   onCancel: () => void;
 }
@@ -87,7 +89,7 @@ function MathEditorPanel({
   isOpen,
   initialEquation = '',
   isInline,
-  anchorRect,
+  anchor,
   onSubmit,
   onCancel,
 }: MathEditorPanelProps): React.ReactElement | null {
@@ -170,56 +172,67 @@ function MathEditorPanel({
     }
   }, [equation, isInline, onSubmit, onCancel]);
 
-  const handleOverlayClick = useCallback((e: React.MouseEvent) => {
-    // Only close if clicking the overlay itself, not the panel
-    if (e.target === e.currentTarget) {
+  // Submit (or cancel, if empty) when the user starts a pointer interaction
+  // outside the panel. Listening for pointerdown (rather than click) means a
+  // drag that starts inside the panel can never dismiss it, even if the
+  // pointer is released outside.
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handlePointerDown = (event: PointerEvent) => {
+      const target = event.target;
+      if (!(target instanceof Node)) return;
+      if (panelRef.current?.contains(target)) return;
+      // Scrollbar interactions target the root element; ignore them so
+      // scrolling the page doesn't dismiss the panel.
+      if (target === document.documentElement) return;
       if (equation.trim()) {
         onSubmit(equation, isInline);
       } else {
         onCancel();
       }
-    }
-  }, [equation, isInline, onSubmit, onCancel]);
+    };
 
-  if (!isOpen || !anchorRect) {
+    document.addEventListener('pointerdown', handlePointerDown);
+    return () => document.removeEventListener('pointerdown', handlePointerDown);
+  }, [isOpen, equation, isInline, onSubmit, onCancel]);
+
+  if (!isOpen || !anchor) {
     return null;
   }
 
   // Calculate position - center below the cursor
   const panelStyle: React.CSSProperties = {
-    left: anchorRect.left + (anchorRect.width / 2),
-    top: anchorRect.bottom + 8,
+    left: anchor.left + (anchor.width / 2),
+    top: anchor.bottom + 8,
     transform: 'translateX(-50%)',
   };
 
   return createPortal(
-    <div className={classes.overlay} onClick={handleOverlayClick}>
-      <div
-        ref={panelRef}
-        className={classes.panel}
-        style={panelStyle}
-        onClick={(e) => e.stopPropagation()}
-      >
-        <div className={classes.inputContainer}>
-          <textarea
-            ref={inputRef}
-            className={classes.input}
-            value={equation}
-            onChange={(e) => setEquation(e.target.value)}
-            onKeyDown={handleKeyDown}
-            placeholder={isInline ? "x^2 + y^2 = z^2" : "\\sum_{i=1}^{n} i = \\frac{n(n+1)}{2}"}
-            rows={1}
-          />
-          <div className={classes.hint}>
-            Enter to submit • Esc to cancel • Shift+Enter for newline
-          </div>
-        </div>
-        <div 
-          ref={previewRef} 
-          className={classes.preview}
-          style={{ display: equation.trim() ? 'flex' : 'none' }}
+    <div
+      ref={panelRef}
+      className={classes.panel}
+      style={panelStyle}
+    >
+      <div className={classes.inputContainer}>
+        <textarea
+          ref={inputRef}
+          className={classes.input}
+          value={equation}
+          onChange={(e) => setEquation(e.target.value)}
+          onKeyDown={handleKeyDown}
+          placeholder={isInline ? "x^2 + y^2 = z^2" : "\\sum_{i=1}^{n} i = \\frac{n(n+1)}{2}"}
+          rows={1}
         />
+        <div className={classes.hint}>
+          Enter to submit • Esc to cancel • Shift+Enter for newline
+        </div>
       </div>
+      <div
+        ref={previewRef}
+        className={classes.preview}
+        style={{ display: equation.trim() ? 'flex' : 'none' }}
+      />
     </div>,
     document.body
   );

--- a/packages/lesswrong/components/editor/lexicalPlugins/math/MathPlugin.tsx
+++ b/packages/lesswrong/components/editor/lexicalPlugins/math/MathPlugin.tsx
@@ -21,7 +21,7 @@ import { $isCodeNode } from '@lexical/code';
 import { $isLinkNode } from '@lexical/link';
 import { mergeRegister } from '@lexical/utils';
 import { MathNode, $createMathNode, $isMathNode } from './MathNode';
-import MathEditorPanel from './MathEditorPanel';
+import MathEditorPanel, { MathEditorAnchor } from './MathEditorPanel';
 import { loadMathJax } from './loadMathJax';
 
 // Commands for opening the math editor panel
@@ -70,6 +70,18 @@ function extractDelimiters(text: string): { equation: string; display: boolean }
 }
 
 /**
+ * Convert a viewport-relative rect (from getBoundingClientRect) into the
+ * document-relative anchor position used by MathEditorPanel.
+ */
+function viewportRectToDocumentAnchor(rect: DOMRect): MathEditorAnchor {
+  return {
+    left: rect.left + window.scrollX,
+    bottom: rect.bottom + window.scrollY,
+    width: rect.width,
+  };
+}
+
+/**
  * Get the DOM rect of the current selection
  */
 function getSelectionRect(): DOMRect | null {
@@ -98,7 +110,7 @@ interface MathEditorState {
   isOpen: boolean;
   isInline: boolean;
   initialEquation: string;
-  anchorRect: DOMRect | null;
+  anchor: MathEditorAnchor | null;
   editingNodeKey: string | null;
 }
 
@@ -153,7 +165,7 @@ export function MathPlugin(): React.ReactElement {
     isOpen: false,
     isInline: true,
     initialEquation: '',
-    anchorRect: null,
+    anchor: null,
     editingNodeKey: null,
   });
 
@@ -176,7 +188,7 @@ export function MathPlugin(): React.ReactElement {
       isOpen: true,
       isInline: inline,
       initialEquation: existingEquation,
-      anchorRect: rect,
+      anchor: rect ? viewportRectToDocumentAnchor(rect) : null,
       editingNodeKey: nodeKey,
     });
   }, [editor]);
@@ -349,12 +361,17 @@ export function MathPlugin(): React.ReactElement {
         editor.update(() => {
           const node = $getNearestNodeFromDOMNode(target);
           if ($isMathNode(node)) {
+            // Move the insertion point next to the clicked equation, so that
+            // when the panel closes and the editor regains focus, the user
+            // stays at the equation instead of being scrolled back to
+            // wherever their insertion point was before clicking.
+            node.selectNext(0, 0);
             const rect = mathPreview.getBoundingClientRect();
             setEditorState({
               isOpen: true,
               isInline: !node.isDisplayMode(),
               initialEquation: node.getEquation(),
-              anchorRect: rect,
+              anchor: viewportRectToDocumentAnchor(rect),
               editingNodeKey: node.getKey(),
             });
           }
@@ -377,7 +394,7 @@ export function MathPlugin(): React.ReactElement {
       isOpen={editorState.isOpen}
       initialEquation={editorState.initialEquation}
       isInline={editorState.isInline}
-      anchorRect={editorState.anchorRect}
+      anchor={editorState.anchor}
       onSubmit={handleSubmit}
       onCancel={closeEditor}
     />

--- a/packages/lesswrong/components/lexical/plugins/YjsUndoCursorPlugin/index.tsx
+++ b/packages/lesswrong/components/lexical/plugins/YjsUndoCursorPlugin/index.tsx
@@ -22,6 +22,7 @@ import {
   COMMAND_PRIORITY_LOW,
   COLLABORATION_TAG,
   HISTORIC_TAG,
+  HISTORY_PUSH_TAG,
   REDO_COMMAND,
   UNDO_COMMAND,
 } from 'lexical';
@@ -173,15 +174,18 @@ export default function YjsUndoCursorPlugin(): null {
         const prevSelection = prevEditorState._selection;
 
         // Only save selection at the start of a new undo group (matching the
-        // UndoManager's 500ms capture timeout)
-        if (now - lastEditTimeRef.current > CAPTURE_TIMEOUT_MS) {
+        // UndoManager's 500ms capture timeout). An update tagged
+        // HISTORY_PUSH_TAG is its own undo group on both sides (the collab
+        // sync calls stopCapturing() around it), so mirror that here.
+        const isHistoryPush = tags.has(HISTORY_PUSH_TAG);
+        if (isHistoryPush || now - lastEditTimeRef.current > CAPTURE_TIMEOUT_MS) {
           if ($isRangeSelection(prevSelection)) {
             undoStackRef.current.push({ before: prevSelection.clone() });
           }
           // New edit clears redo stack (standard undo behavior)
           redoStackRef.current.length = 0;
         }
-        lastEditTimeRef.current = now;
+        lastEditTimeRef.current = isHistoryPush ? 0 : now;
       }),
 
       // Intercept UNDO_COMMAND to set the action flag before the default handler runs.

--- a/packages/lesswrong/lib/vendor/lexical-markdown/MarkdownShortcuts.ts
+++ b/packages/lesswrong/lib/vendor/lexical-markdown/MarkdownShortcuts.ts
@@ -1,0 +1,723 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Vendored from @lexical/markdown v0.44.0 (MarkdownShortcuts.ts), with the
+ * internal helpers it depends on (canContainTransformableMarkdown, indexBy,
+ * transformersByType and the punctuation regexes) inlined, since the npm
+ * package only exposes its root entry point.
+ *
+ * Local modification: getOpenTagStartIndex applies the CommonMark
+ * "left-flanking" rule when searching for an opening text-format tag, so a
+ * word-final delimiter (e.g. the asterisk in "If*,") is not treated as
+ * opening emphasis when a later delimiter is typed.
+ */
+
+import type {
+  ElementTransformer,
+  MultilineElementTransformer,
+  TextFormatTransformer,
+  TextMatchTransformer,
+  Transformer,
+} from '@lexical/markdown';
+import type {ElementNode, LexicalEditor, LexicalNode, TextNode} from 'lexical';
+
+import {$isCodeNode} from '@lexical/code';
+import {TRANSFORMERS} from '@lexical/markdown';
+import {
+  $addUpdateTag,
+  $createRangeSelection,
+  $getSelection,
+  $isLineBreakNode,
+  $isRangeSelection,
+  $isRootOrShadowRoot,
+  $isTextNode,
+  $setSelection,
+  COLLABORATION_TAG,
+  COMMAND_PRIORITY_LOW,
+  HISTORIC_TAG,
+  HISTORY_PUSH_TAG,
+  KEY_ENTER_COMMAND,
+  mergeRegister,
+} from 'lexical';
+
+import invariant from '../lexical-shared/invariant';
+
+// Inlined from @lexical/markdown's internal utils.ts
+const PUNCTUATION_OR_SPACE = /[!-/:-@[-`{-~\s]/;
+const WHITESPACE = /[ \t\n\r\f]/;
+const PUNCTUATION = /[!"#$%&'()*+,\-./:;<=>?@[\]^_`{|}~]/;
+
+// Inlined from @lexical/markdown's internal importTextTransformers.ts
+function canContainTransformableMarkdown(
+  node: LexicalNode | undefined,
+): node is TextNode {
+  return $isTextNode(node) && !node.hasFormat('code');
+}
+
+// Inlined from @lexical/markdown's internal utils.ts
+function indexBy<T>(
+  list: Array<T>,
+  callback: (arg0: T) => string | undefined,
+): Readonly<Record<string, Array<T>>> {
+  const index: Record<string, Array<T>> = {};
+
+  for (const item of list) {
+    const key = callback(item);
+
+    if (!key) {
+      continue;
+    }
+
+    if (index[key]) {
+      index[key].push(item);
+    } else {
+      index[key] = [item];
+    }
+  }
+
+  return index;
+}
+
+// Inlined from @lexical/markdown's internal utils.ts
+function transformersByType(transformers: Array<Transformer>): Readonly<{
+  element: Array<ElementTransformer>;
+  multilineElement: Array<MultilineElementTransformer>;
+  textFormat: Array<TextFormatTransformer>;
+  textMatch: Array<TextMatchTransformer>;
+}> {
+  const byType = indexBy(transformers, (t) => t.type);
+
+  return {
+    element: (byType.element || []) as Array<ElementTransformer>,
+    multilineElement: (byType['multiline-element'] ||
+      []) as Array<MultilineElementTransformer>,
+    textFormat: (byType['text-format'] || []) as Array<TextFormatTransformer>,
+    textMatch: (byType['text-match'] || []) as Array<TextMatchTransformer>,
+  };
+}
+
+function runElementTransformers(
+  parentNode: ElementNode,
+  anchorNode: TextNode,
+  anchorOffset: number,
+  elementTransformers: ReadonlyArray<ElementTransformer>,
+): boolean {
+  const grandParentNode = parentNode.getParent();
+
+  if (
+    !$isRootOrShadowRoot(grandParentNode) ||
+    parentNode.getFirstChild() !== anchorNode
+  ) {
+    return false;
+  }
+
+  const textContent = anchorNode.getTextContent();
+
+  // Checking for anchorOffset position to prevent any checks for cases when caret is too far
+  // from a line start to be a part of block-level markdown trigger.
+  //
+  // TODO:
+  // Can have a quick check if caret is close enough to the beginning of the string (e.g. offset less than 10-20)
+  // since otherwise it won't be a markdown shortcut, but tables are exception
+  if (textContent[anchorOffset - 1] !== ' ') {
+    return false;
+  }
+
+  for (const {regExp, replace} of elementTransformers) {
+    const match = textContent.match(regExp);
+
+    if (
+      match &&
+      match[0].length ===
+        (match[0].endsWith(' ') ? anchorOffset : anchorOffset - 1)
+    ) {
+      const nextSiblings = anchorNode.getNextSiblings();
+      const [leadingNode, remainderNode] = anchorNode.splitText(anchorOffset);
+      const siblings = remainderNode
+        ? [remainderNode, ...nextSiblings]
+        : nextSiblings;
+      if (replace(parentNode, siblings, match, false) !== false) {
+        leadingNode.remove();
+        return true;
+      }
+    }
+  }
+
+  return false;
+}
+
+function runMultilineElementTransformers(
+  parentNode: ElementNode,
+  anchorNode: TextNode,
+  anchorOffset: number,
+  elementTransformers: ReadonlyArray<MultilineElementTransformer>,
+  triggerOnEnter?: boolean,
+): boolean {
+  const grandParentNode = parentNode.getParent();
+
+  if (
+    !$isRootOrShadowRoot(grandParentNode) ||
+    parentNode.getFirstChild() !== anchorNode
+  ) {
+    return false;
+  }
+
+  const textContent = anchorNode.getTextContent();
+
+  if (!triggerOnEnter) {
+    // Checking for anchorOffset position to prevent any checks for cases when caret is too far
+    // from a line start to be a part of block-level markdown trigger.
+    //
+    // TODO:
+    // Can have a quick check if caret is close enough to the beginning of the string (e.g. offset less than 10-20)
+    // since otherwise it won't be a markdown shortcut, but tables are exception
+    if (textContent[anchorOffset - 1] !== ' ') {
+      return false;
+    }
+  }
+
+  for (const {regExpStart, replace, regExpEnd} of elementTransformers) {
+    if (
+      (regExpEnd && !('optional' in regExpEnd)) ||
+      (regExpEnd && 'optional' in regExpEnd && !regExpEnd.optional)
+    ) {
+      continue;
+    }
+
+    const match = textContent.match(regExpStart);
+
+    if (match) {
+      const matchLength =
+        triggerOnEnter || match[0].endsWith(' ')
+          ? anchorOffset
+          : anchorOffset - 1;
+
+      if (match[0].length !== matchLength) {
+        continue;
+      }
+
+      const nextSiblings = anchorNode.getNextSiblings();
+      const [leadingNode, remainderNode] = anchorNode.splitText(anchorOffset);
+      const siblings = remainderNode
+        ? [remainderNode, ...nextSiblings]
+        : nextSiblings;
+
+      if (replace(parentNode, siblings, match, null, null, false) !== false) {
+        leadingNode.remove();
+        return true;
+      }
+    }
+  }
+
+  return false;
+}
+
+function runTextMatchTransformers(
+  anchorNode: TextNode,
+  anchorOffset: number,
+  transformersByTrigger: Readonly<Record<string, Array<TextMatchTransformer>>>,
+): boolean {
+  let textContent = anchorNode.getTextContent();
+  const lastChar = textContent[anchorOffset - 1];
+  const transformers = transformersByTrigger[lastChar];
+
+  if (transformers == null) {
+    return false;
+  }
+
+  // If typing in the middle of content, remove the tail to do
+  // reg exp match up to a string end (caret position)
+  if (anchorOffset < textContent.length) {
+    textContent = textContent.slice(0, anchorOffset);
+  }
+
+  for (const transformer of transformers) {
+    if (!transformer.replace || !transformer.regExp) {
+      continue;
+    }
+    const match = textContent.match(transformer.regExp);
+
+    if (match === null) {
+      continue;
+    }
+
+    const startIndex = match.index || 0;
+    const endIndex = startIndex + match[0].length;
+    let replaceNode;
+
+    if (startIndex === 0) {
+      [replaceNode] = anchorNode.splitText(endIndex);
+    } else {
+      [, replaceNode] = anchorNode.splitText(startIndex, endIndex);
+    }
+
+    replaceNode.selectNext(0, 0);
+    transformer.replace(replaceNode, match);
+    return true;
+  }
+
+  return false;
+}
+
+function $runTextFormatTransformers(
+  anchorNode: TextNode,
+  anchorOffset: number,
+  textFormatTransformers: Readonly<
+    Record<string, ReadonlyArray<TextFormatTransformer>>
+  >,
+): boolean {
+  const textContent = anchorNode.getTextContent();
+  const closeTagEndIndex = anchorOffset - 1;
+  const closeChar = textContent[closeTagEndIndex];
+  // Quick check if we're possibly at the end of inline markdown style
+  const matchers = textFormatTransformers[closeChar];
+
+  if (!matchers) {
+    return false;
+  }
+
+  for (const matcher of matchers) {
+    const {tag} = matcher;
+    const tagLength = tag.length;
+    const closeTagStartIndex = closeTagEndIndex - tagLength + 1;
+
+    // If tag is not single char check if rest of it matches with text content
+    if (tagLength > 1) {
+      if (
+        !isEqualSubString(textContent, closeTagStartIndex, tag, 0, tagLength)
+      ) {
+        continue;
+      }
+    }
+
+    // Space before closing tag cancels inline markdown
+    if (textContent[closeTagStartIndex - 1] === ' ') {
+      continue;
+    }
+
+    // Some tags can not be used within words, hence should have newline/space/punctuation after it
+    const afterCloseTagChar = textContent[closeTagEndIndex + 1];
+
+    if (
+      matcher.intraword === false &&
+      afterCloseTagChar &&
+      !PUNCTUATION_OR_SPACE.test(afterCloseTagChar)
+    ) {
+      continue;
+    }
+
+    const closeNode = anchorNode;
+    let openNode = closeNode;
+    let openTagStartIndex = getOpenTagStartIndex(
+      textContent,
+      closeTagStartIndex,
+      tag,
+    );
+
+    // Go through text node siblings and search for opening tag
+    // if haven't found it within the same text node as closing tag
+    let sibling: TextNode | null = openNode;
+
+    while (
+      openTagStartIndex < 0 &&
+      (sibling = sibling.getPreviousSibling<TextNode>())
+    ) {
+      if ($isLineBreakNode(sibling)) {
+        break;
+      }
+
+      if ($isTextNode(sibling)) {
+        if (sibling.hasFormat('code')) {
+          continue;
+        }
+        const siblingTextContent = sibling.getTextContent();
+        const nextSibling = sibling.getNextSibling();
+        openNode = sibling;
+        openTagStartIndex = getOpenTagStartIndex(
+          siblingTextContent,
+          siblingTextContent.length,
+          tag,
+          $isTextNode(nextSibling)
+            ? nextSibling.getTextContent()[0]
+            : undefined,
+        );
+      }
+    }
+
+    // Opening tag is not found
+    if (openTagStartIndex < 0) {
+      continue;
+    }
+
+    // No content between opening and closing tag
+    if (
+      openNode === closeNode &&
+      openTagStartIndex + tagLength === closeTagStartIndex
+    ) {
+      continue;
+    }
+
+    // Checking longer tags for repeating chars (e.g. *** vs **)
+    const prevOpenNodeText = openNode.getTextContent();
+
+    if (
+      openTagStartIndex > 0 &&
+      prevOpenNodeText[openTagStartIndex - 1] === closeChar
+    ) {
+      continue;
+    }
+
+    // Some tags can not be used within words, hence should have newline/space/punctuation before it
+    const beforeOpenTagChar = prevOpenNodeText[openTagStartIndex - 1];
+
+    if (
+      matcher.intraword === false &&
+      beforeOpenTagChar &&
+      !PUNCTUATION_OR_SPACE.test(beforeOpenTagChar)
+    ) {
+      continue;
+    }
+
+    // Per CommonMark, code spans take precedence over other inline formatting
+    if (
+      !matcher.format.includes('code') &&
+      $isInsideUnclosedCodeSpan(openNode, openTagStartIndex)
+    ) {
+      continue;
+    }
+
+    // Clean text from opening and closing tags (starting from closing tag
+    // to prevent any offset shifts if we start from opening one)
+    const prevCloseNodeText = closeNode.getTextContent();
+    const closeNodeText =
+      prevCloseNodeText.slice(0, closeTagStartIndex) +
+      prevCloseNodeText.slice(closeTagEndIndex + 1);
+    closeNode.setTextContent(closeNodeText);
+    const openNodeText =
+      openNode === closeNode ? closeNodeText : prevOpenNodeText;
+    openNode.setTextContent(
+      openNodeText.slice(0, openTagStartIndex) +
+        openNodeText.slice(openTagStartIndex + tagLength),
+    );
+    const selection = $getSelection();
+    const nextSelection = $createRangeSelection();
+    $setSelection(nextSelection);
+    // Adjust offset based on deleted chars
+    const newOffset =
+      closeTagEndIndex - (tagLength * (openNode === closeNode ? 2 : 1)) + 1;
+    nextSelection.anchor.set(openNode.__key, openTagStartIndex, 'text');
+    nextSelection.focus.set(closeNode.__key, newOffset, 'text');
+
+    // Apply formatting to selected text
+    for (const format of matcher.format) {
+      if (!nextSelection.hasFormat(format)) {
+        nextSelection.formatText(format);
+      }
+    }
+
+    // Collapse selection up to the focus point
+    nextSelection.anchor.set(
+      nextSelection.focus.key,
+      nextSelection.focus.offset,
+      nextSelection.focus.type,
+    );
+
+    // Remove formatting from collapsed selection
+    for (const format of matcher.format) {
+      if (nextSelection.hasFormat(format)) {
+        nextSelection.toggleFormat(format);
+      }
+    }
+
+    if ($isRangeSelection(selection)) {
+      nextSelection.format = selection.format;
+    }
+
+    return true;
+  }
+
+  return false;
+}
+
+// Per CommonMark spec, code spans take precedence over other inline
+// formatting. Returns true if there is an unclosed backtick (code span
+// opener) in the text preceding the given offset, which means the offset
+// is inside a code span that hasn't been closed yet.
+function $isInsideUnclosedCodeSpan(node: TextNode, offset: number): boolean {
+  let backtickCount = 0;
+
+  const text = node.getTextContent();
+  for (let i = 0; i < offset; i++) {
+    if (text[i] === '`') {
+      backtickCount++;
+    }
+  }
+
+  return backtickCount % 2 !== 0;
+}
+
+/**
+ * Search backwards from maxIndex for an opening tag. `charAfterString` is
+ * the character that follows `string` in the document (the first character
+ * of the next text node), used to classify a tag at the very end of the
+ * string.
+ */
+function getOpenTagStartIndex(
+  string: string,
+  maxIndex: number,
+  tag: string,
+  charAfterString?: string,
+): number {
+  const tagLength = tag.length;
+
+  for (let i = maxIndex; i >= tagLength; i--) {
+    const startIndex = i - tagLength;
+
+    if (!isEqualSubString(string, startIndex, tag, 0, tagLength)) {
+      continue;
+    }
+
+    // CommonMark left-flanking rule: an opening tag must not be followed by
+    // whitespace, and if it is followed by punctuation it must be preceded
+    // by whitespace or punctuation. This prevents a word-final tag (e.g.
+    // the asterisk in "If*,") from opening emphasis.
+    const afterChar =
+      startIndex + tagLength < string.length
+        ? string[startIndex + tagLength]
+        : charAfterString;
+    if (afterChar !== undefined) {
+      if (WHITESPACE.test(afterChar)) {
+        continue;
+      }
+      const beforeChar = string[startIndex - 1];
+      if (
+        PUNCTUATION.test(afterChar) &&
+        beforeChar !== undefined &&
+        !PUNCTUATION_OR_SPACE.test(beforeChar)
+      ) {
+        continue;
+      }
+    }
+
+    return startIndex;
+  }
+
+  return -1;
+}
+
+function isEqualSubString(
+  stringA: string,
+  aStart: number,
+  stringB: string,
+  bStart: number,
+  length: number,
+): boolean {
+  for (let i = 0; i < length; i++) {
+    if (stringA[aStart + i] !== stringB[bStart + i]) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+export function registerMarkdownShortcuts(
+  editor: LexicalEditor,
+  transformers: Array<Transformer> = TRANSFORMERS,
+): () => void {
+  const byType = transformersByType(transformers);
+  const textFormatTransformersByTrigger = indexBy(
+    byType.textFormat,
+    ({tag}) => tag[tag.length - 1],
+  );
+  const textMatchTransformersByTrigger = indexBy(
+    byType.textMatch,
+    ({trigger}) => trigger,
+  );
+
+  for (const transformer of transformers) {
+    const type = transformer.type;
+    if (
+      type === 'element' ||
+      type === 'text-match' ||
+      type === 'multiline-element'
+    ) {
+      const dependencies = transformer.dependencies;
+      for (const node of dependencies) {
+        if (!editor.hasNode(node)) {
+          invariant(
+            false,
+            'MarkdownShortcuts: missing dependency %s for transformer. Ensure node dependency is included in editor initial config.',
+            node.getType(),
+          );
+        }
+      }
+    }
+  }
+
+  const $transform = (
+    parentNode: ElementNode,
+    anchorNode: TextNode,
+    anchorOffset: number,
+  ): boolean => {
+    if (
+      runElementTransformers(
+        parentNode,
+        anchorNode,
+        anchorOffset,
+        byType.element,
+      )
+    ) {
+      return true;
+    }
+
+    if (
+      runMultilineElementTransformers(
+        parentNode,
+        anchorNode,
+        anchorOffset,
+        byType.multilineElement,
+      )
+    ) {
+      return true;
+    }
+
+    if (
+      runTextMatchTransformers(
+        anchorNode,
+        anchorOffset,
+        textMatchTransformersByTrigger,
+      )
+    ) {
+      return true;
+    }
+
+    if (
+      $runTextFormatTransformers(
+        anchorNode,
+        anchorOffset,
+        textFormatTransformersByTrigger,
+      )
+    ) {
+      return true;
+    }
+
+    return false;
+  };
+
+  return mergeRegister(
+    editor.registerUpdateListener(
+      ({tags, dirtyLeaves, editorState, prevEditorState}) => {
+        // Ignore updates from collaboration and undo/redo (as changes already calculated)
+        if (tags.has(COLLABORATION_TAG) || tags.has(HISTORIC_TAG)) {
+          return;
+        }
+
+        // If editor is still composing (i.e. backticks) we must wait before the user confirms the key
+        if (editor.isComposing()) {
+          return;
+        }
+
+        const selection = editorState.read($getSelection);
+        const prevSelection = prevEditorState.read($getSelection);
+
+        // We expect selection to be a collapsed range and not match previous one (as we want
+        // to trigger transforms only as user types)
+        if (
+          !$isRangeSelection(prevSelection) ||
+          !$isRangeSelection(selection) ||
+          !selection.isCollapsed() ||
+          selection.is(prevSelection)
+        ) {
+          return;
+        }
+
+        const anchorKey = selection.anchor.key;
+        const anchorOffset = selection.anchor.offset;
+
+        const anchorNode = editorState._nodeMap.get(anchorKey);
+
+        if (
+          !$isTextNode(anchorNode) ||
+          !dirtyLeaves.has(anchorKey) ||
+          (anchorOffset !== 1 && anchorOffset > prevSelection.anchor.offset + 1)
+        ) {
+          return;
+        }
+
+        editor.update(() => {
+          if (!canContainTransformableMarkdown(anchorNode)) {
+            return;
+          }
+
+          const parentNode = anchorNode.getParent();
+
+          if (parentNode === null || $isCodeNode(parentNode)) {
+            return;
+          }
+
+          if ($transform(parentNode, anchorNode, selection.anchor.offset)) {
+            $addUpdateTag(HISTORY_PUSH_TAG);
+          }
+        });
+      },
+    ),
+    editor.registerCommand(
+      KEY_ENTER_COMMAND,
+      (event) => {
+        if (event !== null && event.shiftKey) {
+          return false;
+        }
+
+        const selection = $getSelection();
+
+        if (!$isRangeSelection(selection) || !selection.isCollapsed()) {
+          return false;
+        }
+
+        const anchorOffset = selection.anchor.offset;
+        const anchorNode = selection.anchor.getNode();
+
+        if (
+          !$isTextNode(anchorNode) ||
+          !canContainTransformableMarkdown(anchorNode)
+        ) {
+          return false;
+        }
+
+        const parentNode = anchorNode.getParent();
+
+        if (parentNode === null || $isCodeNode(parentNode)) {
+          return false;
+        }
+
+        const textContent = anchorNode.getTextContent();
+
+        if (anchorOffset !== textContent.length) {
+          return false;
+        }
+
+        if (
+          runMultilineElementTransformers(
+            parentNode,
+            anchorNode,
+            anchorOffset,
+            byType.multilineElement,
+            true,
+          )
+        ) {
+          if (event !== null) {
+            event.preventDefault();
+          }
+          return true;
+        }
+
+        return false;
+      },
+      COMMAND_PRIORITY_LOW,
+    ),
+  );
+}

--- a/packages/lesswrong/lib/vendor/lexical-react/LexicalMarkdownShortcutPlugin.tsx
+++ b/packages/lesswrong/lib/vendor/lexical-react/LexicalMarkdownShortcutPlugin.tsx
@@ -14,9 +14,11 @@ import {
   $isHorizontalRuleNode,
   HorizontalRuleNode,
 } from '@lexical/extension';
-import {registerMarkdownShortcuts, TRANSFORMERS} from '@lexical/markdown';
+import {TRANSFORMERS} from '@lexical/markdown';
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {useEffect} from 'react';
+
+import {registerMarkdownShortcuts} from '../lexical-markdown/MarkdownShortcuts';
 
 const HR: ElementTransformer = {
   dependencies: [HorizontalRuleNode],

--- a/packages/lesswrong/lib/vendor/lexical-react/shared/useYjsCollaboration.tsx
+++ b/packages/lesswrong/lib/vendor/lexical-react/shared/useYjsCollaboration.tsx
@@ -24,6 +24,7 @@ import {
   createBindingV2__EXPERIMENTAL,
   createUndoManager,
   DIFF_VERSIONS_COMMAND__EXPERIMENTAL,
+  getUndoManagerForBinding,
   initLocalState,
   renderSnapshot__EXPERIMENTAL,
   setLocalStateFocus,
@@ -45,6 +46,7 @@ import {
   COMMAND_PRIORITY_EDITOR,
   FOCUS_COMMAND,
   HISTORY_MERGE_TAG,
+  HISTORY_PUSH_TAG,
   REDO_COMMAND,
   SKIP_COLLAB_TAG,
   UNDO_COMMAND,
@@ -118,6 +120,14 @@ export function useYjsCollaboration(
         tags,
       }) => {
         if (!tags.has(SKIP_COLLAB_TAG)) {
+          // An update tagged HISTORY_PUSH_TAG (e.g. a markdown auto-format)
+          // should be its own undo step: stop the UndoManager from merging it
+          // into the preceding typing, and stop subsequent typing from
+          // merging into it.
+          const undoManager = tags.has(HISTORY_PUSH_TAG)
+            ? getUndoManagerForBinding(binding)
+            : undefined;
+          undoManager?.stopCapturing();
           syncLexicalUpdateToYjs(
             binding,
             provider,
@@ -128,6 +138,7 @@ export function useYjsCollaboration(
             normalizedNodes,
             tags,
           );
+          undoManager?.stopCapturing();
         }
       },
     );
@@ -288,6 +299,11 @@ export function useYjsCollaborationV2__EXPERIMENTAL(
         tags,
       }) => {
         if (!tags.has(SKIP_COLLAB_TAG)) {
+          // See the matching HISTORY_PUSH_TAG handling in useYjsCollaboration.
+          const undoManager = tags.has(HISTORY_PUSH_TAG)
+            ? getUndoManagerForBinding(binding)
+            : undefined;
+          undoManager?.stopCapturing();
           syncLexicalUpdateToYjsV2__EXPERIMENTAL(
             binding,
             provider,
@@ -297,6 +313,7 @@ export function useYjsCollaborationV2__EXPERIMENTAL(
             normalizedNodes,
             tags,
           );
+          undoManager?.stopCapturing();
         }
       },
     );

--- a/packages/lesswrong/lib/vendor/lexical-yjs/index.ts
+++ b/packages/lesswrong/lib/vendor/lexical-yjs/index.ts
@@ -87,13 +87,28 @@ export type {
 } from './Bindings';
 export {createBinding, createBindingV2__EXPERIMENTAL} from './Bindings';
 
+const undoManagersByBinding = new WeakMap<BaseBinding, UndoManager>();
+
 export function createUndoManager(
   binding: BaseBinding,
   root: XmlText | XmlElement,
 ): UndoManager {
-  return new YjsUndoManager(root, {
+  const undoManager = new YjsUndoManager(root, {
     trackedOrigins: new Set([binding, null]),
   });
+  undoManagersByBinding.set(binding, undoManager);
+  return undoManager;
+}
+
+/**
+ * Returns the UndoManager created for the given binding (if any), so that
+ * code observing lexical updates can insert undo-capture boundaries (e.g.
+ * around updates tagged with HISTORY_PUSH_TAG).
+ */
+export function getUndoManagerForBinding(
+  binding: BaseBinding,
+): UndoManager | undefined {
+  return undoManagersByBinding.get(binding);
 }
 
 export function initLocalState(


### PR DESCRIPTION
Written by Claude
------
1. Math editor panel: position in document coordinates instead of a full-screen fixed overlay, so it scrolls with the page. Dismiss via a document-level pointerdown listener, so a drag that starts inside the panel can't dismiss it.

2. Asterisk auto-italics: vendor @lexical/markdown's registerMarkdownShortcuts and apply the CommonMark left-flanking rule to the opening delimiter, so a word-final asterisk (e.g. "If*,") no longer opens emphasis. Also honor HISTORY_PUSH_TAG in collab mode by inserting yjs UndoManager capture boundaries around tagged updates, so a single undo reverts just the auto-format transform (restoring the literal asterisks), with the YjsUndoCursorPlugin selection stack mirroring the same grouping.

3. Editing a math equation no longer scrolls back to the previous insertion point: clicking an equation moves the Lexical selection next to it, so refocusing the editor on panel close stays at the equation.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1216261187929826) by [Unito](https://www.unito.io)
