### PR TITLE
Handle y-indexeddb open failure via its _db promise

### DIFF
--- a/packages/lesswrong/components/lexical/collaboration.ts
+++ b/packages/lesswrong/components/lexical/collaboration.ts
@@ -204,7 +204,8 @@ function cleanupPersistence(documentName: string): void {
   const indexedDbKey = getIndexedDbKey(documentName);
   const persistence = persistenceInstances.get(indexedDbKey);
   if (persistence) {
-    void persistence.destroy();
+    // destroy() rejects when the instance's IndexedDB open had failed.
+    void persistence.destroy().catch(() => {});
     persistenceInstances.delete(indexedDbKey);
   }
 }
@@ -244,15 +245,23 @@ function setupPersistence(
       complete();
     });
 
-    persistence.on('error', (error: Error) => {
+    // y-indexeddb has no error event ('synced' is the only event it emits),
+    // so watch its internal open promise. On failure, clearData() would
+    // reject on this same promise before deleting anything, so delete the
+    // database directly.
+    void persistence._db.catch((error: unknown) => {
       // eslint-disable-next-line no-console
-      console.error('[Collaboration] IndexedDB persistence error:', error);
+      console.error('[Collaboration] IndexedDB persistence failed:', error);
       config.onError?.(new Error('IndexedDB persistence failed. Continuing without offline support.'));
-      // Try to clear bad data, then proceed
-      void persistence.clearData().finally(() => {
-        clearTimeout(timeoutId);
-        complete();
-      });
+      void persistence.destroy().catch(() => {});
+      persistenceInstances.delete(indexedDbKey);
+      try {
+        indexedDB.deleteDatabase(indexedDbKey);
+      } catch {
+        // No usable indexedDB in this environment at all.
+      }
+      clearTimeout(timeoutId);
+      complete();
     });
   });
 }


### PR DESCRIPTION
Written by Claude
-----
y-indexeddb never emits an 'error' event ('synced' is the only event it emits), so the persistence.on('error') handler was dead code: an IndexedDB failure (private browsing, quota, corrupted database) stalled the collab connect for the full 3s timeout with no user-visible warning, and the corrupt-data cleanup never ran — and couldn't have, since clearData() chains on the same rejected open promise and bails before deleting anything.

Watch the persistence's internal open promise (`_db`, part of y-indexeddb's shipped types) instead: fail fast, surface the onError warning, detach the doc listeners, and delete the possibly-corrupt database via indexedDB.deleteDatabase so it can't fail every future load. The timeout remains as a backstop for loads that are merely slow.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1216747949408837) by [Unito](https://www.unito.io)
