### PR TITLE
Bump research sandbox Claude Code pin to 2.1.207 (Sonnet 5 for subagents)

### DIFF
--- a/packages/lesswrong/server/research/sandbox/sandboxLayout.ts
+++ b/packages/lesswrong/server/research/sandbox/sandboxLayout.ts
@@ -34,7 +34,7 @@ export const CLAUDE_MD_PATH = `${CLAUDE_DIR}/CLAUDE.md`;
  * this, rebuild the baseline snapshots, and existing sandboxes reconcile on
  * their next launch.
  */
-export const PINNED_CLAUDE_CODE_VERSION = "2.1.181";
+export const PINNED_CLAUDE_CODE_VERSION = "2.1.207";
 
 /** The model the research agent runs (`claude --model ...`). Requires a CLI
  * version that knows the model family — see PINNED_CLAUDE_CODE_VERSION. */


### PR DESCRIPTION
## Summary

Bumps `PINNED_CLAUDE_CODE_VERSION` from 2.1.181 → 2.1.207 so research-sandbox agents can use Sonnet 5 in subagents/workflows. 2.1.181 predates `claude-sonnet-5`; 2.1.207 is the current latest and knows the model (verified by inspecting the CLI binary). `RESEARCH_AGENT_MODEL` (the primary model) is unchanged, so the supervisor bundle is functionally unaffected.

## Rollout

- Existing conversations upgrade automatically via `reconcileClaudeCodeVersion` on their next supervisor launch (i.e. the first turn after their sandbox has idle-stopped). That turn pays a one-time npm install (tens of seconds).
- Conversations warm across the deploy keep the old CLI until they idle-stop (30 min) or their sandbox is stopped manually.

## Post-deploy steps

1. Rebuild the baseline snapshots so fresh sandboxes get 2.1.207 baked in instead of paying the reconcile install at provision: `yarn research-supervisor-build && yarn research-sandbox-build-snapshot`
2. Run one end-to-end turn on an upgraded sandbox, ideally exercising `AskUserQuestion` (the `can_use_tool` stdio control channel is the protocol compatibility surface — last verified against 2.1.198) and a Sonnet 5 subagent spawn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1216549625632088) by [Unito](https://www.unito.io)
