### PR TITLE
Noindex revision and compare pages

### DIFF
--- a/app/compare/post/[_id]/[slug]/page.tsx
+++ b/app/compare/post/[_id]/[slug]/page.tsx
@@ -12,7 +12,7 @@ assertRouteAttributes("/compare/post/[_id]/[slug]", {
   hasMarkdownVersion: false,
 });
 
-export const generateMetadata = getPostPageMetadataFunction<{ _id: string }>(({ _id }) => _id);
+export const generateMetadata = getPostPageMetadataFunction<{ _id: string }>(({ _id }) => _id, { noIndex: true });
 
 export default async function Page({ params }: {
   params: Promise<{ _id: string, slug: string }>

--- a/app/compare/w/[slug]/page.tsx
+++ b/app/compare/w/[slug]/page.tsx
@@ -12,7 +12,7 @@ assertRouteAttributes("/compare/w/[slug]", {
   hasMarkdownVersion: false,
 });
 
-export const generateMetadata = getTagPageMetadataFunction<{ slug: string }>(({ slug }) => slug);
+export const generateMetadata = getTagPageMetadataFunction<{ slug: string }>(({ slug }) => slug, { noIndex: true });
 
 export default async function Page({ params }: {
   params: Promise<{ slug: string }>

--- a/app/revisions/post/[_id]/[slug]/page.tsx
+++ b/app/revisions/post/[_id]/[slug]/page.tsx
@@ -12,7 +12,7 @@ assertRouteAttributes("/revisions/post/[_id]/[slug]", {
   hasMarkdownVersion: false,
 });
 
-export const generateMetadata = getPostPageMetadataFunction<{ _id: string; slug: string }>(({ _id }) => _id);
+export const generateMetadata = getPostPageMetadataFunction<{ _id: string; slug: string }>(({ _id }) => _id, { noIndex: true });
 
 export default async function Page({ params }: {
   params: Promise<{ _id: string; slug: string }>

--- a/app/revisions/w/[slug]/page.tsx
+++ b/app/revisions/w/[slug]/page.tsx
@@ -13,7 +13,7 @@ assertRouteAttributes("/revisions/w/[slug]", {
   hasMarkdownVersion: false,
 });
 
-export const generateMetadata = getTagPageMetadataFunction<{ slug: string }>(({ slug }) => slug);
+export const generateMetadata = getTagPageMetadataFunction<{ slug: string }>(({ slug }) => slug, { noIndex: true });
 
 export default async function Page({ params }: {
   params: Promise<{ slug: string }>


### PR DESCRIPTION
Generated by GPT-5.5 via Cursor automation
-----
Slack thread: https://slack.com/app_redirect?channel=CJUN2UAFN&message_ts=1782681970.701439

Github diff: https://github.com/ForumMagnum/ForumMagnum/compare/master...noindex-revision-pages

Preview deployment: `https://baserates-test-git-noindex-revision-pages-lesswrong.vercel.app`

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1216471540216151) by [Unito](https://www.unito.io)
