### PR TITLE
Fix supervisor launch hanging every cold sandbox provision

### DIFF
--- a/packages/lesswrong/server/research/sandbox/sandboxManager.ts
+++ b/packages/lesswrong/server/research/sandbox/sandboxManager.ts
@@ -261,8 +261,13 @@ async function launchSupervisor(sandbox: Sandbox, env: SupervisorLaunchEnv): Pro
     cmd: "sh",
     args: [
       "-c",
+      // The `&`-backgrounded unit must stay a simple command with every fd
+      // redirected (`;` before it, never `&&`): backgrounding a compound list
+      // makes runCommand wait on the subshell's inherited output pipes, which
+      // on a freshly created session never close — the provision then hangs
+      // until the function times out.
       `tail -c 262144 ${log} > ${log}.trim 2>/dev/null && mv ${log}.trim ${log}; ` +
-        `echo "[launch] $(date -u +%Y-%m-%dT%H:%M:%SZ)" >> ${log} && ` +
+        `echo "[launch] $(date -u +%Y-%m-%dT%H:%M:%SZ)" >> ${log}; ` +
         `nohup setsid node ${SUPERVISOR_PATH} >> ${log} 2>&1 < /dev/null &`,
     ],
     env: supervisorEnv,


### PR DESCRIPTION
Written by Claude
------
97384faac0 prepended a log trim/marker to the supervisor launch command, chaining the marker to the launch with `&&`. Since `&&` binds tighter than `&`, the backgrounded unit became the compound list `echo … && nohup …` instead of the fully-redirected simple `nohup` command; on a freshly created or resumed session, runCommand then waits forever on the background subshell's inherited output pipes, so getOrCreateSandbox never returns and the firing request rides to the 300s function timeout. Every cold provision (new conversation, or continuing one whose sandbox had stopped) has failed this way since deploy — the conversation row is created but the turn is never dispatched — while warm turns, which skip the launch stack, kept working. Reproduced deterministically in throwaway sandboxes (3/3 hangs for the compound shape, none for the simple shape).

Backgrounding the simple command (`; ` before `nohup`, not `&&`) restores the old detach semantics while keeping the trim and marker.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1216474321055859) by [Unito](https://www.unito.io)
