### PR TITLE
Lexical collab: per-editor bound provider factory (drop config singleton)

### DIFF
--- a/packages/lesswrong/components/lexical/Editor.tsx
+++ b/packages/lesswrong/components/lexical/Editor.tsx
@@ -31,7 +31,7 @@ import {SelectionAlwaysOnDisplay} from '@lexical/react/LexicalSelectionAlwaysOnD
 import {TabIndentationPlugin} from '@lexical/react/LexicalTabIndentationPlugin';
 import {TablePlugin} from '@lexical/react/LexicalTablePlugin';
 import {useLexicalEditable} from '@lexical/react/useLexicalEditable';
-import {useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState} from 'react';
+import {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import {Doc} from 'yjs';
 import * as Y from 'yjs';
 import {$generateHtmlFromNodes, $generateNodesFromDOM} from '@lexical/html';
@@ -40,9 +40,8 @@ import { CodeBlockPlugin } from '../editor/lexicalPlugins/codeBlock/CodeBlockPlu
 import TablesPlugin from '../editor/lexicalPlugins/tables/TablesPlugin';
 
 import {
-  createWebsocketProvider,
   createWebsocketProviderWithDoc,
-  setCollaborationConfig,
+  makeCollabProviderFactory,
   CollaboratorIdentityProvider,
   type CollaborationConfig,
   type CollaboratorIdentity,
@@ -651,9 +650,6 @@ export default function Editor({
     };
   }, [editor, onGetDataWithDiscardedSuggestions]);
   
-  // Track when collaboration config is ready (set synchronously, not in useEffect)
-  const [isCollabConfigReady, setIsCollabConfigReady] = useState(false);
-
   const externalModeContext = useContext(EditorUserModeContext);
   const setIsWsConnected = externalModeContext?.setIsWsConnected;
 
@@ -698,36 +694,34 @@ export default function Editor({
     });
   }, [editor]);
   
-  // Set up collaboration config before rendering collaboration plugins.
-  // Merge in our onSynced and onConnectionStatusChange handlers.
-  useLayoutEffect(() => {
-    if (collaborationConfig) {
-      const configWithHandlers: CollaborationConfig = {
-        ...collaborationConfig,
-        onSynced: (doc, isFirstSync, docId) => {
-          handleCollaborationSync(doc, isFirstSync, docId);
-          collaborationConfig.onSynced?.(doc, isFirstSync, docId);
-        },
-        onConnectionStatusChange: (connected) => {
-          setIsWsConnected?.(connected);
-          collaborationConfig.onConnectionStatusChange?.(connected);
-        },
-      };
-      setCollaborationConfig(configWithHandlers);
-    } else {
-      setCollaborationConfig(null);
-    }
-    setIsCollabConfigReady(!!collaborationConfig);
-    return () => {
-      // Note: We intentionally do not clean up IndexedDB persistence here.
-      // The persistence should survive component remounts to properly support
-      // offline editing. It will be cleaned up when:
-      // 1. A new persistence is created for the same document (in createWebsocketProviderWithDoc)
-      // 2. The page unloads
-      setCollaborationConfig(null);
-      setIsCollabConfigReady(false);
+  // Collaboration config with our onSynced/onConnectionStatusChange handlers
+  // merged in, and the provider factory bound to it. Both are memoized so the
+  // factory is referentially stable per document: Lexical's CollaborationPlugin
+  // memoizes the provider on the factory, so a fresh factory each render would
+  // recreate the provider and cause reconnect churn. (`collaborationConfig`
+  // itself is memoized upstream in LexicalEditor, so these only change when the
+  // document/user actually changes.) No IndexedDB cleanup on unmount — the
+  // persistence survives remounts for offline editing and is reconciled the
+  // next time a persistence is created for the same document.
+  const configWithHandlers = useMemo<CollaborationConfig | null>(() => {
+    if (!collaborationConfig) return null;
+    return {
+      ...collaborationConfig,
+      onSynced: (doc, isFirstSync, docId) => {
+        handleCollaborationSync(doc, isFirstSync, docId);
+        collaborationConfig.onSynced?.(doc, isFirstSync, docId);
+      },
+      onConnectionStatusChange: (connected) => {
+        setIsWsConnected?.(connected);
+        collaborationConfig.onConnectionStatusChange?.(connected);
+      },
     };
   }, [collaborationConfig, handleCollaborationSync, setIsWsConnected]);
+
+  const collabProviderFactory = useMemo(
+    () => (configWithHandlers ? makeCollabProviderFactory(configWithHandlers) : undefined),
+    [configWithHandlers],
+  );
 
   const {
     settings: {
@@ -907,7 +901,7 @@ export default function Editor({
           {collaboratorIdentity && showCommentFeatures && (
             <CollaboratorIdentityProvider value={collaboratorIdentity}>
               <CommentStoreProvider
-                providerFactory={isCollabConfigReady ? createWebsocketProvider : undefined}
+                providerFactory={collabProviderFactory}
               >
                 {!(isCollab && useCollabV2) && (
                   <>
@@ -927,12 +921,13 @@ export default function Editor({
         </MarkNodesProvider>
         {isRichText ? (
           <>
-            {isCollabConfigReady && collaborationConfig ? (
+            {collabProviderFactory && configWithHandlers && collaborationConfig ? (
               <>
                 {useCollabV2 ? (
                   <>
                     <CollabV2
                       id={COLLAB_DOC_ID}
+                      config={configWithHandlers}
                       shouldBootstrap={false}
                       username={collaborationConfig.user.name}
                       cursorsContainerRef={cursorsContainerRef}
@@ -943,7 +938,7 @@ export default function Editor({
                   <CollaborationPlugin
                     key={`${collaborationConfig.postId}:${collaborationConfig.fieldName ?? COLLAB_DOC_ID}`}
                     id={COLLAB_DOC_ID}
-                    providerFactory={createWebsocketProvider}
+                    providerFactory={collabProviderFactory}
                     shouldBootstrap={false}
                     username={collaborationConfig.user.name}
                     cursorsContainerRef={cursorsContainerRef}
@@ -1096,11 +1091,13 @@ export default function Editor({
 
 function CollabV2({
   id,
+  config,
   shouldBootstrap,
   username,
   cursorsContainerRef,
 }: {
   id: string;
+  config: CollaborationConfig;
   shouldBootstrap: boolean;
   username?: string;
   cursorsContainerRef: React.RefObject<HTMLDivElement | null>;
@@ -1109,8 +1106,8 @@ function CollabV2({
   const doc = useMemo(() => new Doc({gc: false}), []);
 
   const provider = useMemo(() => {
-    return createWebsocketProviderWithDoc('main', doc);
-  }, [doc]);
+    return createWebsocketProviderWithDoc('main', doc, config);
+  }, [doc, config]);
 
   return (
     // eslint-disable-next-line react/jsx-pascal-case

--- a/packages/lesswrong/components/lexical/collaboration.ts
+++ b/packages/lesswrong/components/lexical/collaboration.ts
@@ -171,16 +171,13 @@ export function useCanRejectSuggestion(): (suggestionAuthorId: string) => boolea
   );
 }
 
-// Module-level config storage - set this before rendering the Editor.
-// This singleton pattern is necessary because Lexical's CollaborationPlugin
-// expects a provider factory function with a fixed signature that can't accept
-// additional parameters. The config is set before rendering and accessed by
-// the factory function.
-let _collaborationConfig: CollaborationConfig | null = null;
-
-export function setCollaborationConfig(config: CollaborationConfig | null): void {
-  _collaborationConfig = config;
-}
+// The collaboration config used to be stored in a module-level singleton,
+// because Lexical's CollaborationPlugin expects a provider factory with a fixed
+// `(id, yjsDocMap) => Provider` signature that can't carry the config. That
+// forced a single active editor: two mounted at once would clobber each other's
+// config. Instead we now build a *bound* factory per editor
+// (`makeCollabProviderFactory`), closing the config over the factory — so
+// multiple collaborative editors can coexist.
 
 const COLLAB_DOCUMENT_NAME_PREFIXES: Partial<Record<CollectionNameString, string>> = {
   Posts: 'post-',
@@ -311,30 +308,38 @@ function setupPersistence(
   });
 }
 
-// parent dom -> child doc
-export function createWebsocketProvider(
-  id: string,
-  yjsDocMap: Map<string, Doc>,
-): Provider & HocuspocusProvider {
-  let doc = yjsDocMap.get(id);
+/**
+ * The provider factory Lexical's CollaborationPlugin (and our CommentStoreProvider)
+ * expect: `(id, yjsDocMap) => Provider`. `id` is the subdoc id ('main', 'comments',
+ * …); the factory resolves/creates that subdoc's `Doc` in the editor's own map.
+ */
+export type CollabProviderFactory =
+  (id: string, yjsDocMap: Map<string, Doc>) => Provider & HocuspocusProvider;
 
-  if (doc === undefined) {
-    doc = new Doc();
-    yjsDocMap.set(id, doc);
-  } else {
-    doc.load();
-  }
-
-  return createWebsocketProviderWithDoc(id, doc);
+/**
+ * Build a provider factory bound to one document's `config`. Each editor gets
+ * its own factory (see the note by the removed singleton above), so several
+ * collaborative editors can be mounted simultaneously without stepping on each
+ * other's document/token/user.
+ */
+export function makeCollabProviderFactory(config: CollaborationConfig): CollabProviderFactory {
+  return (id, yjsDocMap) => {
+    let doc = yjsDocMap.get(id);
+    if (doc === undefined) {
+      doc = new Doc();
+      yjsDocMap.set(id, doc);
+    } else {
+      doc.load();
+    }
+    return createWebsocketProviderWithDoc(id, doc, config);
+  };
 }
 
-export function createWebsocketProviderWithDoc(id: string, doc: Doc): Provider & HocuspocusProvider {
-  const config = _collaborationConfig;
-
-  if (!config) {
-    throw new Error('[Collaboration] No collaboration config set. Call setCollaborationConfig() before using collaboration features.');
-  }
-
+export function createWebsocketProviderWithDoc(
+  id: string,
+  doc: Doc,
+  config: CollaborationConfig,
+): Provider & HocuspocusProvider {
   const wsUrl = process.env.NEXT_PUBLIC_HOCUSPOCUS_URL;
   if (!wsUrl) {
     throw new Error('[Collaboration] HOCUSPOCUS_URL is not configured. Set the HOCUSPOCUS_URL environment variable at build time.');


### PR DESCRIPTION
Enabling refactor for smoother `/research` document navigation (and generally allowing two collaborative editors to coexist).

## Problem
The Lexical collaboration config lived in a **module-level singleton** (`_collaborationConfig`, set via `setCollaborationConfig`) because `CollaborationPlugin` wants a provider factory with a fixed `(id, yjsDocMap) => Provider` signature that can't carry the config. That meant **only one collaborative editor could be mounted at a time** — a second one clobbers the first's document/token/user. It's why holding the previous document on screen while the next loads (to avoid the empty-editor flash on navigation) has been so fiddly, and it's the crash source behind earlier `<Activity>` attempts.

## Change
- Replace the singleton with a **factory builder**: `makeCollabProviderFactory(config)` returns the `(id, yjsDocMap) => Provider` closure with the config bound in.
- `Editor.tsx` builds it in a `useMemo` (referentially **stable per document** — Lexical memoizes the provider on the factory, so a fresh one each render would cause reconnect churn) and hands it to `CollaborationPlugin`, `CommentStoreProvider` (comments subdoc), and the V2 path.
- `createWebsocketProviderWithDoc` now takes `config` as a parameter; `setCollaborationConfig` / `_collaborationConfig` are gone.

## Deliberately *not* changed
Provider/doc **lifecycle is identical** — created per mount, torn down per unmount. This only removes the global so multiple editors can coexist; it does **not** introduce provider keep-alive or ref-counting. It unblocks the follow-up (keep the outgoing doc rendered via a transition / `<Activity>` until the incoming one has content).

## Scope
2 files, ~70 lines. No vendored-Lexical changes. `yarn tsc` clean; `/research` compiles and renders.

## ⚠️ Verification still needed
This is the **shared** editor, so it needs an interactive pass before merge:
- **Posts**: collab editing syncs, comments/suggestions work, versions/restore work.
- **Research**: doc editing syncs and persists; live sync across two tabs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1216334686556059) by [Unito](https://www.unito.io)
