### PR TITLE
Route negative-karma users to the supermod offboard tab

### DIFF
--- a/packages/lesswrong/lib/collections/users/newSchema.ts
+++ b/packages/lesswrong/lib/collections/users/newSchema.ts
@@ -3989,7 +3989,7 @@ const schema = {
         const baseGroup = getReviewGroupFromActions(actionsWithActiveStatus, lastRemovedFromReviewQueueAt);
 
         // Users who would otherwise be in `newContent` get pulled into the
-        // `offboard` group if their content matches the offboarding criteria.
+        // `offboard` group if they match the offboarding criteria.
         if (baseGroup === 'newContent' && await getIsOffboardCandidate(context, doc._id)) {
           return 'offboard';
         }

--- a/packages/lesswrong/server/repos/UsersRepo.ts
+++ b/packages/lesswrong/server/repos/UsersRepo.ts
@@ -412,12 +412,13 @@ class UsersRepo extends AbstractRepo<"Users"> {
    * "offboard" review group, because they either:
    *   (1) have a rejected post/comment with a high Pangram score, or
    *   (2) have at least two rejected posts and/or comments, or
-   *   (3) have all of their content rejected.
-   * Rejected content counts for all criteria even if the user has since
+   *   (3) have all of their content rejected, or
+   *   (4) have negative karma.
+   * Rejected content counts for criteria (1)-(3) even if the user has since
    * re-drafted/deleted the post or deleted the comment; never-rejected drafts
    * and deleted items are ignored. Criterion (1) considers evaluations of any
    * revision, not just the latest.
-   * All criteria are evaluated over all-time content state (deliberately not
+   * Criteria (1)-(3) are evaluated over all-time content state (deliberately not
    * bounded by `lastRemovedFromReviewQueueAt`), so the offboard question keeps
    * getting re-asked until the user is offboarded or their record improves.
    */
@@ -451,6 +452,11 @@ class UsersRepo extends AbstractRepo<"Users"> {
       GROUP BY c."userId"
       HAVING COUNT(*) FILTER (WHERE c."rejected" IS TRUE) >= 2
         OR COUNT(*) FILTER (WHERE c."rejected" IS NOT TRUE) = 0
+      UNION
+      -- (4) negative karma
+      SELECT u."_id" AS "userId"
+      FROM "Users" u
+      WHERE u."_id" = ANY($(userIds)::text[]) AND u."karma" < 0
     `, { userIds, highPangramScoreThreshold: OFFBOARD_HIGH_PANGRAM_SCORE_THRESHOLD });
     return rows.map((row) => row.userId);
   }

--- a/packages/lesswrong/unitTests/moderationInboxReducer.tests.ts
+++ b/packages/lesswrong/unitTests/moderationInboxReducer.tests.ts
@@ -10,7 +10,7 @@ import {
 
 const moderatorActionTypes: Record<ReviewGroup, ModeratorActionType> = {
   newContent: UNREVIEWED_FIRST_POST,
-  // `offboard` is derived from content (not a moderator action); this mapping is
+  // `offboard` is derived from content and karma (not a moderator action); this mapping is
   // only used to attach a plausible action to mock users in these reducer tests.
   offboard: UNREVIEWED_FIRST_POST,
   highContext: MANUAL_FLAG_ALERT,


### PR DESCRIPTION
Users with negative karma who would otherwise appear in the supermod **New Content** tab now appear in **Offboard?** instead.

Negative karma is added as a fourth criterion inside `UsersRepo.getOffboardCandidateUserIds`, next to the existing content-based ones (high-Pangram rejection, ≥2 rejected items, all content rejected), so all offboard criteria live in one place. Only users whose base review group is `newContent` are affected; higher-signal groups (highContext, maybeSpam, etc.) are unchanged.

Verified against the dev DB: negative-karma users come back as offboard candidates, positive-karma users don't.

🤖 Generated with [Claude Code](https://claude.com/claude-code)