### PR TITLE
Match collapsible-section spacing to paragraph spacing in research docs

### DIFF
--- a/packages/lesswrong/components/common/ContentStylesValues.ts
+++ b/packages/lesswrong/components/common/ContentStylesValues.ts
@@ -32,7 +32,10 @@ const researchDocumentBodyStyles = (theme: ThemeType) => ({
     margin: '0 auto',
     padding: '44px 32px 160px',
   },
-  '& [contenteditable="true"] p:not(.research-agent-block *)': {
+  // Collapsible sections share the paragraph rule so they can't drift from it.
+  // Left to the `1em` margins they inherit from `postBodyStyles`, they'd sit in
+  // more space than the paragraphs around them.
+  '& [contenteditable="true"] p:not(.research-agent-block *), & [contenteditable="true"] .detailsBlock:not(.research-agent-block *)': {
     margin: '0 0 0.7em',
   },
   '& [contenteditable="true"] h1:not(.research-agent-block *)': {

--- a/packages/lesswrong/components/common/ContentStylesValues.ts
+++ b/packages/lesswrong/components/common/ContentStylesValues.ts
@@ -33,8 +33,6 @@ const researchDocumentBodyStyles = (theme: ThemeType) => ({
     padding: '44px 32px 160px',
   },
   // Collapsible sections share the paragraph rule so they can't drift from it.
-  // Left to the `1em` margins they inherit from `postBodyStyles`, they'd sit in
-  // more space than the paragraphs around them.
   '& [contenteditable="true"] p:not(.research-agent-block *), & [contenteditable="true"] .detailsBlock:not(.research-agent-block *)': {
     margin: '0 0 0.7em',
   },


### PR DESCRIPTION
Follow-up to #12681. In research documents, paragraphs are on a `0 0 0.7em` rhythm (`researchDocumentBodyStyles`), but collapsible sections kept the `1em` top/bottom margins they inherit from `postBodyStyles`, so a section sat in more space than the paragraphs around it.

Measured in the research editor's typography (18px / 1.65):

| gap | before | after |
| --- | --- | --- |
| paragraph → collapsible | 18px | 12.6px |
| collapsible → paragraph | 18px | 12.6px |
| paragraph → paragraph | 12.6px | 12.6px |

The fix folds `.detailsBlock` into the existing paragraph rule rather than adding a second copy of `0.7em`, so the two can't drift apart.

Notes:
- Everywhere else the two already agree: the rendered page and the comment styles use the UA `p` margin of `1em`, and `ckEditorStyles` sets `1em` explicitly, all of which match `.detailsBlock`'s `1em` (adjacent margins collapse).
- `.detailsBlockTitle` still has `2px` of vertical padding, so the *title text* sits 2px lower than a paragraph would. Left alone here because that padding is also what the marker's position was tuned against; say the word and I'll drop it for an exact match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1216875115725947) by [Unito](https://www.unito.io)
