### PR TITLE
Preserve hue for dark mode content colors

### DIFF
--- a/packages/lesswrong/components/contents/ContentItemBody.tsx
+++ b/packages/lesswrong/components/contents/ContentItemBody.tsx
@@ -19,7 +19,7 @@ import { useTracking } from '@/lib/analyticsEvents';
 import repeat from 'lodash/repeat';
 import { captureException } from '@/lib/sentryWrapper';
 import { getColorReplacementsCache } from '@/themes/userThemes/darkMode';
-import { colorToString, invertColor, parseColor } from '@/themes/colorUtil';
+import { colorToString, invertColorPreservingHue, parseColor } from '@/themes/colorUtil';
 import { useAbstractThemeOptions } from '../themes/useTheme';
 import { useStyles } from '../hooks/useStyles';
 import { getHighlights, highlightCodeElement, updateHighlightContext, removeHighlightContext, codeHighlightStyles } from '@/lib/codeHighlighting';
@@ -707,7 +707,7 @@ function transformAttributeValueForDarkMode(attributeValue: string): string {
   if (!getColorReplacementsCache()[normalized]) {
     const parsedColor = parseColor(normalized);
     if (parsedColor) {
-      const invertedColor = invertColor(parsedColor);
+      const invertedColor = invertColorPreservingHue(parsedColor);
       getColorReplacementsCache()[normalized] = colorToString(invertedColor);
     } else {
       // If unable to parse a color (eg an unsupported color format), use black

--- a/packages/lesswrong/themes/colorUtil.ts
+++ b/packages/lesswrong/themes/colorUtil.ts
@@ -87,6 +87,44 @@ export function invertColor(color: ColorTuple): ColorTuple
   return [invertChannel(r),invertChannel(g),invertChannel(b),1];
 }
 
+function rgbToHsl(r: number, g: number, b: number): [number, number, number]
+{
+  const max = Math.max(r, g, b);
+  const min = Math.min(r, g, b);
+  const lightness = (max + min) / 2;
+
+  if (max === min) {
+    return [0, 0, lightness];
+  }
+
+  const delta = max - min;
+  const saturation = lightness > 0.5
+    ? delta / (2 - max - min)
+    : delta / (max + min);
+  let hue: number;
+
+  switch (max) {
+    case r:
+      hue = ((g - b) / delta) + (g < b ? 6 : 0);
+      break;
+    case g:
+      hue = ((b - r) / delta) + 2;
+      break;
+    default:
+      hue = ((r - g) / delta) + 4;
+      break;
+  }
+
+  return [hue / 6, saturation, lightness];
+}
+
+export function invertColorPreservingHue(color: ColorTuple): ColorTuple
+{
+  const [r,g,b] = color;
+  const [h,s,l] = rgbToHsl(r, g, b);
+  return hslToRgb(h, s, 1 - l);
+}
+
 function validateColor(color: ColorTuple) {
   const [r,g,b,a] = color;
   if (r < 0 || r > 1 || g < 0 || g > 1 || b < 0 || b > 1 || a < 0 || a > 1) {
@@ -175,7 +213,7 @@ function hslToRgb(h: number, s: number, l: number): ColorTuple {
     b = hueToRgb(p, q, h - (1/3));
   }
 
-  return [Math.round(r * 255), Math.round(g * 255), Math.round(b * 255), 1.0];
+  return [r, g, b, 1.0];
 }
 
 function hueToRgb(p: number, q: number, t: number) {

--- a/packages/lesswrong/themes/colorUtil.ts
+++ b/packages/lesswrong/themes/colorUtil.ts
@@ -196,7 +196,7 @@ export const invertIfDarkMode = (color: string) => `light-dark(${color},${invert
  * Converts an HSL color value to RGB. Conversion formula
  * adapted from https://en.wikipedia.org/wiki/HSL_color_space.
  * Assumes h, s, and l are contained in the set [0, 1] and
- * returns r, g, and b in the set [0, 255].
+ * returns r, g, and b in the range [0, 1].
  *
  * Source: https://stackoverflow.com/questions/2353211/hsl-to-rgb-color-conversion
  */

--- a/packages/lesswrong/unitTests/colorUtil.tests.ts
+++ b/packages/lesswrong/unitTests/colorUtil.tests.ts
@@ -1,0 +1,16 @@
+import { colorToString, invertColorPreservingHue, invertHexColor } from '../themes/colorUtil';
+
+describe('colorUtil', () => {
+  it('keeps the old channel-wise inversion for theme colors', () => {
+    expect(invertHexColor('#0000ff')).toBe('#ffff00');
+  });
+
+  it('preserves hue when inverting lightness for content colors', () => {
+    expect(colorToString(invertColorPreservingHue([0, 0, 1, 1]))).toBe('#0000ff');
+    expect(colorToString(invertColorPreservingHue([0, 0, 128 / 255, 1]))).toBe('#7f7fff');
+  });
+
+  it('inverts greyscale lightness when preserving hue', () => {
+    expect(colorToString(invertColorPreservingHue([0.2, 0.2, 0.2, 1]))).toBe('#cccccc');
+  });
+});


### PR DESCRIPTION
Slack thread: https://slack.com/app_redirect?channel=CJUN2UAFN&message_ts=1783407277.615589

Github diff: https://github.com/ForumMagnum/ForumMagnum/compare/master...cursor/bot-task-workflow-abfd

Preview deployment: `https://baserates-test-git-cursor-bot-task-workflow-abfd-lesswrong.vercel.app`

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1216380815985769) by [Unito](https://www.unito.io)
