### PR TITLE
Default flip=true in FMTooltip so tooltips stay within the viewport

### DIFF
--- a/packages/lesswrong/components/common/FMTooltip.tsx
+++ b/packages/lesswrong/components/common/FMTooltip.tsx
@@ -50,7 +50,7 @@ interface FMTooltipProps {
 }
 
 export const TooltipRef = <T extends HTMLElement>({
-  title, placement="bottom", distance=16, styling="tooltip", flip, clickable,
+  title, placement="bottom", distance=16, styling="tooltip", flip=true, clickable,
   disabled, hideOnTouchScreens, analyticsProps, otherEventProps, className,
   popperClassName, forceOpen, preserve, children
 }: FMTooltipProps & {


### PR DESCRIPTION
## Problem

On mobile, tapping a vote button on the post page shows the "Click-and-hold for strong vote (click twice on mobile)" tooltip — and the page gets wider, with horizontal scroll appearing.

## Cause

`FMTooltip` passes `allowOverflow={!flip}` down to `LWPopper`, but unlike `LWTooltip` (which defaults `flip=true`), it never gave `flip` a default. No caller passes `flip`, so every `TooltipRef`/`TooltipSpan` ran with popper's `flip` and `preventOverflow` modifiers disabled. The post-page vote buttons sit at the far right edge of the mobile viewport, and their bottom-placed tooltip (max-width 300px) is centered on the button, so it spilled past the right edge and stretched the page.

## Fix

Default `flip=true` in `FMTooltip`, matching `LWTooltip`. Popper now keeps the tooltip clamped inside the viewport (it slides left instead of overflowing). This also fixes the same latent overflow for all other `TooltipSpan`/`TooltipRef` usages. No existing caller passes `flip` explicitly, and nothing uses the `preserve` prop (which has a known popper interaction near screen edges), so no existing behavior that relied on overflowing is affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1216747763275946) by [Unito](https://www.unito.io)
