### PR TITLE
Supermod: undo returns you to the user's page where the action was done

### DIFF
--- a/packages/lesswrong/components/sunshineDashboard/supermod/ModerationInbox.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/supermod/ModerationInbox.tsx
@@ -364,12 +364,14 @@ const ModerationInboxInner = ({ users, posts, classifiedPosts, curationPosts, la
             expiresAt: now + UNDO_QUEUE_DURATION,
             timeoutId,
             executeAction,
+            sourceTab: state.activeTab,
+            wasDetailView: !!state.openedUserId,
           },
         });
         dispatch({ type: 'REMOVE_USER', userId: userIdToRemove });
       }
     }
-  }, [state.openedUserId, state.focusedUserId, allOrderedUsers]);
+  }, [state.openedUserId, state.focusedUserId, state.activeTab, allOrderedUsers]);
 
   const isPostsTab = state.activeTab === 'posts' || state.activeTab === 'classifiedPosts';
   const isCurationTab = state.activeTab === 'curation';

--- a/packages/lesswrong/components/sunshineDashboard/supermod/inboxReducer.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/supermod/inboxReducer.tsx
@@ -20,7 +20,7 @@ export interface UndoHistoryItem {
   expiresAt: number;
   timeoutId: NodeJS.Timeout;
   executeAction: () => Promise<void>;
-  // View context where the action was performed, so undoing can return there
+  // View context of the action, so undo can return there
   sourceTab: TabId;
   wasDetailView: boolean;
 };
@@ -130,8 +130,6 @@ export function inboxStateReducer(state: InboxState, action: InboxAction): Inbox
         clearTimeout(item.timeoutId);
       }
 
-      // Return to where the action was performed: reopen the user's detail view
-      // if the action was done there, otherwise refocus them in the inbox
       return {
         ...state,
         users: [...state.users, item.user],

--- a/packages/lesswrong/components/sunshineDashboard/supermod/inboxReducer.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/supermod/inboxReducer.tsx
@@ -20,6 +20,9 @@ export interface UndoHistoryItem {
   expiresAt: number;
   timeoutId: NodeJS.Timeout;
   executeAction: () => Promise<void>;
+  // View context where the action was performed, so undoing can return there
+  sourceTab: TabId;
+  wasDetailView: boolean;
 };
 
 
@@ -127,10 +130,17 @@ export function inboxStateReducer(state: InboxState, action: InboxAction): Inbox
         clearTimeout(item.timeoutId);
       }
 
+      // Return to where the action was performed: reopen the user's detail view
+      // if the action was done there, otherwise refocus them in the inbox
       return {
         ...state,
         users: [...state.users, item.user],
         undoQueue: state.undoQueue.filter(item => item.user._id !== action.userId),
+        activeTab: item.sourceTab,
+        focusedUserId: item.user._id,
+        openedUserId: item.wasDetailView ? item.user._id : null,
+        focusedPostId: null,
+        focusedContentIndex: 0,
       };
     }
 

--- a/packages/lesswrong/unitTests/moderationInboxReducer.tests.ts
+++ b/packages/lesswrong/unitTests/moderationInboxReducer.tests.ts
@@ -1,4 +1,4 @@
-import { inboxStateReducer, type InboxState } from '@/components/sunshineDashboard/supermod/inboxReducer';
+import { inboxStateReducer, type InboxState, type UndoHistoryItem } from '@/components/sunshineDashboard/supermod/inboxReducer';
 import {
   UNREVIEWED_FIRST_POST,
   MANUAL_FLAG_ALERT,
@@ -59,6 +59,23 @@ function createMockUser(
     }],
     ...partialUser,
   } as SunshineUsersList;
+}
+
+function createUndoItem(
+  user: SunshineUsersList,
+  overrides?: Partial<UndoHistoryItem>
+): UndoHistoryItem {
+  return {
+    user,
+    actionLabel: 'Approved',
+    timestamp: 0,
+    expiresAt: 0,
+    timeoutId: setTimeout(() => {}, 0),
+    executeAction: async () => {},
+    sourceTab: 'all',
+    wasDetailView: false,
+    ...overrides,
+  };
 }
 
 describe('Moderation Inbox Reducer', () => {
@@ -405,6 +422,92 @@ describe('Moderation Inbox Reducer', () => {
       expect(state.focusedUserId).toBe(null);
       expect(state.openedUserId).toBe(null);
       expect(state.users.length).toBe(0);
+    });
+  });
+
+  describe('UNDO_ACTION', () => {
+    test('reopens the user detail view when the action was done there', () => {
+      const undoneUser = createMockUser('user1', 'newContent');
+      const users = [
+        createMockUser('user2', 'newContent'),
+        createMockUser('user3', 'highContext'),
+      ];
+
+      const state: InboxState = {
+        users,
+        posts: [],
+        classifiedPosts: [],
+        curationPosts: [],
+        activeTab: 'all',
+        focusedUserId: null,
+        openedUserId: 'user2',
+        focusedPostId: null,
+        focusedContentIndex: 3,
+        undoQueue: [createUndoItem(undoneUser, { sourceTab: 'newContent', wasDetailView: true })],
+        history: [],
+        runningLlmCheckId: null,
+      };
+
+      const newState = inboxStateReducer(state, { type: 'UNDO_ACTION', userId: 'user1' });
+
+      expect(newState.users.map(u => u._id)).toContain('user1');
+      expect(newState.undoQueue.length).toBe(0);
+      expect(newState.activeTab).toBe('newContent');
+      expect(newState.openedUserId).toBe('user1');
+      expect(newState.focusedUserId).toBe('user1');
+      expect(newState.focusedContentIndex).toBe(0);
+    });
+
+    test('refocuses the user in the inbox when the action was done from the inbox', () => {
+      const undoneUser = createMockUser('user1', 'newContent');
+      const users = [
+        createMockUser('user2', 'newContent'),
+        createMockUser('user3', 'highContext'),
+      ];
+
+      const state: InboxState = {
+        users,
+        posts: [],
+        classifiedPosts: [],
+        curationPosts: [],
+        activeTab: 'highContext',
+        focusedUserId: null,
+        openedUserId: 'user3',
+        focusedPostId: null,
+        focusedContentIndex: 1,
+        undoQueue: [createUndoItem(undoneUser, { sourceTab: 'newContent', wasDetailView: false })],
+        history: [],
+        runningLlmCheckId: null,
+      };
+
+      const newState = inboxStateReducer(state, { type: 'UNDO_ACTION', userId: 'user1' });
+
+      expect(newState.users.map(u => u._id)).toContain('user1');
+      expect(newState.undoQueue.length).toBe(0);
+      expect(newState.activeTab).toBe('newContent');
+      expect(newState.openedUserId).toBe(null);
+      expect(newState.focusedUserId).toBe('user1');
+    });
+
+    test('does nothing when the user is not in the undo queue', () => {
+      const state: InboxState = {
+        users: [createMockUser('user2', 'newContent')],
+        posts: [],
+        classifiedPosts: [],
+        curationPosts: [],
+        activeTab: 'newContent',
+        focusedUserId: 'user2',
+        openedUserId: null,
+        focusedPostId: null,
+        focusedContentIndex: 0,
+        undoQueue: [],
+        history: [],
+        runningLlmCheckId: null,
+      };
+
+      const newState = inboxStateReducer(state, { type: 'UNDO_ACTION', userId: 'user1' });
+
+      expect(newState).toBe(state);
     });
   });
 


### PR DESCRIPTION
## Summary

When you undo a moderation action on supermod (clicking the undo-queue item or pressing Ctrl+Z), you're now returned to where that action was performed, instead of staying wherever you've since navigated to:

- If the action was done from the user's detail view, undo reopens that user's detail view (which also restores the `?user=<id>` URL).
- If the action was done from the inbox list, undo switches back to the tab it was done on and refocuses that user in the inbox (closing any detail view you've since opened).

## Implementation

- `UndoHistoryItem` now records `sourceTab` and `wasDetailView` at the time the action is queued (captured in `addToUndoQueue` in `ModerationInbox.tsx`).
- The `UNDO_ACTION` reducer case restores that context along with re-adding the user to the local list. The existing URL-sync effect picks up the `openedUserId` change and restores `?user=`.

## Testing

- Added three reducer unit tests covering detail-view restore, inbox refocus (including closing an unrelated open detail view), and the no-op case; `yarn unit packages/lesswrong/unitTests/moderationInboxReducer.tests.ts` passes (15/15).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1216847768694348) by [Unito](https://www.unito.io)
