### PR TITLE
Don't put users in the review queue for updating their map location

### DIFF
--- a/packages/lesswrong/lib/collections/moderatorActions/constants.ts
+++ b/packages/lesswrong/lib/collections/moderatorActions/constants.ts
@@ -134,7 +134,6 @@ export const getMaxAllowedContactsBeforeBlock = () => forumSelect({ EAForum: 4, 
 
 export const REVIEW_REASON_TO_MODERATOR_ACTION = {
   biography: UNREVIEWED_BIO_UPDATE,
-  mapLocation: UNREVIEWED_MAP_LOCATION_UPDATE,
   profileImageId: UNREVIEWED_PROFILE_IMAGE_UPDATE,
   firstPost: UNREVIEWED_FIRST_POST,
   firstComment: UNREVIEWED_FIRST_COMMENT,

--- a/packages/lesswrong/server/callbacks/sunshineCallbackUtils.tsx
+++ b/packages/lesswrong/server/callbacks/sunshineCallbackUtils.tsx
@@ -8,14 +8,14 @@ import { createModeratorAction, updateModeratorAction } from "../collections/mod
 import { createCommentModeratorAction } from "../collections/commentModeratorActions/mutations";
 import { backgroundTask } from "../utils/backgroundTask";
 
-export type ReasonReviewIsNeeded = "mapLocation" | "firstPost" | "firstComment" | "unreviewedPost" | "unreviewedComment" | "biography" | "profileImageId" | "newContent";
+export type ReasonReviewIsNeeded = "firstPost" | "firstComment" | "unreviewedPost" | "unreviewedComment" | "biography" | "profileImageId" | "newContent";
 
 async function createModeratorActionForReview(userId: string, reason: ReasonReviewIsNeeded, context: ResolverContext) {
   const moderatorActionType = REVIEW_REASON_TO_MODERATOR_ACTION[reason];
   await createModeratorAction({ data: { userId, type: moderatorActionType } }, context);
 }
 
-type ReviewCheckTrigger = 'newComment' | 'updatedComment' | 'publishedPost' | 'mapLocation' | 'biography' | 'profileImageId';
+type ReviewCheckTrigger = 'newComment' | 'updatedComment' | 'publishedPost' | 'biography' | 'profileImageId';
 
 /** 
  * This function contains all logic for determining whether a given user needs review in the moderation sidebar.
@@ -36,7 +36,6 @@ export async function triggerReviewIfNeeded(userId: string, trigger: ReviewCheck
       case 'updatedComment':
         return await createModeratorActionForReview(userId, 'newContent', context);
       // If the user is snoozed, we don't want want to put them back in the review queue for updating these fields
-      case 'mapLocation':
       case 'biography':
       case 'profileImageId':
         return;
@@ -58,7 +57,6 @@ export async function triggerReviewIfNeeded(userId: string, trigger: ReviewCheck
       return await createModeratorActionForReview(userId, user.reviewedAt ? 'unreviewedComment' : 'firstComment', context);
     case 'publishedPost':
       return await createModeratorActionForReview(userId, user.reviewedAt ? 'unreviewedPost' : 'firstPost', context);
-    case 'mapLocation':
     case 'biography':
     case 'profileImageId':
       return await createModeratorActionForReview(userId, trigger, context);

--- a/packages/lesswrong/server/callbacks/userCallbackFunctions.tsx
+++ b/packages/lesswrong/server/callbacks/userCallbackFunctions.tsx
@@ -365,7 +365,8 @@ export function syncProfileUpdatedAt(modifier: MongoModifier, user: DbUser) {
 
 /* UPDATE ASYNC */
 export function updateUserMayTriggerReview({newDocument, data, context, oldDocument}: UpdateCallbackProperties<"Users">) {
-  const reviewTriggerFields = ['biography', 'mapLocation', 'profileImageId'] as const;
+  // Deliberately excludes mapLocation; updating your map location shouldn't land you in the review queue
+  const reviewTriggerFields = ['biography', 'profileImageId'] as const;
 
   const updatedField = reviewTriggerFields.find(field => {
     if (!(field in data)) return false;
@@ -380,18 +381,10 @@ export function updateUserMayTriggerReview({newDocument, data, context, oldDocum
       return !!fieldValue;
     }
 
-    // I don't want to figure out how to introspect on mapLocation objects;
-    // this come up infrequently enough that I think it's fine to trigger review
-    // if it ever changes for an unreviewed user.  (Note: I don't think we actually
-    // have a way to see the location that they set for themselves in the UI.)
-    if (field === 'mapLocation') {
-      return true;
-    }
-
     // Biography is an editable field and I don't want to trigger review if the value
     // is updated to an empty string.
     if (field === 'biography') {
-      return !!fieldValue?.originalContents?.data;
+      return !!data.biography?.originalContents?.data;
     }
   });
 


### PR DESCRIPTION
## Summary

Editing your map location currently creates an `unreviewedMapLocationUpdate` ("Unreviewed map location update") moderator action, which — because that type is in `reviewTriggerModeratorActions` — sets `needsReview: true` via `triggerReviewAfterModeration` and lands the user in the moderation review queue. This PR stops map location edits from triggering that at all.

## Changes

- `updateUserMayTriggerReview` no longer treats `mapLocation` as a review-trigger field (with a comment noting the exclusion is deliberate)
- Removed `mapLocation` from the `ReviewCheckTrigger` / `ReasonReviewIsNeeded` unions and the corresponding `triggerReviewIfNeeded` switch cases and `REVIEW_REASON_TO_MODERATOR_ACTION` entry
- The `unreviewedMapLocationUpdate` action type itself is **kept** (in `reviewTriggerModeratorActions`, `MODERATOR_ACTION_TYPES`, and the review-group/display switches) so existing historical actions still display, group into `maybeSpam`, and auto-close when a user is reviewed

One incidental type fix: `mapLocation`'s `any` type was collapsing the `fieldValue` union in `updateUserMayTriggerReview`; with it removed, the biography branch needed to reference `data.biography` directly to typecheck.

## Testing

- `yarn tsc` passes
- `yarn unit packages/lesswrong/unitTests/moderationInboxReducer.tests.ts` passes (12/12)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1216846249536432) by [Unito](https://www.unito.io)
