### PR TITLE
Never keep or submit an archived environment id from a query-input block

### DIFF
--- a/packages/lesswrong/components/research/lexical/QueryInputHeaderComponent.tsx
+++ b/packages/lesswrong/components/research/lexical/QueryInputHeaderComponent.tsx
@@ -9,7 +9,7 @@ import { useStopLexicalEventPropagation } from '@/components/editor/lexicalPlugi
 import { researchMono, researchWarmAlpha, researchRadius } from '../researchStyleUtils';
 import { getBrowserLocalStorage } from '@/components/editor/localStorageHandlers';
 import { ResearchEnvironmentsByProjectQuery } from '../researchEnvironmentsQuery';
-import { useResearchEditorEnvironmentOptional } from './ResearchEditorContext';
+import { useResearchEditorEnvironment } from './ResearchEditorContext';
 import {
   $isQueryInputNode,
   type QueryInputSelection,
@@ -62,13 +62,22 @@ function storageKeyForProject(projectId: string): string {
   return `research:lastSelectedEnvironment:${projectId}`;
 }
 
-function resolveDefaultSelection(projectId: string | null): QueryInputSelection {
-  if (projectId) {
-    const last = getBrowserLocalStorage()?.getItem(storageKeyForProject(projectId)) ?? null;
-    const decoded = last ? decodeSelection(last) : null;
-    if (decoded?.runtime && (RESEARCH_BLANK_RUNTIMES as readonly string[]).includes(decoded.runtime)) {
-      return decoded;
-    }
+function readRememberedSelection(projectId: string): QueryInputSelection | null {
+  const last = getBrowserLocalStorage()?.getItem(storageKeyForProject(projectId)) ?? null;
+  return last ? decodeSelection(last) : null;
+}
+
+function dropRememberedSelectionIfStale(projectId: string, activeEnvIds: Set<string>): void {
+  const remembered = readRememberedSelection(projectId);
+  if (remembered?.baseEnvironmentId && !activeEnvIds.has(remembered.baseEnvironmentId)) {
+    getBrowserLocalStorage()?.removeItem(storageKeyForProject(projectId));
+  }
+}
+
+function resolveDefaultSelection(projectId: string): QueryInputSelection {
+  const remembered = readRememberedSelection(projectId);
+  if (remembered?.runtime && (RESEARCH_BLANK_RUNTIMES as readonly string[]).includes(remembered.runtime)) {
+    return remembered;
   }
   return { baseEnvironmentId: null, runtime: DEFAULT_BLANK_RUNTIME };
 }
@@ -81,8 +90,7 @@ export function QueryInputHeaderComponent({
   const [editor] = useLexicalComposerContext();
   const selectRef = useRef<HTMLSelectElement>(null);
   const hasHydratedRef = useRef(false);
-  const env = useResearchEditorEnvironmentOptional();
-  const projectId = env?.projectId ?? null;
+  const { projectId } = useResearchEditorEnvironment();
 
   // The selection lives on the parent QueryInputNode, but decorate() only
   // re-runs when this DecoratorNode is dirty — not when the parent mutates.
@@ -109,8 +117,7 @@ export function QueryInputHeaderComponent({
   }, [editor, containerNodeKey]);
 
   const { data } = useQuery(ResearchEnvironmentsByProjectQuery, {
-    variables: { projectId: projectId ?? '' },
-    skip: !projectId,
+    variables: { projectId },
     fetchPolicy: 'cache-first',
   });
   const environments = useMemo(() => data?.researchEnvironments?.results ?? [], [data]);
@@ -126,9 +133,7 @@ export function QueryInputHeaderComponent({
   const handleChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
     const next = decodeSelection(event.target.value) ?? { baseEnvironmentId: null, runtime: DEFAULT_BLANK_RUNTIME };
     setSelected(next);
-    if (projectId) {
-      getBrowserLocalStorage()?.setItem(storageKeyForProject(projectId), encodeSelection(next));
-    }
+    getBrowserLocalStorage()?.setItem(storageKeyForProject(projectId), encodeSelection(next));
     writeSelectionToContainer(next);
   };
 
@@ -148,13 +153,12 @@ export function QueryInputHeaderComponent({
   // saved `baseEnvironmentId` is invalid. On a cold load the cache-first query
   // hasn't resolved yet (`knownEnvIds` empty), and hydrating then would clobber a
   // genuine saved-environment selection with a blank baseline. `data !== undefined`
-  // (or no projectId, so the query is skipped and no env could be valid anyway)
   // means it's safe to decide; the effect re-runs when `data` arrives.
   useEffect(() => {
     if (hasHydratedRef.current) return;
-    const envQuerySettled = !projectId || data !== undefined;
-    if (!envQuerySettled) return;
+    if (data === undefined) return;
     hasHydratedRef.current = true;
+    dropRememberedSelectionIfStale(projectId, knownEnvIds);
     editor.getEditorState().read(() => {
       const parent = $getNodeByKey(containerNodeKey);
       if (!$isQueryInputNode(parent)) return;
@@ -163,10 +167,7 @@ export function QueryInputHeaderComponent({
         (current.baseEnvironmentId && knownEnvIds.has(current.baseEnvironmentId)) ||
         (!current.baseEnvironmentId && current.runtime);
       if (hasValid) return;
-      const last = projectId
-        ? getBrowserLocalStorage()?.getItem(storageKeyForProject(projectId)) ?? null
-        : null;
-      const remembered = last ? decodeSelection(last) : null;
+      const remembered = readRememberedSelection(projectId);
       const next: QueryInputSelection =
         remembered?.baseEnvironmentId && knownEnvIds.has(remembered.baseEnvironmentId)
           ? remembered
@@ -179,6 +180,22 @@ export function QueryInputHeaderComponent({
     // not the inline `writeSelectionToContainer`/`resolveDefaultSelection` it calls.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [editor, containerNodeKey, projectId, data, knownEnvIds]);
+
+  // A block must never *keep* a selection pointing at an environment that has
+  // been archived or deleted — whether it was persisted in the document before
+  // the archive or the archive happened while this editor was open, so this
+  // runs on every env-list change, not once per mount.
+  useEffect(() => {
+    if (data === undefined) return;
+    if (!selected.baseEnvironmentId || knownEnvIds.has(selected.baseEnvironmentId)) return;
+    dropRememberedSelectionIfStale(projectId, knownEnvIds);
+    const next = resolveDefaultSelection(projectId);
+    setSelected(next);
+    writeSelectionToContainer(next);
+    // Tracks the env-query settle and the mirrored node selection, not the
+    // inline helpers it calls.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [projectId, data, knownEnvIds, selected, editor, containerNodeKey]);
 
   return (
     <span className={classes.cluster}>

--- a/packages/lesswrong/components/research/lexical/QueryInputPlugin.tsx
+++ b/packages/lesswrong/components/research/lexical/QueryInputPlugin.tsx
@@ -46,6 +46,7 @@ import {
   QueryInputContentNode,
 } from './QueryInputContentNode';
 import { useResearchEditorEnvironment, type ResearchEditorEnvironment } from './ResearchEditorContext';
+import { useActiveResearchEnvironmentIds, type ActiveResearchEnvironmentIds } from '../researchEnvironmentsQuery';
 import { isSandboxWarmingError } from '../sandboxWarming';
 import { useMessages } from '@/components/common/withMessages';
 import { type WithMessagesFunctions } from '@/components/layout/FlashMessages';
@@ -216,6 +217,12 @@ export function QueryInputPlugin() {
   const isSuggestionModeRef = useRef(false);
   isSuggestionModeRef.current = externalModeContext?.userMode === EditorUserMode.Suggest;
 
+  // Read through a ref for the same reason as the mode above: the submit
+  // handler must see the current environment list without re-registering.
+  const activeEnvironments = useActiveResearchEnvironmentIds(env.projectId);
+  const activeEnvironmentsRef = useRef<ActiveResearchEnvironmentIds>(activeEnvironments);
+  activeEnvironmentsRef.current = activeEnvironments;
+
   useEffect(() => {
     if (!editor.hasNodes([QueryInputNode, QueryInputContentNode])) {
       throw new Error('QueryInputPlugin: QueryInputNode / QueryInputContentNode not registered on editor');
@@ -296,11 +303,22 @@ export function QueryInputPlugin() {
           // Default to a blank baseline if neither field is set (e.g. a submit
           // before the header finished hydrating), so we never send "neither"
           // and trip the backend's exactly-one check.
+          //
+          // A saved-environment selection that no longer resolves to an active
+          // environment (archived or deleted since it was stored in the node)
+          // must never reach the server either — it would boot the sandbox
+          // from an obsolete snapshot. `settled` gates the check so a
+          // cold-load submit can't misclassify a valid environment as stale.
           const rawSelection = queryInput.getSelection();
+          const { settled, activeIds } = activeEnvironmentsRef.current;
+          const environmentIsStale = !!rawSelection.baseEnvironmentId && settled && !activeIds.has(rawSelection.baseEnvironmentId);
           const querySelection: QueryInputSelection =
-            rawSelection.baseEnvironmentId || rawSelection.runtime
+            !environmentIsStale && (rawSelection.baseEnvironmentId || rawSelection.runtime)
               ? rawSelection
               : { baseEnvironmentId: null, runtime: DEFAULT_BLANK_RUNTIME };
+          if (environmentIsStale) {
+            flash({ messageString: `The selected environment is no longer available — running on a blank ${DEFAULT_BLANK_RUNTIME} sandbox instead.` });
+          }
 
           // Generate the conversation id client-side so the doc binds to the
           // conversation BEFORE the mutation returns: a refresh mid-flight

--- a/packages/lesswrong/components/research/researchEnvironmentsQuery.ts
+++ b/packages/lesswrong/components/research/researchEnvironmentsQuery.ts
@@ -1,4 +1,6 @@
+import { useMemo } from 'react';
 import { gql } from '@/lib/generated/gql-codegen';
+import { useQuery } from '@/lib/crud/useQuery';
 
 export const ResearchEnvironmentsByProjectQuery = gql(`
   query ResearchEnvironmentsByProjectQuery($projectId: String!) {
@@ -20,3 +22,19 @@ export const ResearchEnvironmentsByProjectQuery = gql(`
     }
   }
 `);
+
+export interface ActiveResearchEnvironmentIds {
+  settled: boolean;
+  activeIds: Set<string>;
+}
+
+export function useActiveResearchEnvironmentIds(projectId: string): ActiveResearchEnvironmentIds {
+  const { data } = useQuery(ResearchEnvironmentsByProjectQuery, {
+    variables: { projectId },
+    fetchPolicy: 'cache-and-network',
+  });
+  return useMemo(() => ({
+    settled: data !== undefined,
+    activeIds: new Set((data?.researchEnvironments?.results ?? []).map((environment) => environment._id)),
+  }), [data]);
+}


### PR DESCRIPTION
Written by Claude
----
A query-input block's environment selection is persisted in the lexical node and remembered per-project in localStorage, and neither was validated against the current environment list at submit — so a conversation could be created against an archived environment and boot its sandbox from an obsolete snapshot.

- Hydrating a new block now drops a remembered selection whose environment is no longer active, falling back to the blank node24 baseline.
- A new header effect rewrites any block whose stored selection has gone stale (persisted pre-archive, or archived while the editor is open).
- Submit validates the node's selection against the active list and falls back to the blank baseline (with a flash notice) instead of sending a stale id; the check is gated on the environment query having settled so a cold-load submit can't misclassify a valid environment.
- The plugin revalidates the environment list with cache-and-network on mount, bounding staleness from archives made in other tabs.

Also switch QueryInputHeaderComponent to the non-optional useResearchEditorEnvironment: its only render surface is the document editor, which always provides the context, so projectId is non-null.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1216749469558279) by [Unito](https://www.unito.io)
