### PR TITLE
Fix research-sandbox session loss: safe env saves, staged session bootstrap

### DIFF
--- a/app/api/research/agent/conversations/[conversationId]/events/route.ts
+++ b/app/api/research/agent/conversations/[conversationId]/events/route.ts
@@ -24,7 +24,7 @@ const eventKindSchema = z.enum([
   // Per-turn metadata wrapper (`subtype`, `duration_ms`, `usage`,
   // `is_error`). Claude Code emits exactly one per turn, regardless of how
   // many intermediate events the turn produced, so we use it as a robust
-  // turn-end signal in the UI. Skipped during `writeBootstrapJsonl` so it
+  // turn-end signal in the UI. Skipped during `buildBootstrapJsonl` so it
   // never lands back in Claude's resume context.
   "result",
 ]);

--- a/packages/lesswrong/server/research/sandbox/sandboxManager.ts
+++ b/packages/lesswrong/server/research/sandbox/sandboxManager.ts
@@ -32,6 +32,7 @@ import { decryptUserSecret } from "@/server/research/userSecretsCrypto";
 import { getSiteUrlFromHeaders } from "@/server/utils/getSiteUrl";
 import { serverCaptureEvent } from "@/server/analytics/serverAnalyticsWriter";
 import { getPlatformAssets } from "./platformAssets";
+import { SESSION_STAGING_SUFFIX } from "./supervisor/sessionBootstrap";
 import {
   AGENT_CWD,
   CLAUDE_MD_PATH,
@@ -73,6 +74,38 @@ const DEFAULT_RUNTIME = "node24";
 /** The persistent sandbox name for a conversation. Stable across sessions. */
 export function sandboxNameForConversation(conversationId: string): string {
   return `${SANDBOX_NAME_PREFIX}${conversationId}`;
+}
+
+/**
+ * Absolute in-sandbox path of a conversation's Claude Code session JSONL:
+ * `<home>/.claude/projects/<encoded-cwd>/<sessionId>.jsonl`, where the encoded
+ * cwd is the agent cwd with `/` replaced by `-`. Must stay in agreement with
+ * the supervisor's `sessionJsonlPath` (supervisor/sessionBootstrap.ts), which
+ * computes the same path from inside the sandbox.
+ */
+export function claudeSessionJsonlPath(claudeSessionId: string): string {
+  const encodedCwd = AGENT_CWD.replace(/\//g, "-");
+  return `${SANDBOX_HOME_DIR}/.claude/projects/${encodedCwd}/${claudeSessionId}.jsonl`;
+}
+
+/**
+ * Stage a reconstructed Claude session file into the sandbox through the
+ * Sandbox filesystem API — never the supervisor's HTTP interface, whose body
+ * cap a long conversation's JSONL can exceed. `writeFiles` creates parent
+ * directories as needed. The write lands at a staging path rather than the
+ * session path itself: this API can't serialize with the supervisor's claude
+ * process lifecycle, so the supervisor installs the staged file at spawn
+ * time, under its per-conversation lock (`installStagedSessionJsonl`).
+ */
+export async function stageClaudeSessionFile(
+  sandbox: Sandbox,
+  claudeSessionId: string,
+  jsonlLines: string[],
+): Promise<void> {
+  const body = jsonlLines.join("\n") + "\n";
+  await sandbox.writeFiles([
+    { path: claudeSessionJsonlPath(claudeSessionId) + SESSION_STAGING_SUFFIX, content: body },
+  ]);
 }
 
 /** Inverse of `sandboxNameForConversation`; `null` if the name isn't ours. */

--- a/packages/lesswrong/server/research/sandbox/saveEnvironment.ts
+++ b/packages/lesswrong/server/research/sandbox/saveEnvironment.ts
@@ -4,6 +4,7 @@ import {
   getRunningSandbox,
   sandboxNameForConversation,
   supervisorUrlForSandbox,
+  SNAPSHOT_EXPIRATION_MS,
 } from "./sandboxManager";
 
 const QUIESCE_TIMEOUT_MS = 60_000;
@@ -144,52 +145,40 @@ export async function buildEnvironmentSnapshot(args: {
   }
   const effectiveWith = withConversation && sourceEventId !== null;
 
-  let intermediateSnapshot: Snapshot | null = null;
   let clone: Sandbox | null = null;
 
   try {
-    let repoDir: string | null = null;
-    let envSnapshotId: string;
-
-    if (effectiveWith) {
-      if (running) {
-        repoDir = await detectRepoDirName(running);
-        // Snapshot the quiesced sandbox directly (stops it → cold resume next turn).
-        const snap = await running.snapshot({ expiration: 0 });
-        envSnapshotId = snap.snapshotId;
-      } else {
-        const srcSnapshotId = await Snapshot.fromSandbox(sandboxName);
-        clone = await createCloneFromSnapshot(srcSnapshotId);
-        repoDir = await detectRepoDirName(clone);
-        const snap = await clone.snapshot({ expiration: 0 });
-        envSnapshotId = snap.snapshotId;
-      }
+    // The env snapshot is always taken from a throwaway clone, never from the
+    // conversation's persistent sandbox: an env snapshot's lifecycle is the
+    // environment's (deleted if the insert fails, deletable by the user), and
+    // the persistent sandbox must never resume from a snapshot that can be
+    // deleted out from under it.
+    let cloneSourceSnapshotId: string;
+    if (running) {
+      // Stops the sandbox (cold resume next turn). This snapshot is what the
+      // persistent sandbox resumes from, so it must outlive this function; it
+      // gets the same retention as the sandbox's own auto-snapshots and is
+      // superseded by the next one.
+      const intermediate = await running.snapshot({ expiration: SNAPSHOT_EXPIRATION_MS });
+      cloneSourceSnapshotId = intermediate.snapshotId;
     } else {
-      let cloneSourceSnapshotId: string;
-      if (running) {
-        intermediateSnapshot = await running.snapshot({ expiration: 0 });
-        cloneSourceSnapshotId = intermediateSnapshot.snapshotId;
-      } else {
-        cloneSourceSnapshotId = await Snapshot.fromSandbox(sandboxName);
-      }
-      clone = await createCloneFromSnapshot(cloneSourceSnapshotId);
-      repoDir = await detectRepoDirName(clone);
-      await scrubAgentSession(clone);
-      const snap = await clone.snapshot({ expiration: 0 });
-      envSnapshotId = snap.snapshotId;
+      cloneSourceSnapshotId = await Snapshot.fromSandbox(sandboxName);
     }
+    clone = await createCloneFromSnapshot(cloneSourceSnapshotId);
+    const repoDir = await detectRepoDirName(clone);
+    if (!effectiveWith) {
+      await scrubAgentSession(clone);
+    }
+    const snap = await clone.snapshot({ expiration: 0 });
 
     return {
-      vercelSnapshotId: envSnapshotId,
+      vercelSnapshotId: snap.snapshotId,
       sourceEventId: effectiveWith ? sourceEventId : null,
       label: deriveLabel(repoDir, conversationTitle),
     };
   } finally {
     if (clone) {
       await clone.stop().catch(() => {});
-    }
-    if (intermediateSnapshot) {
-      await intermediateSnapshot.delete().catch(() => {});
     }
   }
 }

--- a/packages/lesswrong/server/research/sandbox/supervisor/conversationHub.ts
+++ b/packages/lesswrong/server/research/sandbox/supervisor/conversationHub.ts
@@ -40,7 +40,11 @@ import { randomUUID } from "node:crypto";
 import { ParsedJsonlLine, ClaudeEventKind } from "./jsonlParser";
 import { CanUseToolRequest, ClaudeProcessHandle, startClaudeProcess } from "./claudeRunner";
 import { BackendEvent, PostPersister } from "./postPersister";
-import { writeBootstrapJsonl } from "./sessionBootstrap";
+import {
+  installStagedSessionJsonl,
+  SESSION_FILE_MISSING_REASON,
+  sessionJsonlExists,
+} from "./sessionBootstrap";
 import { ConversationState } from "./server";
 import { FLUSH_RESULT_SUBTYPE } from "../../../../lib/research/turnActivity";
 
@@ -149,33 +153,24 @@ export interface DispatchInput {
   /**
    * True when a Claude session for this conversation has existed before (the
    * backend checks its persisted events for any line carrying a session_id).
-   * Decides `--resume` vs `--session-id` at spawn. This deliberately comes
-   * from the backend rather than a supervisor-side existence check on the
-   * session file: right after a sandbox resume the snapshot restore can lag,
-   * so a filesystem probe races it — observed as `--session-id` being chosen
-   * for an existing session, which the CLI rejects with "already in use".
+   * Decides `--resume` vs `--session-id` at spawn. This comes from the backend
+   * rather than being inferred from a session-file existence check: right
+   * after a sandbox resume the snapshot restore can lag, so a filesystem probe
+   * races it — observed as `--session-id` being chosen for an existing
+   * session, which the CLI rejects with "already in use". The hub still
+   * probes the file before an `--resume` spawn, but a miss never downgrades
+   * to `--session-id`; it rejects the dispatch as `session_file_missing` so
+   * the backend can ship a reconstruction and retry.
    */
   sessionHasHistory?: boolean;
-  /**
-   * Verbatim JSONL lines from prior `ResearchConversationEvents`, in seq order.
-   * If non-empty, the hub writes them to the Claude Code session dir before
-   * spawning so `--resume` finds the history. Each entry is one line of text.
-   * The write replaces any file already at that path: the backend only ships
-   * a bootstrap when the on-disk file can't be trusted (fresh rebuild — where
-   * any file present came from a stale base snapshot — or a legacy
-   * conversation with a just-derived id), so the reconstruction wins.
-   * Ignored when the conversation's process is already running (the live
-   * process owns the session file).
-   */
-  bootstrapJsonl?: string[];
 }
 
 /**
  * Ship a supervisor-synthesized terminal `result` for a turn that can't end
  * normally (process crash, cancel flush, sandbox restart). Uses the
  * `interrupted` subtype, which in-flight derivations treat as closing every
- * outstanding user turn; `writeBootstrapJsonl` strips result lines, so it
- * never lands back in Claude's resume context.
+ * outstanding user turn; the session reconstruction (`buildBootstrapJsonl`)
+ * strips result lines, so it never lands back in Claude's resume context.
  */
 export function enqueueSyntheticInterruptedResult(
   postPersister: PostPersister,
@@ -194,6 +189,27 @@ export function enqueueSyntheticInterruptedResult(
     claudeMessageUuid: null,
     supervisorEmittedAt: new Date(nowMs).toISOString(),
   });
+}
+
+const SESSION_PROBE_ATTEMPTS = 3;
+const SESSION_PROBE_RETRY_MS = 1500;
+
+/**
+ * Existence check for the session JSONL that tolerates the snapshot-restore
+ * lag documented on `DispatchInput.sessionHasHistory`: a file that is really
+ * on the snapshot can transiently read as absent right after a resume, so
+ * only a miss that persists across a few seconds counts.
+ */
+async function sessionFileExistsWithRetry(
+  target: { claudeSessionId: string; cwd?: string },
+): Promise<boolean> {
+  for (let attempt = 0; attempt < SESSION_PROBE_ATTEMPTS; attempt++) {
+    if (attempt > 0) {
+      await new Promise((resolve) => setTimeout(resolve, SESSION_PROBE_RETRY_MS));
+    }
+    if (await sessionJsonlExists(target)) return true;
+  }
+  return false;
 }
 
 export function createConversationHub(config: ConversationHubConfig) {
@@ -350,22 +366,34 @@ export function createConversationHub(config: ConversationHubConfig) {
     const claudeSessionId = entry.claudeSessionId ?? input.claudeSessionId ?? randomUUID();
     entry.claudeSessionId = claudeSessionId;
 
-    let sessionExists = input.sessionHasHistory ?? false;
+    const sessionExists = input.sessionHasHistory ?? false;
 
-    if (input.bootstrapJsonl && input.bootstrapJsonl.length > 0) {
+    if (sessionExists) {
+      const target = { claudeSessionId, cwd: runnerOpts.cwd };
+      // A backend-staged session reconstruction is installed here — and only
+      // here — because the opChain guarantees no live process holds the
+      // session file at this point, which the backend's out-of-band staging
+      // write cannot guarantee on its own.
       try {
-        await writeBootstrapJsonl(
-          { claudeSessionId, cwd: runnerOpts.cwd },
-          input.bootstrapJsonl.map((line) => ({ payload: line })),
-        );
-        sessionExists = true;
+        await installStagedSessionJsonl(target);
       } catch (err) {
         // eslint-disable-next-line no-console
         console.error(
-          `[hub] bootstrap write failed for conv=${entry.conversationId} session=${claudeSessionId}:`,
+          `[hub] staged session install failed for conv=${entry.conversationId} session=${claudeSessionId}:`,
           err,
         );
-        return { ok: false, reason: "bootstrap_failed" };
+      }
+      // `--resume` hard-fails the spawn when the session file is gone (e.g.
+      // the sandbox was rebuilt from a base snapshot). A persistent miss
+      // rejects the dispatch with a reason the backend recognizes; it stages
+      // a reconstruction and re-dispatches.
+      const exists = await sessionFileExistsWithRetry(target);
+      if (!exists) {
+        // eslint-disable-next-line no-console
+        console.error(
+          `[hub] session file missing for conv=${entry.conversationId} session=${claudeSessionId}; rejecting dispatch for backend bootstrap`,
+        );
+        return { ok: false, reason: SESSION_FILE_MISSING_REASON };
       }
     }
 
@@ -633,7 +661,8 @@ function updateOutstandingTasks(
  * `result` is persisted because it's the only line Claude Code emits exactly
  * once per turn regardless of how many intermediate events the turn produced;
  * the client uses its presence as a turn-end signal. It's filtered back out
- * in `writeBootstrapJsonl` so it never lands in Claude's resume context.
+ * of session reconstructions (`buildBootstrapJsonl`) so it never lands in
+ * Claude's resume context.
  */
 function mapKindForPersistence(kind: ClaudeEventKind): BackendEvent["kind"] | null {
   switch (kind) {

--- a/packages/lesswrong/server/research/sandbox/supervisor/index.ts
+++ b/packages/lesswrong/server/research/sandbox/supervisor/index.ts
@@ -244,7 +244,6 @@ export async function bootSupervisor() {
           prompt: req.prompt,
           claudeSessionId: req.claudeSessionId,
           sessionHasHistory: req.sessionHasHistory,
-          bootstrapJsonl: req.bootstrapJsonl,
         },
         {
           // The cwd the claude subprocess starts in — also the cwd the

--- a/packages/lesswrong/server/research/sandbox/supervisor/server.ts
+++ b/packages/lesswrong/server/research/sandbox/supervisor/server.ts
@@ -72,8 +72,6 @@ export interface DispatchRequest {
    * `--session-id` at spawn; see DispatchInput.sessionHasHistory.
    */
   sessionHasHistory?: boolean;
-  /** Synthesized JSONL lines to seed the session dir before --resume. */
-  bootstrapJsonl?: string[];
   /** References attached as part of the user turn (file paths, doc handles, etc.). */
   references?: unknown[];
   /**
@@ -153,10 +151,8 @@ async function handleRequest(
   }
 
   if (path === "/dispatch" && method === "POST") {
-    const body = await readJsonBody(req).catch((e) => ({ __err: e }));
-    if ("__err" in body) {
-      return json(res, 400, { error: "bad json" });
-    }
+    const body = await readJsonBodyOrRespond(req, res, "/dispatch");
+    if (!body) return;
     const dispatchReq = parseDispatchRequest(body);
     if (!dispatchReq) {
       return json(res, 400, { error: "missing conversationId or prompt" });
@@ -184,10 +180,8 @@ async function handleRequest(
     if (!supervisorTokenCanAccessConversation(validation.payload, conversationId)) {
       return json(res, 403, { error: "forbidden", reason: "conversation scope mismatch" });
     }
-    const body = await readJsonBody(req).catch((e) => ({ __err: e }));
-    if ("__err" in body) {
-      return json(res, 400, { error: "bad json" });
-    }
+    const body = await readJsonBodyOrRespond(req, res, "/answer");
+    if (!body) return;
     const answerReq = parseAnswerRequest(body);
     if (!answerReq) {
       return json(res, 400, { error: "missing toolUseId or answers" });
@@ -222,9 +216,6 @@ function parseDispatchRequest(body: Record<string, unknown>): DispatchRequest | 
   };
   if (typeof body.claudeSessionId === "string") out.claudeSessionId = body.claudeSessionId;
   if (typeof body.sessionHasHistory === "boolean") out.sessionHasHistory = body.sessionHasHistory;
-  if (Array.isArray(body.bootstrapJsonl)) {
-    out.bootstrapJsonl = body.bootstrapJsonl.filter((s): s is string => typeof s === "string");
-  }
   if (Array.isArray(body.references)) out.references = body.references;
   if (typeof body.agentBackendToken === "string") out.agentBackendToken = body.agentBackendToken;
   return out;
@@ -244,16 +235,70 @@ function parseAnswerRequest(
   return { toolUseId: body.toolUseId, answers: out };
 }
 
-async function readJsonBody(req: IncomingMessage): Promise<Record<string, unknown>> {
-  const chunks: Buffer[] = [];
-  for await (const chunk of req) {
-    chunks.push(typeof chunk === "string" ? Buffer.from(chunk) : chunk);
-    if (chunks.reduce((n, c) => n + c.length, 0) > 1_000_000) {
-      throw new Error("payload too large");
-    }
+/**
+ * Sanity cap on request bodies, not a sizing constraint: every caller is our
+ * own authenticated backend, so this only guards against buffering a runaway
+ * body in memory.
+ */
+const MAX_BODY_BYTES = 20_000_000;
+
+class PayloadTooLargeError extends Error {
+  constructor(receivedBytes: number) {
+    super(`payload too large (${receivedBytes} bytes, cap ${MAX_BODY_BYTES})`);
+    this.name = "PayloadTooLargeError";
   }
+}
+
+async function readJsonBody(req: IncomingMessage): Promise<unknown> {
+  const chunks: Buffer[] = [];
+  let total = 0;
+  let overCap = false;
+  // An over-cap body is drained rather than aborted: throwing out of the
+  // async iterator destroys the request (and with it the socket), so the 413
+  // would reach the caller as a connection reset instead of a status.
+  for await (const chunk of req) {
+    const buf = typeof chunk === "string" ? Buffer.from(chunk) : chunk;
+    total += buf.length;
+    if (!overCap && total > MAX_BODY_BYTES) {
+      overCap = true;
+      chunks.length = 0;
+    }
+    if (!overCap) chunks.push(buf);
+  }
+  if (overCap) throw new PayloadTooLargeError(total);
   const text = Buffer.concat(chunks).toString("utf8");
   return text.length === 0 ? {} : JSON.parse(text);
+}
+
+/**
+ * Read and parse the JSON body, or answer the request with the right error
+ * status and return null: 413 for an over-cap body, 400 for unparseable JSON
+ * or JSON that isn't an object. Rejections are logged — a silently swallowed
+ * 4xx here is invisible from outside the sandbox and very hard to debug.
+ */
+async function readJsonBodyOrRespond(
+  req: IncomingMessage,
+  res: ServerResponse,
+  route: string,
+): Promise<Record<string, unknown> | null> {
+  let parsed: unknown;
+  try {
+    parsed = await readJsonBody(req);
+  } catch (err) {
+    const tooLarge = err instanceof PayloadTooLargeError;
+    const message = err instanceof Error ? err.message : String(err);
+    // eslint-disable-next-line no-console
+    console.error(`[supervisor] ${route} body rejected: ${message}`);
+    json(res, tooLarge ? 413 : 400, { error: tooLarge ? "payload too large" : "bad json" });
+    return null;
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    // eslint-disable-next-line no-console
+    console.error(`[supervisor] ${route} body rejected: not a JSON object`);
+    json(res, 400, { error: "bad json" });
+    return null;
+  }
+  return parsed as Record<string, unknown>;
 }
 
 function json(res: ServerResponse, status: number, body: unknown) {

--- a/packages/lesswrong/server/research/sandbox/supervisor/sessionBootstrap.ts
+++ b/packages/lesswrong/server/research/sandbox/supervisor/sessionBootstrap.ts
@@ -1,29 +1,39 @@
 /**
- * JSONL bootstrap for `claude --resume` in a fresh sandbox.
+ * Session-file plumbing for `claude --resume`.
  *
  * Claude Code persists its conversation history at:
  *   ~/.claude/projects/<encoded-cwd>/<sessionId>.jsonl
  * where `<encoded-cwd>` is the absolute working directory with `/` replaced
- * by `-`. The file is a sequence of JSONL events: each line is one of
- * user|assistant|tool_use|tool_result|thinking|system, and `--resume` reads
- * this file from disk to reconstruct the context window.
+ * by `-`. The file is a sequence of JSONL events, and `--resume` reads it
+ * from disk to reconstruct the context window.
  *
- * When a conversation continues in a fresh sandbox (the previous one was
- * reaped or hit the lifetime cap), our `ResearchConversationEvents` table is
- * the only surviving copy. The bootstrap step writes a synthesized JSONL
- * file from those events before invoking `claude --resume`.
- *
- * Per design doc: events store the **verbatim** JSONL line as `payload`, so
- * synthesis is just JSON.stringify per event back into newline-delimited form.
+ * When a conversation continues in a sandbox that doesn't have this file
+ * (the previous sandbox was reaped or rebuilt), `ResearchConversationEvents`
+ * is the only surviving copy. The backend reconstructs the JSONL from it and
+ * stages the result at `<session path>.staged` through the sandbox filesystem
+ * API — whose writes can't be serialized with the claude process lifecycle —
+ * and the hub installs it from here while spawning, inside the conversation's
+ * opChain where no live process can hold the session file. That hand-off is
+ * what preserves the single-writer invariant on the session file.
  */
 import { promises as fs } from "node:fs";
 import { homedir } from "node:os";
 import * as path from "node:path";
 
-export interface BootstrapEvent {
-  /** Parsed payload of a ResearchConversationEvent — the JSONL line as an object. */
-  payload: unknown;
-}
+/**
+ * Dispatch-rejection reason for "this session has history but its file is not
+ * on disk". Shared contract between the hub (which rejects with it) and the
+ * backend's dispatch path (which reacts by staging a reconstruction and
+ * re-dispatching).
+ */
+export const SESSION_FILE_MISSING_REASON = "session_file_missing";
+
+/**
+ * Suffix appended to the session-JSONL path to form the staging path. Shared
+ * contract with the backend's `stageClaudeSessionFile` (sandboxManager.ts),
+ * which writes to it from outside the sandbox.
+ */
+export const SESSION_STAGING_SUFFIX = ".staged";
 
 export interface BootstrapTarget {
   claudeSessionId: string;
@@ -46,78 +56,36 @@ export function sessionJsonlPath(target: BootstrapTarget): string {
 }
 
 /**
- * Synthesize a JSONL file from `events` at the path Claude Code expects for
- * `--resume <sessionId>`. Creates parent directories as needed. Idempotent:
- * overwrites any existing file at the same path.
- *
- * Each event's `payload` is JSON-stringified onto its own line. If `payload`
- * was already stored as a string (raw JSONL line), it's written verbatim.
- *
- * `result`-kind events are stripped before writing — they're per-turn
- * metadata wrappers (`{type:"result", duration_ms, usage, ...}`) that Claude
- * Code emits to stdout but never writes to its own session file, so leaving
- * them in the synthesized resume file would feed the model lines it never
- * sees during a normal session.
+ * Whether the session JSONL exists on disk. Right after a sandbox resume the
+ * snapshot restore can lag, so a single probe can transiently miss a file
+ * that is actually there — callers acting on a negative must retry over a
+ * few seconds first.
  */
-export async function writeBootstrapJsonl(
-  target: BootstrapTarget,
-  events: BootstrapEvent[],
-): Promise<{ filePath: string; lineCount: number }> {
-  const filePath = sessionJsonlPath(target);
-  await fs.mkdir(path.dirname(filePath), { recursive: true });
-  const body = events
-    .map(serializeEvent)
-    .filter((s): s is string => s !== null)
-    .join("\n");
-  const withTrailingNewline = body.length > 0 ? body + "\n" : "";
-  await fs.writeFile(filePath, withTrailingNewline, "utf8");
-  return { filePath, lineCount: withTrailingNewline === "" ? 0 : body.split("\n").length };
-}
-
-function serializeEvent(e: BootstrapEvent): string | null {
-  if (typeof e.payload === "string") {
-    return isResultLine(e.payload) ? null : e.payload;
-  }
-  if (e.payload && typeof e.payload === "object") {
-    if ((e.payload as { type?: unknown }).type === "result") return null;
-    try {
-      return JSON.stringify(e.payload);
-    } catch {
-      return null;
-    }
-  }
-  return null;
-}
-
-function isResultLine(line: string): boolean {
-  // Cheap pre-check before the full JSON.parse — most lines aren't `result`.
-  if (!line.includes('"type":"result"') && !line.includes('"type": "result"')) return false;
+export async function sessionJsonlExists(target: BootstrapTarget): Promise<boolean> {
   try {
-    const parsed = JSON.parse(line) as { type?: unknown };
-    return parsed.type === "result";
+    await fs.access(sessionJsonlPath(target));
+    return true;
   } catch {
     return false;
   }
 }
 
 /**
- * Inverse of `writeBootstrapJsonl`. Mainly for tests / inspection: reads a
- * JSONL session file back into parsed objects.
+ * Install a backend-staged session reconstruction, if one is present:
+ * - staged file, no session file → rename it into place (atomic, same dir);
+ * - staged file and a session file → delete the staged copy: the session file
+ *   is owned by a live-or-recent claude process and is the newer truth;
+ * - no staged file → no-op.
+ * Callers must hold the conversation's opChain with no live process.
  */
-export async function readBootstrapJsonl(
-  target: BootstrapTarget,
-): Promise<unknown[]> {
-  const filePath = sessionJsonlPath(target);
-  const text = await fs.readFile(filePath, "utf8");
-  if (text.trim().length === 0) return [];
-  return text
-    .split("\n")
-    .filter((l) => l.length > 0)
-    .map((line) => {
-      try {
-        return JSON.parse(line);
-      } catch {
-        return line;
-      }
-    });
+export async function installStagedSessionJsonl(target: BootstrapTarget): Promise<void> {
+  const finalPath = sessionJsonlPath(target);
+  const stagedPath = finalPath + SESSION_STAGING_SUFFIX;
+  const stagedExists = await fs.access(stagedPath).then(() => true, () => false);
+  if (!stagedExists) return;
+  if (await sessionJsonlExists(target)) {
+    await fs.rm(stagedPath, { force: true });
+    return;
+  }
+  await fs.rename(stagedPath, finalPath);
 }

--- a/packages/lesswrong/server/resolvers/researchResolvers.ts
+++ b/packages/lesswrong/server/resolvers/researchResolvers.ts
@@ -10,9 +10,11 @@ import {
   sandboxNameForConversation,
   SandboxWarmingError,
   SESSION_TIMEOUT_MS,
+  stageClaudeSessionFile,
   supervisorUrlForSandbox,
   type ProvisionedSandbox,
 } from "@/server/research/sandbox/sandboxManager";
+import { SESSION_FILE_MISSING_REASON } from "@/server/research/sandbox/supervisor/sessionBootstrap";
 import { listSandboxDirectory, SANDBOX_DEFAULT_DIR } from "@/server/research/sandbox/listSandboxDirectory";
 import { readSandboxTextFile } from "@/server/research/sandbox/readSandboxTextFile";
 import { getSandboxResourceStats } from "@/server/research/sandbox/sandboxResourceStats";
@@ -77,6 +79,18 @@ function signSupervisorBearer(target: SupervisorTarget): string {
 }
 
 /**
+ * Thrown when the supervisor rejects a dispatch because the session has
+ * history but its file is not on the sandbox's disk. The dispatch path
+ * reacts by staging a reconstruction and retrying.
+ */
+class SessionFileMissingError extends Error {
+  constructor() {
+    super("supervisor /dispatch rejected: session file missing");
+    this.name = "SessionFileMissingError";
+  }
+}
+
+/**
  * POSTs to the supervisor's /dispatch endpoint with a fresh signed bearer.
  *
  * The supervisor accepts the turn and starts Claude Code asynchronously,
@@ -93,7 +107,6 @@ async function dispatchTurnViaSupervisor(args: {
   prompt: string;
   claudeSessionId: string;
   sessionHasHistory: boolean;
-  bootstrapJsonl?: string[];
 }): Promise<void> {
   const { provisioned } = args;
   const bearer = signSupervisorBearer(provisioned);
@@ -118,7 +131,6 @@ async function dispatchTurnViaSupervisor(args: {
       prompt: args.prompt,
       claudeSessionId: args.claudeSessionId,
       sessionHasHistory: args.sessionHasHistory,
-      bootstrapJsonl: args.bootstrapJsonl,
       agentBackendToken,
     }),
   });
@@ -130,6 +142,9 @@ async function dispatchTurnViaSupervisor(args: {
   console.error(
     `[research] supervisor /dispatch failed: ${response.status}${vercelErr ? ` (${vercelErr})` : ""} ${text}`,
   );
+  if (response.status === 409 && text.includes(SESSION_FILE_MISSING_REASON)) {
+    throw new SessionFileMissingError();
+  }
   throw new Error(
     `supervisor /dispatch failed: ${response.status}${vercelErr ? ` (${vercelErr})` : ""}`,
   );
@@ -492,7 +507,7 @@ export const researchResolversMutations = {
       // A fork that recovered its source session resumes the session file on
       // the env snapshot; everything else is a brand-new session (a fork
       // without a recoverable source id resumes via the synthesized bootstrap
-      // instead, which the supervisor accounts for on its own).
+      // instead, which dispatchToSandbox writes and accounts for).
       sessionHasHistory: !!sourceSessionId,
       bootstrapEvents,
     });
@@ -812,14 +827,20 @@ async function provisionSandboxOrWarming(
  * Provision (or resume) the conversation's persistent sandbox and dispatch one
  * turn to its supervisor.
  *
- * `bootstrapEvents` is the conversation's persisted history, shipped so a
- * sandbox without the session file on disk can have the Claude session
- * reconstructed. It's sent when the sandbox was freshly built (a rebuild
- * after an expired snapshot, or a fork whose source session couldn't be
- * recovered) — a warm resume still has the file on disk, so `--resume` reads
- * it directly. `bootstrapEvenIfWarm` ships it regardless, for conversations
- * whose session id was just derived and so can't have a file anywhere; the
- * supervisor only writes the reconstruction when the file is actually absent.
+ * `bootstrapEvents` is the conversation's persisted history, from which the
+ * Claude session file can be reconstructed when it isn't on the sandbox's
+ * disk. The reconstruction is staged through the sandbox filesystem API —
+ * never the dispatch body, which is capped far below a long conversation's
+ * JSONL size — and the supervisor installs it at spawn time under its
+ * per-conversation lock. Staging happens in two cases:
+ *  - proactively, when this call freshly built the sandbox (a rebuild after an
+ *    expired snapshot, or a fork whose source session couldn't be recovered),
+ *    or when `bootstrapEvenIfWarm` says the session id was just derived and so
+ *    can't have a file anywhere;
+ *  - reactively, when the supervisor rejects the dispatch because a session
+ *    with history has no file on disk (the sandbox was rebuilt by a caller
+ *    that stages no bootstrap). Events are fetched here if the caller didn't
+ *    supply them, and the dispatch is retried once.
  */
 async function dispatchToSandbox(args: {
   context: ResolverContext;
@@ -830,8 +851,7 @@ async function dispatchToSandbox(args: {
   claudeSessionId: string;
   /**
    * Whether a Claude session for this conversation has ever actually run —
-   * forwarded to the supervisor, which uses it (not a filesystem probe, which
-   * races snapshot restore on a fresh resume) to pick `--resume` vs
+   * forwarded to the supervisor, which uses it to pick `--resume` vs
    * `--session-id`.
    */
   sessionHasHistory: boolean;
@@ -841,20 +861,40 @@ async function dispatchToSandbox(args: {
   const provisioned = await provisionSandboxOrWarming(args.conversationId, args.context);
 
   const shipBootstrap = provisioned.wasFreshlyCreated || args.bootstrapEvenIfWarm;
-  const bootstrapJsonl = shipBootstrap && args.bootstrapEvents?.length
-    ? buildBootstrapJsonl(args.bootstrapEvents, args.claudeSessionId)
-    : undefined;
+  let stagedBootstrap = false;
+  if (shipBootstrap && args.bootstrapEvents?.length) {
+    const lines = buildBootstrapJsonl(args.bootstrapEvents, args.claudeSessionId);
+    if (lines.length > 0) {
+      await stageClaudeSessionFile(provisioned.sandbox, args.claudeSessionId, lines);
+      stagedBootstrap = true;
+    }
+  }
 
-  await dispatchTurnViaSupervisor({
+  const dispatchArgs = {
     provisioned,
     conversationId: args.conversationId,
     projectId: args.projectId,
     userId: args.userId,
     prompt: args.prompt,
     claudeSessionId: args.claudeSessionId,
-    sessionHasHistory: args.sessionHasHistory,
-    bootstrapJsonl,
-  });
+    sessionHasHistory: args.sessionHasHistory || stagedBootstrap,
+  };
+
+  try {
+    await dispatchTurnViaSupervisor(dispatchArgs);
+  } catch (err) {
+    if (!(err instanceof SessionFileMissingError)) throw err;
+    const events = args.bootstrapEvents?.length
+      ? args.bootstrapEvents
+      : await args.context.ResearchConversationEvents.find(
+          { conversationId: args.conversationId },
+          { sort: { seq: 1 } },
+        ).fetch();
+    const lines = buildBootstrapJsonl(events, args.claudeSessionId);
+    if (lines.length === 0) throw err;
+    await stageClaudeSessionFile(provisioned.sandbox, args.claudeSessionId, lines);
+    await dispatchTurnViaSupervisor(dispatchArgs);
+  }
 }
 
 export const researchResolversQueries = {

--- a/packages/lesswrong/unitTests/conversationHub.tests.ts
+++ b/packages/lesswrong/unitTests/conversationHub.tests.ts
@@ -1,4 +1,18 @@
+import { promises as fs } from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
 import { createConversationHub } from "../server/research/sandbox/supervisor/conversationHub";
+
+// The session-file probe resolves ~ via os.homedir(), which the probe tests
+// must point at a temp dir. Neither $HOME (jest copies process.env, so writes
+// never reach the C environment homedir() reads) nor jest.spyOn (module
+// interop copies) redirect it reliably, so mock the module itself; the
+// override is read lazily, and everything else passes through.
+let mockHomedir: string | null = null;
+jest.mock("node:os", () => {
+  const actual = jest.requireActual<typeof import("node:os")>("node:os");
+  return { ...actual, homedir: () => mockHomedir ?? actual.homedir() };
+});
 import {
   ClaudeProcessHandle,
   ClaudeProcessOptions,
@@ -6,6 +20,10 @@ import {
 } from "../server/research/sandbox/supervisor/claudeRunner";
 import { createJsonlChunker } from "../server/research/sandbox/supervisor/jsonlParser";
 import { BackendEvent, PostPersister } from "../server/research/sandbox/supervisor/postPersister";
+import {
+  SESSION_STAGING_SUFFIX,
+  sessionJsonlPath,
+} from "../server/research/sandbox/supervisor/sessionBootstrap";
 
 interface FakeProcess {
   opts: ClaudeProcessOptions;
@@ -154,17 +172,76 @@ describe("conversationHub", () => {
     expect(procs[0].sent).toEqual(["first", "second"]);
   });
 
-  it("resumes the session when the backend reports prior history", async () => {
-    const { hub, procs } = mkHub();
-    await hub.dispatch({
-      conversationId: "c1",
-      prompt: "continue",
-      claudeSessionId: "sess-1",
-      sessionHasHistory: true,
+  // The history-bearing dispatch path probes the real filesystem for the
+  // session JSONL (at ~/.claude/projects/...), so these tests point the
+  // (mocked) home directory at a temp dir and place (or omit) a real file
+  // there.
+  describe("session-file probe", () => {
+    let tmpHome: string;
+
+    beforeEach(async () => {
+      tmpHome = await fs.mkdtemp(path.join(os.tmpdir(), "hub-probe-"));
+      mockHomedir = tmpHome;
     });
-    // No filesystem probe: the backend's word decides --resume vs --session-id
-    // (an existence check races snapshot restore on freshly-resumed sandboxes).
-    expect(procs[0].opts.sessionMode).toBe("resume");
+
+    afterEach(async () => {
+      mockHomedir = null;
+      await fs.rm(tmpHome, { recursive: true, force: true });
+    });
+
+    async function writeSessionFile(filePath: string, content: string): Promise<void> {
+      await fs.mkdir(path.dirname(filePath), { recursive: true });
+      await fs.writeFile(filePath, content, "utf8");
+    }
+
+    it("resumes the session when the backend reports prior history", async () => {
+      await writeSessionFile(
+        sessionJsonlPath({ claudeSessionId: "sess-1" }),
+        '{"type":"user","uuid":"u-0","message":{"role":"user","content":"hi"}}\n',
+      );
+      const { hub, procs } = mkHub();
+      await hub.dispatch({
+        conversationId: "c1",
+        prompt: "continue",
+        claudeSessionId: "sess-1",
+        sessionHasHistory: true,
+      });
+      expect(procs[0].opts.sessionMode).toBe("resume");
+    });
+
+    it("installs a backend-staged reconstruction before resuming", async () => {
+      const finalPath = sessionJsonlPath({ claudeSessionId: "sess-1" });
+      await writeSessionFile(
+        finalPath + SESSION_STAGING_SUFFIX,
+        '{"type":"user","uuid":"u-0","message":{"role":"user","content":"hi"}}\n',
+      );
+      const { hub, procs } = mkHub();
+      const r = await hub.dispatch({
+        conversationId: "c1",
+        prompt: "continue",
+        claudeSessionId: "sess-1",
+        sessionHasHistory: true,
+      });
+      expect(r.accepted).toBe(true);
+      expect(procs[0].opts.sessionMode).toBe("resume");
+      await expect(fs.access(finalPath)).resolves.toBeUndefined();
+      await expect(fs.access(finalPath + SESSION_STAGING_SUFFIX)).rejects.toThrow();
+    });
+
+    it("rejects a history-bearing dispatch when the session file is missing", async () => {
+      const { hub, procs, events } = mkHub();
+      const r = await hub.dispatch({
+        conversationId: "c1",
+        prompt: "continue",
+        claudeSessionId: "sess-1",
+        sessionHasHistory: true,
+      });
+      // Never downgrade to --session-id (that silently drops the history): the
+      // backend reacts to this reason by writing a reconstruction and retrying.
+      expect(r).toEqual({ accepted: false, reason: "session_file_missing" });
+      expect(procs.length).toBe(0);
+      expect(events.length).toBe(0); // rejected before the user turn was recorded
+    }, 15000); // the probe retries over a few seconds before giving up
   });
 
   it("stays busy until the CLI reports idle, not at the first result", async () => {

--- a/packages/lesswrong/unitTests/sessionBootstrap.tests.ts
+++ b/packages/lesswrong/unitTests/sessionBootstrap.tests.ts
@@ -2,10 +2,16 @@ import { promises as fs } from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import {
+  installStagedSessionJsonl,
+  SESSION_STAGING_SUFFIX,
+  sessionJsonlExists,
   sessionJsonlPath,
-  writeBootstrapJsonl,
-  readBootstrapJsonl,
 } from "../server/research/sandbox/supervisor/sessionBootstrap";
+
+async function writeFileWithDirs(filePath: string, content: string): Promise<void> {
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.writeFile(filePath, content, "utf8");
+}
 
 describe("sessionBootstrap", () => {
   let tmpHome: string;
@@ -24,163 +30,40 @@ describe("sessionBootstrap", () => {
       cwd: "/vercel/sandbox",
       homeDir: "/home/v",
     });
-    (p as any).should.be.equal("/home/v/.claude/projects/-vercel-sandbox/sess-1.jsonl");
+    expect(p).toBe("/home/v/.claude/projects/-vercel-sandbox/sess-1.jsonl");
   });
 
-  it("round-trips a plain text turn", async () => {
-    const events = [
-      { payload: { type: "user", message: { role: "user", content: "hello" } } },
-      {
-        payload: {
-          type: "assistant",
-          message: { role: "assistant", content: [{ type: "text", text: "hi back" }] },
-        },
-      },
-    ];
-    const result = await writeBootstrapJsonl(
-      { claudeSessionId: "abc", homeDir: tmpHome },
-      events,
-    );
-    (result.lineCount as any).should.be.equal(2);
-    const round = await readBootstrapJsonl({ claudeSessionId: "abc", homeDir: tmpHome });
-    (round.length as any).should.be.equal(2);
-    ((round[0] as any).type).should.be.equal("user");
-    ((round[1] as any).type).should.be.equal("assistant");
+  it("reports session-file existence", async () => {
+    const target = { claudeSessionId: "exists-check", homeDir: tmpHome };
+    expect(await sessionJsonlExists(target)).toBe(false);
+    await writeFileWithDirs(sessionJsonlPath(target), '{"type":"user"}\n');
+    expect(await sessionJsonlExists(target)).toBe(true);
   });
 
-  it("round-trips a tool_use + tool_result turn", async () => {
-    const events = [
-      { payload: { type: "user", message: { role: "user", content: "list files" } } },
-      {
-        payload: {
-          type: "assistant",
-          message: {
-            role: "assistant",
-            content: [
-              {
-                type: "tool_use",
-                id: "tu_1",
-                name: "Bash",
-                input: { command: "ls" },
-              },
-            ],
-          },
-        },
-      },
-      {
-        payload: {
-          type: "user",
-          message: {
-            role: "user",
-            content: [
-              { type: "tool_result", tool_use_id: "tu_1", content: "file1\nfile2" },
-            ],
-          },
-        },
-      },
-      {
-        payload: {
-          type: "assistant",
-          message: {
-            role: "assistant",
-            content: [{ type: "text", text: "I see two files" }],
-          },
-        },
-      },
-    ];
-    await writeBootstrapJsonl({ claudeSessionId: "tool-sess", homeDir: tmpHome }, events);
-    const round = await readBootstrapJsonl({ claudeSessionId: "tool-sess", homeDir: tmpHome });
-    (round.length as any).should.be.equal(4);
-    const toolUse = (round[1] as any).message.content[0];
-    (toolUse.type as any).should.be.equal("tool_use");
-    (toolUse.id as any).should.be.equal("tu_1");
-    const toolResult = (round[2] as any).message.content[0];
-    (toolResult.type as any).should.be.equal("tool_result");
-    (toolResult.tool_use_id as any).should.be.equal("tu_1");
-  });
-
-  it("round-trips a sub-agent spawn turn", async () => {
-    const events = [
-      { payload: { type: "user", message: { role: "user", content: "research X" } } },
-      {
-        payload: {
-          type: "assistant",
-          message: {
-            role: "assistant",
-            content: [
-              {
-                type: "tool_use",
-                id: "tu_2",
-                name: "Task",
-                input: {
-                  subagent_type: "general-purpose",
-                  description: "research X",
-                  prompt: "find sources for X and summarize",
-                },
-              },
-            ],
-          },
-        },
-      },
-      {
-        payload: {
-          type: "user",
-          message: {
-            role: "user",
-            content: [
-              {
-                type: "tool_result",
-                tool_use_id: "tu_2",
-                content: "sub-agent finished: 3 sources, summary: ...",
-              },
-            ],
-          },
-        },
-      },
-    ];
-    await writeBootstrapJsonl({ claudeSessionId: "subagent-sess", homeDir: tmpHome }, events);
-    const round = await readBootstrapJsonl({
-      claudeSessionId: "subagent-sess",
-      homeDir: tmpHome,
+  describe("installStagedSessionJsonl", () => {
+    it("renames a staged file into place when no session file exists", async () => {
+      const target = { claudeSessionId: "install", homeDir: tmpHome };
+      const finalPath = sessionJsonlPath(target);
+      await writeFileWithDirs(finalPath + SESSION_STAGING_SUFFIX, '{"staged":true}\n');
+      await installStagedSessionJsonl(target);
+      expect(await fs.readFile(finalPath, "utf8")).toBe('{"staged":true}\n');
+      await expect(fs.access(finalPath + SESSION_STAGING_SUFFIX)).rejects.toThrow();
     });
-    (round.length as any).should.be.equal(3);
-    const taskCall = (round[1] as any).message.content[0];
-    (taskCall.name as any).should.be.equal("Task");
-    (taskCall.input.subagent_type as any).should.be.equal("general-purpose");
-  });
 
-  it("creates parent directories on first write", async () => {
-    const events = [{ payload: { type: "user", message: { role: "user", content: "x" } } }];
-    const target = { claudeSessionId: "fresh", homeDir: tmpHome, cwd: "/some/cwd" };
-    const before = await fs
-      .stat(path.join(tmpHome, ".claude", "projects", "-some-cwd"))
-      .then(() => true)
-      .catch(() => false);
-    (before as any).should.be.equal(false);
-    const result = await writeBootstrapJsonl(target, events);
-    const after = await fs.stat(path.dirname(result.filePath));
-    (after.isDirectory() as any).should.be.equal(true);
-  });
+    it("discards the staged file when a session file already exists", async () => {
+      const target = { claudeSessionId: "keep-live", homeDir: tmpHome };
+      const finalPath = sessionJsonlPath(target);
+      await writeFileWithDirs(finalPath, '{"live":true}\n');
+      await writeFileWithDirs(finalPath + SESSION_STAGING_SUFFIX, '{"staged":true}\n');
+      await installStagedSessionJsonl(target);
+      expect(await fs.readFile(finalPath, "utf8")).toBe('{"live":true}\n');
+      await expect(fs.access(finalPath + SESSION_STAGING_SUFFIX)).rejects.toThrow();
+    });
 
-  it("treats a string payload as a raw JSONL line", async () => {
-    const verbatim = '{"type":"system","subtype":"init","model":"claude-opus-4-7"}';
-    await writeBootstrapJsonl(
-      { claudeSessionId: "raw", homeDir: tmpHome },
-      [{ payload: verbatim }],
-    );
-    const text = await fs.readFile(
-      sessionJsonlPath({ claudeSessionId: "raw", homeDir: tmpHome }),
-      "utf8",
-    );
-    (text as any).should.be.equal(verbatim + "\n");
-  });
-
-  it("overwrites an existing JSONL on re-bootstrap", async () => {
-    const target = { claudeSessionId: "ow", homeDir: tmpHome };
-    await writeBootstrapJsonl(target, [{ payload: { type: "user", message: { content: "first" } } }]);
-    await writeBootstrapJsonl(target, [{ payload: { type: "user", message: { content: "replaced" } } }]);
-    const round = await readBootstrapJsonl(target);
-    (round.length as any).should.be.equal(1);
-    ((round[0] as any).message.content as any).should.be.equal("replaced");
+    it("is a no-op when nothing is staged", async () => {
+      const target = { claudeSessionId: "nothing", homeDir: tmpHome };
+      await installStagedSessionJsonl(target);
+      expect(await sessionJsonlExists(target)).toBe(false);
+    });
   });
 });


### PR DESCRIPTION
Written by Claude
-----
Saving an environment from a running conversation stopped its sandbox via snapshot() and then deleted that snapshot, leaving the persistent sandbox unresumable; the next provision silently rebuilt it from the base environment snapshot, discarding the session file and working tree. The dispatch path then wedged the conversation permanently: the session reconstruction only shipped when the dispatch's own provision created the sandbox, and couldn't ship at all past the supervisor's 1 MB body cap.

- saveEnvironment: env snapshots always come from a throwaway clone; a running sandbox's intermediate snapshot is kept with auto-snapshot retention (it's what the sandbox resumes from), never deleted.
- Session bootstraps now ship via the Sandbox filesystem API: the backend stages the reconstructed JSONL at <session>.jsonl.staged, and the supervisor installs it at spawn time inside the per-conversation opChain, preserving the session file's single-writer invariant. The inline /dispatch-body transport is deleted.
- The supervisor probes for the session file before --resume (with retries to tolerate snapshot-restore lag) and rejects with "session_file_missing" instead of spawning a doomed process; the backend answers by staging a reconstruction and retrying once, so wedged conversations self-heal.
- Supervisor body cap raised to 20 MB, over-cap bodies drained (throwing out of the request iterator destroys the socket, turning the response into a connection reset) and answered with a logged 413; non-object JSON bodies get a 400 instead of hanging.


