### PR TITLE
Prevent iOS Safari auto-zoom when focusing form inputs

### DIFF
--- a/packages/lesswrong/components/common/SearchBar.tsx
+++ b/packages/lesswrong/components/common/SearchBar.tsx
@@ -46,6 +46,12 @@ const styles = defineStyles("SearchBar", (theme: ThemeType) => ({
       whiteSpace: 'nowrap',
       boxSizing: 'border-box',
       fontSize: 14,
+      // The search input inherits this font-size. iOS Safari auto-zooms the
+      // viewport when a focused input's font-size is below 16px, so bump it on
+      // touch devices to suppress the zoom (matches MUI's InputBase root).
+      '@media (pointer: coarse)': {
+        fontSize: 16,
+      },
     },
     "& .ais-SearchBox-form": {
       height: '100%'

--- a/packages/lesswrong/lib/vendor/@material-ui/core/src/InputBase/InputBase.tsx
+++ b/packages/lesswrong/lib/vendor/@material-ui/core/src/InputBase/InputBase.tsx
@@ -133,6 +133,18 @@ export const styles = defineStyles("MuiInputBase", theme => {
     /* Styles applied to the `input` element. */
     input: {
       font: 'inherit',
+      // iOS Safari auto-zooms the viewport whenever a focused form control's
+      // computed font-size is below 16px. Our root font-size is 13px, so most
+      // inputs would trigger the zoom on iPhone. Floor the input at 16px on
+      // touch devices to suppress it while leaving pinch-to-zoom intact. Using
+      // max(16px, 1em) — where 1em is the inherited (root) font-size — makes
+      // this raise-only: it never shrinks inputs that intentionally set a
+      // larger font (e.g. the 3.75rem post-title input). Applied to the input
+      // rather than the root so it overrides `font: inherit` above without any
+      // !important or specificity hacks.
+      '@media (pointer: coarse)': {
+        fontSize: 'max(16px, 1em)',
+      },
       color: 'currentColor',
       padding: `${8 - 2}px 0 ${8 - 1}px`,
       border: 0,

--- a/packages/lesswrong/themes/globalStyles/globalStyles.ts
+++ b/packages/lesswrong/themes/globalStyles/globalStyles.ts
@@ -35,7 +35,23 @@ const clearStyle = (theme: ThemeType) => ({
     outline: "none",
     color: theme.palette.text.maxIntensity,
   },
-  
+
+  // On iOS Safari, focusing a form control whose computed font-size is below
+  // 16px causes the browser to automatically zoom the viewport in to "make it
+  // readable". Our root font-size is 13px, so tapping into inputs on iPhone
+  // zooms the page. We fix the shared sources of input font-size directly
+  // (MUI's InputBase input rule and the Algolia SearchBar) so no !important is
+  // needed; this element selector is the baseline that catches the handful of
+  // raw <input>/<textarea>/<select> elements that aren't styled through either
+  // of those. max(16px, 1em) — where 1em is the inherited font-size — makes it
+  // raise-only, so an element that intentionally inherits a font larger than
+  // 16px is never shrunk. Scoped to coarse pointers so desktop is unaffected.
+  "@media (pointer: coarse)": {
+    "input, textarea, select": {
+      fontSize: "max(16px, 1em)",
+    },
+  },
+
   button: {
     border: "none",
     boxShadow: "none",


### PR DESCRIPTION
## Summary

iOS Safari zooms the viewport whenever a focused `input`/`textarea`/`select` has a computed font-size below 16px. Our html root font-size is 13px, so tapping into inputs on iPhone zoomed the page.

This fixes it at the shared source rules rather than with a global `!important` override:

- MUI `InputBase`'s input rule (the source for ~100 inputs)
- `SearchBar`'s `.ais-SearchBox` (which the Algolia search input inherits)
- a plain element-selector baseline in global styles for the handful of raw inputs

The floor uses `max(16px, 1em)` so it is raise-only: it never shrinks inputs that intentionally set a larger font (e.g. the 3.75rem post-title input). All scoped to `@media (pointer: coarse)`, so desktop is unaffected and pinch-to-zoom stays intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1216278082250590) by [Unito](https://www.unito.io)
