### PR TITLE
Fix research sandbox session access under /root

### DIFF
--- a/packages/lesswrong/server/research/sandbox/sandboxLayout.ts
+++ b/packages/lesswrong/server/research/sandbox/sandboxLayout.ts
@@ -4,11 +4,13 @@
  * `buildResearchSandboxSnapshot` (which seeds them into the baseline snapshot),
  * so the two can't drift onto different paths.
  *
- * The sandbox's home directory: the runtime image runs as root, so this is
- * `/root`. The platform files live under here, *outside* the agent's cwd
- * (`/vercel/sandbox`), so the agent's cwd-scoped cleanup can't reach them. (The
- * in-sandbox supervisor pins `HOME=SANDBOX_HOME_DIR` so its `homedir()` resolves
- * to the same place the backend writes to.)
+ * The legacy home directory used by existing sandbox snapshots. Vercel runs
+ * user code as `vercel-sandbox`, not root, so launch and recovery paths must
+ * make this directory traversable before the supervisor reads it. The platform
+ * files live here, *outside* the agent's cwd (`/vercel/sandbox`), so the agent's
+ * cwd-scoped cleanup can't reach them. The in-sandbox supervisor pins
+ * `HOME=SANDBOX_HOME_DIR` so its `homedir()` resolves to the same place the
+ * backend writes to.
  */
 export const SANDBOX_HOME_DIR = "/root";
 
@@ -40,4 +42,3 @@ export const PINNED_CLAUDE_CODE_VERSION = "2.1.207";
  * version that knows the model family — see PINNED_CLAUDE_CODE_VERSION. */
 export const RESEARCH_AGENT_MODEL = "claude-fable-5";
 // export const RESEARCH_AGENT_MODEL = "claude-opus-4-8";
-

--- a/packages/lesswrong/server/research/sandbox/sandboxManager.ts
+++ b/packages/lesswrong/server/research/sandbox/sandboxManager.ts
@@ -265,12 +265,10 @@ async function reconcileClaudeCodeVersion(
  */
 async function launchSupervisor(sandbox: Sandbox, env: SupervisorLaunchEnv): Promise<void> {
   const supervisorEnv: Record<string, string> = {
-    // Pin HOME so the supervisor's `homedir()` resolves to the SAME directory
-    // the backend overlays platform files into (SANDBOX_HOME_DIR). Without this,
-    // if the runtime image's default home isn't `/root`, the supervisor would
-    // read `~/.claude/CLAUDE.md` and derive the research-tool PATH from a
-    // different home than the overlay wrote to. (If `/root` isn't writable the
-    // overlay's `writeFiles` fails loudly — better than silent path divergence.)
+    // Pin HOME so the supervisor's `homedir()` resolves to the SAME legacy
+    // directory the backend overlays platform files into (SANDBOX_HOME_DIR).
+    // `launchSupervisor` makes it traversable by Vercel's unprivileged
+    // `vercel-sandbox` runtime user before starting the process.
     HOME: SANDBOX_HOME_DIR,
     CLAUDE_CODE_OAUTH_TOKEN: env.claudeToken,
     SUPERVISOR_SECRET: env.supervisorSecret,
@@ -290,7 +288,7 @@ async function launchSupervisor(sandbox: Sandbox, env: SupervisorLaunchEnv): Pro
   // the previous supervisor's crash output, but the log lives in the
   // snapshot-persisted home dir and must not grow without bound.
   const log = `${PLATFORM_DIR}/supervisor.log`;
-  await sandbox.runCommand({
+  const result = await sandbox.runCommand({
     cmd: "sh",
     args: [
       "-c",
@@ -299,13 +297,41 @@ async function launchSupervisor(sandbox: Sandbox, env: SupervisorLaunchEnv): Pro
       // makes runCommand wait on the subshell's inherited output pipes, which
       // on a freshly created session never close — the provision then hangs
       // until the function times out.
-      `tail -c 262144 ${log} > ${log}.trim 2>/dev/null && mv ${log}.trim ${log}; ` +
+      // Keep the permission repair in this existing launch RPC: the chmod
+      // itself is negligible, while a separate runCommand adds a control-plane
+      // round trip. `o+x` permits traversal without allowing directory listing.
+      `sudo chmod o+x ${SANDBOX_HOME_DIR} || exit 1; ` +
+        `tail -c 262144 ${log} > ${log}.trim 2>/dev/null && mv ${log}.trim ${log}; ` +
         `echo "[launch] $(date -u +%Y-%m-%dT%H:%M:%SZ)" >> ${log}; ` +
         `nohup setsid node ${SUPERVISOR_PATH} >> ${log} 2>&1 < /dev/null &`,
     ],
     env: supervisorEnv,
   });
+  if (result.exitCode !== 0) {
+    throw new Error(
+      `supervisor launch command failed (exit ${result.exitCode}): ${(await result.stderr()).slice(0, 500)}`,
+    );
+  }
   await waitForSupervisorReady(supervisorUrlForSandbox(sandbox));
+}
+
+/**
+ * Repair the legacy home directory of an already-running sandbox. New launches
+ * do this inside their existing launch RPC; this separate call is reserved for
+ * the reactive session-file recovery path, so healthy warm dispatches pay no
+ * additional control-plane round trip.
+ */
+export async function ensureSandboxHomeTraversable(sandbox: Sandbox): Promise<void> {
+  const result = await sandbox.runCommand({
+    cmd: "chmod",
+    args: ["o+x", SANDBOX_HOME_DIR],
+    sudo: true,
+  });
+  if (result.exitCode !== 0) {
+    throw new Error(
+      `sandbox home permission repair failed (exit ${result.exitCode}): ${(await result.stderr()).slice(0, 500)}`,
+    );
+  }
 }
 
 /**

--- a/packages/lesswrong/server/research/sandbox/supervisor/sessionBootstrap.ts
+++ b/packages/lesswrong/server/research/sandbox/supervisor/sessionBootstrap.ts
@@ -55,6 +55,29 @@ export function sessionJsonlPath(target: BootstrapTarget): string {
   return path.join(home, ".claude", "projects", encodedCwd, `${target.claudeSessionId}.jsonl`);
 }
 
+function isFileMissingError(err: unknown): boolean {
+  return typeof err === "object" && err !== null && "code" in err && err.code === "ENOENT";
+}
+
+/**
+ * Check for a path using the process's effective filesystem credentials.
+ *
+ * Do not use `fs.access` here: Vercel runs sandbox code as the
+ * `vercel-sandbox` user with filesystem capabilities, and `access(2)` checks
+ * the real uid instead. It can therefore report EACCES for a path that the
+ * process can stat/open. Only ENOENT means the path is actually absent; other
+ * errors must surface rather than being misreported as a missing session.
+ */
+async function pathExists(filePath: string): Promise<boolean> {
+  try {
+    await fs.stat(filePath);
+    return true;
+  } catch (err) {
+    if (isFileMissingError(err)) return false;
+    throw err;
+  }
+}
+
 /**
  * Whether the session JSONL exists on disk. Right after a sandbox resume the
  * snapshot restore can lag, so a single probe can transiently miss a file
@@ -62,12 +85,7 @@ export function sessionJsonlPath(target: BootstrapTarget): string {
  * few seconds first.
  */
 export async function sessionJsonlExists(target: BootstrapTarget): Promise<boolean> {
-  try {
-    await fs.access(sessionJsonlPath(target));
-    return true;
-  } catch {
-    return false;
-  }
+  return await pathExists(sessionJsonlPath(target));
 }
 
 /**
@@ -81,7 +99,7 @@ export async function sessionJsonlExists(target: BootstrapTarget): Promise<boole
 export async function installStagedSessionJsonl(target: BootstrapTarget): Promise<void> {
   const finalPath = sessionJsonlPath(target);
   const stagedPath = finalPath + SESSION_STAGING_SUFFIX;
-  const stagedExists = await fs.access(stagedPath).then(() => true, () => false);
+  const stagedExists = await pathExists(stagedPath);
   if (!stagedExists) return;
   if (await sessionJsonlExists(target)) {
     await fs.rm(stagedPath, { force: true });

--- a/packages/lesswrong/server/resolvers/researchResolvers.ts
+++ b/packages/lesswrong/server/resolvers/researchResolvers.ts
@@ -5,6 +5,7 @@ import { DEVAUTH_SCOPE, signSupervisorToken } from "@/server/research/sandbox/su
 import { mintSandboxCallbackToken } from "../../../../app/api/research/agent/researchAgentAuth";
 import {
   devProxyUrlForSandbox,
+  ensureSandboxHomeTraversable,
   getOrCreateSandbox,
   getRunningSandbox,
   sandboxNameForConversation,
@@ -884,6 +885,10 @@ async function dispatchToSandbox(args: {
     await dispatchTurnViaSupervisor(dispatchArgs);
   } catch (err) {
     if (!(err instanceof SessionFileMissingError)) throw err;
+    // A running pre-fix supervisor can misreport EACCES under the legacy /root
+    // home as a missing session. Repair permissions only on this recovery path
+    // (never on every warm dispatch), then stage history if available and retry.
+    await ensureSandboxHomeTraversable(provisioned.sandbox);
     const events = args.bootstrapEvents?.length
       ? args.bootstrapEvents
       : await args.context.ResearchConversationEvents.find(
@@ -891,8 +896,9 @@ async function dispatchToSandbox(args: {
           { sort: { seq: 1 } },
         ).fetch();
     const lines = buildBootstrapJsonl(events, args.claudeSessionId);
-    if (lines.length === 0) throw err;
-    await stageClaudeSessionFile(provisioned.sandbox, args.claudeSessionId, lines);
+    if (lines.length > 0) {
+      await stageClaudeSessionFile(provisioned.sandbox, args.claudeSessionId, lines);
+    }
     await dispatchTurnViaSupervisor(dispatchArgs);
   }
 }

--- a/packages/lesswrong/unitTests/sessionBootstrap.tests.ts
+++ b/packages/lesswrong/unitTests/sessionBootstrap.tests.ts
@@ -40,6 +40,19 @@ describe("sessionBootstrap", () => {
     expect(await sessionJsonlExists(target)).toBe(true);
   });
 
+  it("does not misreport filesystem errors as a missing session", async () => {
+    const stat = jest.spyOn(fs, "stat").mockRejectedValueOnce(
+      Object.assign(new Error("permission denied"), { code: "EACCES" }),
+    );
+    try {
+      await expect(
+        sessionJsonlExists({ claudeSessionId: "permission-error", homeDir: tmpHome }),
+      ).rejects.toMatchObject({ code: "EACCES" });
+    } finally {
+      stat.mockRestore();
+    }
+  });
+
   describe("installStagedSessionJsonl", () => {
     it("renames a staged file into place when no session file exists", async () => {
       const target = { claudeSessionId: "install", homeDir: tmpHome };
@@ -64,6 +77,19 @@ describe("sessionBootstrap", () => {
       const target = { claudeSessionId: "nothing", homeDir: tmpHome };
       await installStagedSessionJsonl(target);
       expect(await sessionJsonlExists(target)).toBe(false);
+    });
+
+    it("does not misreport an inaccessible staged file as absent", async () => {
+      const stat = jest.spyOn(fs, "stat").mockRejectedValueOnce(
+        Object.assign(new Error("permission denied"), { code: "EACCES" }),
+      );
+      try {
+        await expect(
+          installStagedSessionJsonl({ claudeSessionId: "permission-error", homeDir: tmpHome }),
+        ).rejects.toMatchObject({ code: "EACCES" });
+      } finally {
+        stat.mockRestore();
+      }
     });
   });
 });


### PR DESCRIPTION
## Written by GPT-5.6-Sol

- make the legacy `/root` sandbox home traversable during supervisor launch
- repair already-running sandboxes only after a `session_file_missing` response
- use `stat` rather than `access` so permission errors are not misreported as missing sessions
- propagate unexpected filesystem errors and cover the permission-error cases in unit tests

## Context

Vercel Sandbox runs ordinary commands as `vercel-sandbox`, while this feature currently pins `HOME=/root`. A sandbox can therefore contain the correct Claude session JSONL but fail the preflight check because `/root` is not traversable. This PR is the compatibility fix; moving persistent state to `/home/vercel-sandbox` will be handled separately.

## Testing

- `yarn unit packages/lesswrong/unitTests/sessionBootstrap.tests.ts`
- `yarn unit packages/lesswrong/unitTests/conversationHub.tests.ts`
- `yarn research-supervisor-build`
- targeted ESLint on all five changed files
- `yarn tsc`
- `git diff --check`

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1216582070009529) by [Unito](https://www.unito.io)
