### PR TITLE
Backport fixes from the Lightcone Commons review of the research-workspace port

### DIFF
--- a/packages/lesswrong/components/research/ConversationChatView.tsx
+++ b/packages/lesswrong/components/research/ConversationChatView.tsx
@@ -284,8 +284,11 @@ export const ConversationChatView = ({
 
   useEffect(() => {
     if (variant !== 'fullscreen') return;
+    // Inner overlays (file viewer, icon picker) claim their Escape by
+    // preventDefault on the capture phase; skip those so one keypress closes
+    // only the innermost surface.
     const onKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') onToggleFullscreen();
+      if (e.key === 'Escape' && !e.defaultPrevented) onToggleFullscreen();
     };
     window.addEventListener('keydown', onKeyDown);
     return () => window.removeEventListener('keydown', onKeyDown);

--- a/packages/lesswrong/components/research/ResearchIconPicker.tsx
+++ b/packages/lesswrong/components/research/ResearchIconPicker.tsx
@@ -137,7 +137,13 @@ export const ResearchIconPicker = ({ anchor, onSelect, onClear, onClose }: Resea
   const [query, setQuery] = useState('');
 
   useEffect(() => {
-    const onKeyDown = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose(); };
+    // Capture phase + preventDefault: claim this Escape so outer surfaces
+    // (fullscreen chat's exit handler) don't also close on the same press.
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key !== 'Escape') return;
+      e.preventDefault();
+      onClose();
+    };
     const onPointerDown = (e: PointerEvent) => {
       if (popoverRef.current && e.target instanceof Node && !popoverRef.current.contains(e.target)) {
         onClose();

--- a/packages/lesswrong/components/research/SandboxFileBrowser.tsx
+++ b/packages/lesswrong/components/research/SandboxFileBrowser.tsx
@@ -9,6 +9,7 @@ import ForumIcon from '@/components/common/ForumIcon';
 import Loading from '../vulcan-core/Loading';
 import { useResearchWorkspaceApiOptional } from './researchWorkspaceContext';
 import { researchMono, researchWarmAlpha, researchScrollbars, researchUiSans } from './researchStyleUtils';
+import { formatBytes } from './formatBytes';
 
 const SandboxDirectoryQuery = gql(`
   query ResearchSandboxDirectory($conversationId: String!, $path: String) {
@@ -57,12 +58,6 @@ function setChildren(nodes: FileNode[], id: string, children: FileNode[]): FileN
     }
     return node;
   });
-}
-
-function formatSize(bytes: number): string {
-  if (bytes < 1024) return `${bytes} B`;
-  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
-  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
 }
 
 const ROW_HEIGHT = 24;
@@ -222,7 +217,7 @@ export const SandboxFileBrowser = ({ conversationId }: SandboxFileBrowserProps) 
           <ForumIcon icon="Document" className={classes.glyph} />
         )}
         <span className={dir ? `${classes.name} ${classes.nameDir}` : classes.name}>{node.data.name}</span>
-        {node.data.size != null ? <span className={classes.size}>{formatSize(node.data.size)}</span> : null}
+        {node.data.size != null ? <span className={classes.size}>{formatBytes(node.data.size)}</span> : null}
       </div>
     );
   }, [classes, workspace, conversationId]);

--- a/packages/lesswrong/components/research/SandboxFileViewer.tsx
+++ b/packages/lesswrong/components/research/SandboxFileViewer.tsx
@@ -8,6 +8,7 @@ import ForumIcon from '@/components/common/ForumIcon';
 import Loading from '../vulcan-core/Loading';
 import { highlightFile } from './sandboxFileSyntax';
 import { researchMono, researchWarmAlpha, researchCanvas, researchScrollbars, researchUiSans } from './researchStyleUtils';
+import { formatBytes } from './formatBytes';
 
 const SandboxFileQuery = gql(`
   query ResearchSandboxFile($conversationId: String!, $path: String!) {
@@ -25,12 +26,6 @@ const SandboxFileQuery = gql(`
 function basename(path: string): string {
   const parts = path.split('/').filter(Boolean);
   return parts[parts.length - 1] ?? path;
-}
-
-function formatSize(bytes: number): string {
-  if (bytes < 1024) return `${bytes} B`;
-  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
-  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
 }
 
 const styles = defineStyles('SandboxFileViewer', (theme: ThemeType) => ({
@@ -183,9 +178,15 @@ export const SandboxFileViewer = ({ conversationId, path, onClose }: SandboxFile
   }, [loadFile, conversationId, path]);
 
   useEffect(() => {
-    const onKeyDown = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose(); };
-    window.addEventListener('keydown', onKeyDown);
-    return () => window.removeEventListener('keydown', onKeyDown);
+    // Capture phase + preventDefault: claim this Escape so outer surfaces
+    // (fullscreen chat's exit handler) don't also close on the same press.
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key !== 'Escape') return;
+      e.preventDefault();
+      onClose();
+    };
+    window.addEventListener('keydown', onKeyDown, true);
+    return () => window.removeEventListener('keydown', onKeyDown, true);
   }, [onClose]);
 
   const highlighted = useMemo(() => {
@@ -217,7 +218,7 @@ export const SandboxFileViewer = ({ conversationId, path, onClose }: SandboxFile
       <div className={classes.header}>
         <span className={classes.path} title={path}>{basename(path)}</span>
         {state.status === 'ready' && state.running && !state.binary
-          ? <span className={classes.meta}>{formatSize(state.size)}</span>
+          ? <span className={classes.meta}>{formatBytes(state.size)}</span>
           : null}
         <span className={classes.spacer} />
         <button

--- a/packages/lesswrong/components/research/SandboxStatsFooter.tsx
+++ b/packages/lesswrong/components/research/SandboxStatsFooter.tsx
@@ -9,6 +9,7 @@ import { defineStyles, useStyles } from '@/components/hooks/useStyles';
 import { useMessages } from '@/components/common/withMessages';
 import { retryWhileSandboxWarming } from './sandboxWarming';
 import { researchMono, researchRadius, researchWarmAlpha } from './researchStyleUtils';
+import { formatBytes } from './formatBytes';
 
 const SandboxStatsQuery = gql(`
   query ResearchSandboxStats($conversationId: String!) {
@@ -33,15 +34,6 @@ const RestartResearchSandboxMutation = gql(`
 `);
 
 const POLL_MS = 5000;
-
-function formatBytes(bytes: number): string {
-  if (bytes < 1024) return `${bytes} B`;
-  const kb = bytes / 1024;
-  if (kb < 1024) return `${kb.toFixed(0)} KB`;
-  const mb = kb / 1024;
-  if (mb < 1024) return `${mb.toFixed(0)} MB`;
-  return `${(mb / 1024).toFixed(1)} GB`;
-}
 
 const styles = defineStyles('SandboxStatsFooter', (theme: ThemeType) => ({
   root: {

--- a/packages/lesswrong/components/research/formatBytes.ts
+++ b/packages/lesswrong/components/research/formatBytes.ts
@@ -1,0 +1,12 @@
+/**
+ * One byte formatter for every sandbox surface (file browser, file viewer,
+ * stats footer): whole bytes below 1 KB, one decimal for KB/MB/GB.
+ */
+export function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  const kb = bytes / 1024;
+  if (kb < 1024) return `${kb.toFixed(1)} KB`;
+  const mb = kb / 1024;
+  if (mb < 1024) return `${mb.toFixed(1)} MB`;
+  return `${(mb / 1024).toFixed(1)} GB`;
+}

--- a/packages/lesswrong/components/research/hooks/useTranscriptScroll.ts
+++ b/packages/lesswrong/components/research/hooks/useTranscriptScroll.ts
@@ -1,7 +1,7 @@
 'use client';
 
-import { useCallback, useLayoutEffect, useRef } from 'react';
-import type { RefObject } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useRef } from 'react';
+import type { RefCallback } from 'react';
 import type { ConversationEvent } from './useConversationStream';
 
 const BOTTOM_THRESHOLD_PX = 64;
@@ -26,8 +26,14 @@ interface UseTranscriptScrollParams {
 }
 
 interface TranscriptScroll {
-  scrollRef: RefObject<HTMLDivElement | null>;
-  contentRef: RefObject<HTMLDivElement | null>;
+  /**
+   * Callback refs (not RefObjects): the scroll container can mount after the
+   * hook's first render (loading placeholders) or be unmounted/remounted (the
+   * panel-mode file-browser toggle swaps the transcript out), so observer
+   * attachment and the re-pin must follow the node, not a mount-time effect.
+   */
+  scrollRef: RefCallback<HTMLDivElement>;
+  contentRef: RefCallback<HTMLDivElement>;
   onScroll: () => void;
   scrollToBottom: () => void;
 }
@@ -51,8 +57,8 @@ export function useTranscriptScroll({
   loadOlder,
   onReachedBottom,
 }: UseTranscriptScrollParams): TranscriptScroll {
-  const scrollRef = useRef<HTMLDivElement | null>(null);
-  const contentRef = useRef<HTMLDivElement | null>(null);
+  const scrollElRef = useRef<HTMLDivElement | null>(null);
+  const contentElRef = useRef<HTMLDivElement | null>(null);
   const isPinnedToBottomRef = useRef(true);
   // Latest viewport distance-from-bottom, refreshed on every scroll, so a
   // prepend can restore the exact position the user is at when the page lands.
@@ -68,12 +74,12 @@ export function useTranscriptScroll({
   const scrollToBottom = useCallback(() => {
     isPinnedToBottomRef.current = true;
     onReachedBottomRef.current?.();
-    const el = scrollRef.current;
+    const el = scrollElRef.current;
     if (el) el.scrollTop = el.scrollHeight;
   }, []);
 
   const onScroll = useCallback(() => {
-    const el = scrollRef.current;
+    const el = scrollElRef.current;
     if (!el) return;
     isPinnedToBottomRef.current = isScrolledNearBottom(el);
     if (isPinnedToBottomRef.current) onReachedBottomRef.current?.();
@@ -106,7 +112,7 @@ export function useTranscriptScroll({
     // ref isn't cleared — the programmatic scrollTop below fires a scroll event
     // that refreshes it to the (unchanged) position, ready for the next page.
     if (prependAnchorRef.current != null && topSeq != null && prevTopSeq != null && topSeq < prevTopSeq) {
-      const el = scrollRef.current;
+      const el = scrollElRef.current;
       if (el) el.scrollTop = el.scrollHeight - prependAnchorRef.current;
       return;
     }
@@ -116,19 +122,47 @@ export function useTranscriptScroll({
     }
   }, [resetKey, events, scrollToBottom]);
 
-  useLayoutEffect(() => {
-    const el = scrollRef.current;
+  // Re-pin on any size change of the container or its content: streaming
+  // output grows the content without scroll events, and container resizes
+  // (panel drag, fullscreen toggle) would otherwise unpin the bottom.
+  const pinIfPinned = useCallback(() => {
+    const el = scrollElRef.current;
     if (!el) return;
-    const pinIfPinned = () => {
-      if (isPinnedToBottomRef.current && el.scrollTop !== el.scrollHeight - el.clientHeight) {
-        el.scrollTo({ top: el.scrollHeight, behavior: 'instant' });
-      }
-    };
-    const observer = new ResizeObserver(pinIfPinned);
-    observer.observe(el);
-    if (contentRef.current) observer.observe(contentRef.current);
-    return () => observer.disconnect();
+    if (isPinnedToBottomRef.current && el.scrollTop !== el.scrollHeight - el.clientHeight) {
+      el.scrollTo({ top: el.scrollHeight, behavior: 'instant' });
+    }
   }, []);
+
+  // One lazily-created observer, re-targeted whenever either node (re)mounts.
+  const observerRef = useRef<ResizeObserver | null>(null);
+  const syncObserver = useCallback(() => {
+    observerRef.current?.disconnect();
+    const el = scrollElRef.current;
+    if (!el) return;
+    if (!observerRef.current) observerRef.current = new ResizeObserver(pinIfPinned);
+    observerRef.current.observe(el);
+    if (contentElRef.current) observerRef.current.observe(contentElRef.current);
+  }, [pinIfPinned]);
+  useEffect(() => () => observerRef.current?.disconnect(), []);
+
+  const scrollRef = useCallback<RefCallback<HTMLDivElement>>(
+    (el) => {
+      const remounted = el !== null && el !== scrollElRef.current;
+      scrollElRef.current = el;
+      syncObserver();
+      // A freshly-mounted container starts at scrollTop 0 (e.g. the transcript
+      // returning after the file-browser toggle); restore the pin immediately.
+      if (remounted) pinIfPinned();
+    },
+    [syncObserver, pinIfPinned],
+  );
+  const contentRef = useCallback<RefCallback<HTMLDivElement>>(
+    (el) => {
+      contentElRef.current = el;
+      syncObserver();
+    },
+    [syncObserver],
+  );
 
   return { scrollRef, contentRef, onScroll, scrollToBottom };
 }

--- a/packages/lesswrong/components/research/lexical/ResearchCommentsMargin.tsx
+++ b/packages/lesswrong/components/research/lexical/ResearchCommentsMargin.tsx
@@ -13,8 +13,13 @@ import type { Comment, Thread } from '@/components/lexical/commenting';
 import {
   CommentsComposer,
   RESOLVE_THREAD_COMMAND,
+  SuggestionStatusOrActions,
+  acceptSuggestionThread,
   getThreadMarkId,
+  rejectSuggestionThread,
 } from '@/components/lexical/plugins/CommentPlugin/CommentPluginComponents';
+import { SUGGESTION_SUMMARY_KIND } from '@/components/editor/lexicalPlugins/suggestedEdits/Utils';
+import { formatSuggestionSummary } from '@/components/editor/lexicalPlugins/suggestedEdits/suggestionSummaryUtils';
 import { defineStyles, useStyles } from '@/components/hooks/useStyles';
 import ForumIcon from '@/components/common/ForumIcon';
 import { useResearchCommentsMarginHostOptional } from './researchCommentsMarginContext';
@@ -200,11 +205,14 @@ export default function ResearchCommentsMargin() {
   const [cardHeights, setCardHeights] = useState<Map<string, number>>(new Map());
   const cardElsRef = useRef(new Map<string, HTMLElement>());
 
+  // Threads of BOTH kinds: comment threads and suggestion threads. With the
+  // side-comments plugin gated off for research docs and the docked panel
+  // retired, the margin is the only surface carrying the suggestion
+  // accept/reject actions — filtering suggestions out left them unresolvable.
   const openThreads = useMemo(
     () =>
       comments.filter(
-        (c): c is Thread =>
-          c.type === 'thread' && c.status !== 'archived' && c.threadType !== 'suggestion',
+        (c): c is Thread => c.type === 'thread' && c.status !== 'archived',
       ),
     [comments],
   );
@@ -331,6 +339,17 @@ export default function ResearchCommentsMargin() {
     });
   }, [editor]);
 
+  // Suggestion resolution is accept/reject (the suggestion machinery applies
+  // or reverts the proposed edit), not the comment-thread resolve.
+  const acceptSuggestion = useCallback(
+    (thread: Thread) => acceptSuggestionThread(editor, thread),
+    [editor],
+  );
+  const rejectSuggestion = useCallback(
+    (thread: Thread) => rejectSuggestionThread(editor, thread),
+    [editor],
+  );
+
   const deleteThread = useCallback((thread: Thread) => {
     commentStore.deleteCommentOrThread(thread);
     const markNodeKeys = markNodeMap.get(getThreadMarkId(thread));
@@ -370,6 +389,8 @@ export default function ResearchCommentsMargin() {
           onJumpToMark={scrollToMark}
           onResolve={resolveThread}
           onDelete={deleteThread}
+          onAcceptSuggestion={acceptSuggestion}
+          onRejectSuggestion={rejectSuggestion}
           submitReply={submitReply}
         />
       ))}
@@ -386,6 +407,8 @@ function ThreadCard({
   onJumpToMark,
   onResolve,
   onDelete,
+  onAcceptSuggestion,
+  onRejectSuggestion,
   submitReply,
 }: {
   thread: Thread;
@@ -395,12 +418,31 @@ function ThreadCard({
   onJumpToMark: (thread: Thread) => void;
   onResolve: (thread: Thread) => void;
   onDelete: (thread: Thread) => void;
+  onAcceptSuggestion: (thread: Thread) => void;
+  onRejectSuggestion: (thread: Thread) => void;
   submitReply: (comment: Comment, isInlineComment: boolean, thread?: Thread) => void;
 }) {
   const classes = useStyles(styles);
   const refCallback = useCallback(
     (el: HTMLElement | null) => registerCardEl(thread.id, el),
     [registerCardEl, thread.id],
+  );
+
+  // Suggestion threads carry the proposed edit as a machine-written summary
+  // comment; it renders as the card body and its author heads the card. The
+  // actions are accept/reject (permission-gated inside
+  // SuggestionStatusOrActions) instead of resolve/delete — deleting a
+  // suggestion thread without rejecting would orphan its suggestion nodes.
+  const isSuggestion = thread.threadType === 'suggestion';
+  const summaryComment = isSuggestion
+    ? thread.comments.find((c) => c.commentKind === SUGGESTION_SUMMARY_KIND)
+    : undefined;
+  const summaryText = useMemo(
+    () => (summaryComment?.content ? formatSuggestionSummary(summaryComment.content) : null),
+    [summaryComment?.content],
+  );
+  const visibleComments = thread.comments.filter(
+    (c) => c.commentKind !== SUGGESTION_SUMMARY_KIND,
   );
 
   return (
@@ -411,27 +453,49 @@ function ThreadCard({
       onClick={() => onJumpToMark(thread)}
     >
       <div className={classes.actions}>
-        <button
-          type="button"
-          className={classes.actionButton}
-          onClick={(e) => { e.stopPropagation(); onResolve(thread); }}
-          title="Resolve thread"
-          aria-label="Resolve thread"
-        >
-          <ForumIcon icon="Check" className={classes.actionIcon} />
-        </button>
-        <button
-          type="button"
-          className={classes.actionButton}
-          onClick={(e) => { e.stopPropagation(); onDelete(thread); }}
-          title="Delete thread"
-          aria-label="Delete thread"
-        >
-          <ForumIcon icon="Close" className={classes.actionIcon} />
-        </button>
+        {isSuggestion ? (
+          <div onClick={(e) => e.stopPropagation()}>
+            <SuggestionStatusOrActions
+              status={thread.status ?? 'open'}
+              suggestionAuthorId={summaryComment?.authorId}
+              onAccept={() => onAcceptSuggestion(thread)}
+              onReject={() => onRejectSuggestion(thread)}
+            />
+          </div>
+        ) : (
+          <>
+            <button
+              type="button"
+              className={classes.actionButton}
+              onClick={(e) => { e.stopPropagation(); onResolve(thread); }}
+              title="Resolve thread"
+              aria-label="Resolve thread"
+            >
+              <ForumIcon icon="Check" className={classes.actionIcon} />
+            </button>
+            <button
+              type="button"
+              className={classes.actionButton}
+              onClick={(e) => { e.stopPropagation(); onDelete(thread); }}
+              title="Delete thread"
+              aria-label="Delete thread"
+            >
+              <ForumIcon icon="Close" className={classes.actionIcon} />
+            </button>
+          </>
+        )}
       </div>
+      {isSuggestion && summaryComment ? (
+        <div className={classes.commentRow}>
+          <div className={classes.commentHeader}>
+            <span className={classes.author}>{summaryComment.author}</span>
+            <span className={classes.time}>{moment(summaryComment.timeStamp).fromNow()}</span>
+          </div>
+          {summaryText ? <div className={classes.content}>{summaryText}</div> : null}
+        </div>
+      ) : null}
       {thread.quote ? <div className={classes.quote}>{thread.quote}</div> : null}
-      {thread.comments.map((comment) => (
+      {visibleComments.map((comment) => (
         <div key={comment.id} className={classes.commentRow}>
           <div className={classes.commentHeader}>
             <span className={classes.author}>{comment.author}</span>

--- a/packages/lesswrong/server/research/sandbox/readSandboxTextFile.ts
+++ b/packages/lesswrong/server/research/sandbox/readSandboxTextFile.ts
@@ -24,9 +24,16 @@ export async function readSandboxTextFile(
     // Emit the size before the binary check so binary files still report
     // their true on-disk size.
     `echo "__SIZE__ $size" >&2; ` +
-    // grep -I treats a binary file as non-matching; `. ` matches any line of a
-    // non-empty text file. Skip the check for empty files (they're valid text).
-    `if [ "$size" -gt 0 ] && ! grep -qI . "$target"; then echo "__BINARY__" >&2; exit 7; fi; ` +
+    // grep -I treats a binary file as non-matching; `.` matches any line with
+    // at least one character. That alone misclassifies whitespace-only text
+    // (e.g. a file of blank lines: no line matches `.`), so only call it
+    // binary when the head also contains non-whitespace bytes — a real binary
+    // does, a blank-lines file doesn't. Empty files skip the check entirely.
+    // LC_ALL=C so tr/grep treat the head as raw bytes — a UTF-8 locale would
+    // choke on the arbitrary byte sequences this exists to detect.
+    `if [ "$size" -gt 0 ] && ! grep -qI . "$target" && ` +
+    `head -c 65536 "$target" | LC_ALL=C tr -d ' \\t\\r\\n' | head -c 1 | LC_ALL=C grep -q .; ` +
+    `then echo "__BINARY__" >&2; exit 7; fi; ` +
     `head -c ${SANDBOX_FILE_MAX_BYTES} "$target"`;
   const result = await sandbox.runCommand({
     cmd: "bash",


### PR DESCRIPTION
Written by Claude
-----

Five defects found (and fixed) while porting #12630/#12636 into lightcone-commons, in code that is byte-identical or same-lineage here:

- ResearchCommentsMargin filtered out suggestion threads while the side-comments plugin is gated off research docs — leaving suggested edits with no accept/reject surface. The margin now renders suggestion threads: summary comment as the card body, accept/reject via SuggestionStatusOrActions (permission-gated), no resolve/delete for suggestions (deleting without rejecting orphans suggestion nodes).
- readSandboxTextFile classified whitespace-only text files (e.g. a log truncated to newlines) as binary: grep -qI . matches no line of a blank-lines file. Binary now additionally requires non-whitespace bytes in the head, under LC_ALL=C.
- Stacked window-level Escape handlers: closing the file viewer (or icon picker) in fullscreen chat also exited fullscreen on the same press. Inner overlays claim Escape (capture + preventDefault); the fullscreen handler skips defaultPrevented events.
- useTranscriptScroll's re-pin ResizeObserver ran once with empty deps and bailed forever when the scroll container wasn't mounted yet, and never re-attached after the file-browser toggle remounted the transcript at scrollTop 0. scrollRef/contentRef are now callback refs that (re)target the observer and restore the pin on remount.
- formatSize was duplicated across SandboxFileBrowser/Viewer with a divergent formatBytes in SandboxStatsFooter (no decimals, GB tier); one shared formatBytes now serves all three.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1216328842675822) by [Unito](https://www.unito.io)
