### PR TITLE
Fix sluggish typing in the rejection notice editor

### DIFF
--- a/packages/lesswrong/components/sunshineDashboard/RejectContentDialog.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/RejectContentDialog.tsx
@@ -2,7 +2,7 @@ import Button from '@/lib/vendor/@material-ui/core/src/Button';
 import Checkbox from '@/lib/vendor/@material-ui/core/src/Checkbox';
 import { Paper, Card }from '@/components/widgets/Paper';
 import classNames from 'classnames';
-import React, { useState, useEffect, useCallback, useRef } from 'react';
+import React, { useState, useEffect, useCallback, useRef, useMemo, useContext, createContext } from 'react';
 import EditIcon from '@/lib/vendor/@material-ui/icons/src/Edit'
 import { Link } from '../../lib/reactRouterWrapper';
 import LWTooltip from "../common/LWTooltip";
@@ -258,6 +258,60 @@ const TemplateRowContent = ({
   );
 };
 
+interface SortableTemplateRowContextValue {
+  templatesById: Record<string, ModerationTemplateFragment>;
+  visibleTemplateIds: string[];
+  selectedIndex: number;
+  selections: Record<string, boolean>;
+  displayName?: string;
+  onCheckboxChange: (label: string, checked: boolean) => void;
+  onHide: (templateId: string) => void;
+}
+
+const SortableTemplateRowContext = createContext<SortableTemplateRowContextValue | null>(null);
+
+/**
+ * Rendered inside the sortable list, which is constructed once at module scope
+ * (see `SortableTemplateList` below).  It reads everything it needs from
+ * context rather than from a closure, because a `makeSortableListComponent`
+ * call inside the dialog's render would produce a new component type on every
+ * render, unmounting and remounting the whole drag-and-drop tree each time.
+ */
+const SortableTemplateRow = ({ contents: templateId }: { contents: string }) => {
+  const classes = useStyles(styles);
+  const context = useContext(SortableTemplateRowContext);
+  if (!context) return null;
+
+  const { templatesById, visibleTemplateIds, selectedIndex, selections, displayName, onCheckboxChange, onHide } = context;
+  const template = templatesById[templateId];
+  if (!template) return null;
+
+  const originalIndex = visibleTemplateIds.indexOf(templateId);
+
+  return (
+    <div className={classes.templateRow}>
+      <span className={classes.dragHandle}>
+        <LWTooltip title="Drag to reorder" placement="left">
+          <ForumIcon icon="DragIndicator" className={classes.dragIndicatorIcon} />
+        </LWTooltip>
+      </span>
+      <TemplateRowContent
+        template={template}
+        displayName={displayName}
+        isTop6={originalIndex < 6}
+        selections={selections}
+        onCheckboxChange={onCheckboxChange}
+        onHide={onHide}
+        selected={originalIndex === selectedIndex}
+      />
+    </div>
+  );
+};
+
+const SortableTemplateList = makeSortableListComponent({ RenderItem: SortableTemplateRow });
+
+const noop = () => {};
+
 const STORAGE_KEY_PREFIX = 'rejectionTemplateConfig_';
 
 const RejectContentDialog = ({rejectionTemplates, onClose, rejectContent, displayName}: {
@@ -270,7 +324,14 @@ const RejectContentDialog = ({rejectionTemplates, onClose, rejectContent, displa
   const currentUser = useCurrentUser();
   const [selections, setSelections] = useState<Record<string,boolean>>({});
   const [hideTextField, setHideTextField] = useState(true);
-  const [rejectedReason, setRejectedReason] = useState('');
+  // The editor's live contents are kept in a ref rather than in state, so that
+  // typing in the editor doesn't re-render the (fairly expensive) template
+  // list on every keystroke.  `editorHtml` is only the value the editor is
+  // (re)mounted with, and `hasRejectedReason` only flips between empty and
+  // non-empty, so neither changes while typing.
+  const rejectedReasonRef = useRef('');
+  const [editorHtml, setEditorHtml] = useState('');
+  const [hasRejectedReason, setHasRejectedReason] = useState(false);
   const [lexicalEditorVersion, setLexicalEditorVersion] = useState(0);
   const [hiddenTemplateIds, setHiddenTemplateIds] = useState<Set<string>>(new Set());
   const [templateOrder, setTemplateOrder] = useState<string[]>([]);
@@ -283,22 +344,34 @@ const RejectContentDialog = ({rejectionTemplates, onClose, rejectContent, displa
   const templateListRef = useRef<HTMLDivElement>(null);
   const editorContainerRef = useRef<HTMLDivElement>(null);
   
-  const rejectionReasons = Object.fromEntries(rejectionTemplates.map(({name, contents}) => [name, getDraftMessageHtml({ html: contents?.html ?? "", displayName })]));
+  const rejectionReasons = useMemo(
+    () => Object.fromEntries(rejectionTemplates.map(({name, contents}) => [name, getDraftMessageHtml({ html: contents?.html ?? "", displayName })])),
+    [rejectionTemplates, displayName]
+  );
 
   // Create a map for quick template lookup
-  const templatesById = Object.fromEntries(rejectionTemplates.map(t => [t._id, t]));
+  const templatesById = useMemo(
+    () => Object.fromEntries(rejectionTemplates.map(t => [t._id, t])),
+    [rejectionTemplates]
+  );
 
-  const orderedTemplates = templateOrder
-    .map(id => templatesById[id])
-    .filter(template => !!template);
-  
-  const matchesSearch = (template: ModerationTemplateFragment) => {
-    if (!searchQuery) return true;
-    return template.name.toLowerCase().includes(searchQuery.toLowerCase());
-  };
-  
-  const visibleTemplates = orderedTemplates.filter(t => !hiddenTemplateIds.has(t._id) && matchesSearch(t));
-  const hiddenTemplates = orderedTemplates.filter(t => hiddenTemplateIds.has(t._id) && matchesSearch(t));  
+  const { visibleTemplates, hiddenTemplates } = useMemo(() => {
+    const orderedTemplates = templateOrder
+      .map(id => templatesById[id])
+      .filter(template => !!template);
+
+    const lowercaseQuery = searchQuery.toLowerCase();
+    const matching = lowercaseQuery
+      ? orderedTemplates.filter(t => t.name.toLowerCase().includes(lowercaseQuery))
+      : orderedTemplates;
+
+    return {
+      visibleTemplates: matching.filter(t => !hiddenTemplateIds.has(t._id)),
+      hiddenTemplates: matching.filter(t => hiddenTemplateIds.has(t._id)),
+    };
+  }, [templateOrder, templatesById, searchQuery, hiddenTemplateIds]);
+
+  const visibleTemplateIds = useMemo(() => visibleTemplates.map(t => t._id), [visibleTemplates]);
 
   useEffect(() => {
     const ls = getBrowserLocalStorage();
@@ -405,9 +478,17 @@ const RejectContentDialog = ({rejectionTemplates, onClose, rejectContent, displa
   }, [hiddenTemplateIds, templateOrder, saveConfig]);
 
   const handleClick = useCallback(() => {
-    rejectContent(rejectedReason);
+    rejectContent(rejectedReasonRef.current);
     onClose?.();
-  }, [rejectContent, rejectedReason, onClose]);
+  }, [rejectContent, onClose]);
+
+  const handleEditorChange = useCallback((html: string) => {
+    rejectedReasonRef.current = html;
+    // Setting this to the value it already has is a no-op for React, so this
+    // only causes a re-render when the editor goes from empty to non-empty (or
+    // vice versa), which is the only thing the rest of the dialog cares about.
+    setHasRejectedReason(!!html);
+  }, []);
 
   const composeRejectedReason = useCallback((label: string, checked: boolean) => {
     const newSelections = {...selections, [label]: checked};
@@ -420,7 +501,9 @@ const RejectContentDialog = ({rejectionTemplates, onClose, rejectContent, displa
         .join('')
     }</ul>`;
 
-    setRejectedReason(composedReason);
+    rejectedReasonRef.current = composedReason;
+    setEditorHtml(composedReason);
+    setHasRejectedReason(!!composedReason);
     setLexicalEditorVersion((prev) => prev + 1);
     focusLexicalEditor(editorContainerRef.current);
   }, [rejectionReasons, selections]);
@@ -445,7 +528,7 @@ const RejectContentDialog = ({rejectionTemplates, onClose, rejectContent, displa
       case 'Enter':
         if (e.ctrlKey || e.metaKey) {
           e.preventDefault();
-          if (rejectedReason) {
+          if (hasRejectedReason) {
             handleClick();
           }
         } else {
@@ -472,46 +555,26 @@ const RejectContentDialog = ({rejectionTemplates, onClose, rejectContent, displa
         }, 0);
         break;
     }
-  }, [visibleTemplates, selectedIndex, selections, composeRejectedReason, rejectedReason, hideTextField, handleClick]);
+  }, [visibleTemplates, selectedIndex, selections, composeRejectedReason, hasRejectedReason, hideTextField, handleClick]);
 
   useGlobalKeydown(useCallback((e: KeyboardEvent) => {
     if ((e.ctrlKey || e.metaKey) && e.key === 'Enter') {
-      if (rejectedReason) {
+      if (hasRejectedReason) {
         e.preventDefault();
         handleClick();
       }
     }
-  }, [rejectedReason, handleClick]));
+  }, [hasRejectedReason, handleClick]));
 
-  const SortableTemplateList = makeSortableListComponent({
-    RenderItem: ({ contents: templateId }) => {
-      const template = templatesById[templateId];
-      if (!template) return null;
-
-      const originalIndex = visibleTemplates.findIndex(t => t._id === templateId);
-      const top6 = originalIndex < 6;
-      const isSelected = originalIndex === selectedIndex;
-
-      return (
-        <div className={classes.templateRow}>
-          <span className={classes.dragHandle}>
-            <LWTooltip title="Drag to reorder" placement="left">
-              <ForumIcon icon="DragIndicator" className={classes.dragIndicatorIcon} />
-            </LWTooltip>
-          </span>
-          <TemplateRowContent
-            template={template}
-            displayName={displayName}
-            isTop6={top6}
-            selections={selections}
-            onCheckboxChange={composeRejectedReason}
-            onHide={hideTemplate}
-            selected={isSelected}
-          />
-        </div>
-      );
-    }
-  });
+  const sortableRowContext: SortableTemplateRowContextValue = useMemo(() => ({
+    templatesById,
+    visibleTemplateIds,
+    selectedIndex,
+    selections,
+    displayName,
+    onCheckboxChange: composeRejectedReason,
+    onHide: hideTemplate,
+  }), [templatesById, visibleTemplateIds, selectedIndex, selections, displayName, composeRejectedReason, hideTemplate]);
 
   const dialogContent = <>
     <input
@@ -529,11 +592,13 @@ const RejectContentDialog = ({rejectionTemplates, onClose, rejectContent, displa
       style={initialHeight !== null ? { minHeight: initialHeight } : undefined}
     >
     <div ref={templateListRef}>
-      <SortableTemplateList
-        value={visibleTemplates.map(t => t._id)}
-        setValue={updateTemplateOrder}
-        axis="y"
-      />
+      <SortableTemplateRowContext.Provider value={sortableRowContext}>
+        <SortableTemplateList
+          value={visibleTemplateIds}
+          setValue={updateTemplateOrder}
+          axis="y"
+        />
+      </SortableTemplateRowContext.Provider>
     </div>
     
     {hiddenTemplates.length > 0 && (
@@ -579,10 +644,10 @@ const RejectContentDialog = ({rejectionTemplates, onClose, rejectContent, displa
       <ContentStyles contentType='comment'>
         <LexicalEditor
           key={lexicalEditorVersion}
-          data={rejectedReason}
+          data={editorHtml}
           placeholder="Enter rejection reason..."
-          onChange={setRejectedReason}
-          onReady={() => {}}
+          onChange={handleEditorChange}
+          onReady={noop}
           commentEditor
         />
       </ContentStyles>
@@ -593,7 +658,7 @@ const RejectContentDialog = ({rejectionTemplates, onClose, rejectContent, displa
   const dialogElement = <Paper>
     <div className={classes.dialogContent}>
       {dialogContent}
-      <Button onClick={handleClick} disabled={!rejectedReason}>
+      <Button onClick={handleClick} disabled={!hasRejectedReason}>
         Reject
         <KeystrokeDisplay keystroke="Ctrl+Enter" withMargin splitBeforeTranslation />
       </Button>

--- a/packages/lesswrong/components/sunshineDashboard/RejectContentDialog.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/RejectContentDialog.tsx
@@ -270,13 +270,8 @@ interface SortableTemplateRowContextValue {
 
 const SortableTemplateRowContext = createContext<SortableTemplateRowContextValue | null>(null);
 
-/**
- * Rendered inside the sortable list, which is constructed once at module scope
- * (see `SortableTemplateList` below).  It reads everything it needs from
- * context rather than from a closure, because a `makeSortableListComponent`
- * call inside the dialog's render would produce a new component type on every
- * render, unmounting and remounting the whole drag-and-drop tree each time.
- */
+// Reads from context, not a closure, so SortableTemplateList can be built
+// once at module scope; rebuilding it per render remounts the dnd tree.
 const SortableTemplateRow = ({ contents: templateId }: { contents: string }) => {
   const classes = useStyles(styles);
   const context = useContext(SortableTemplateRowContext);
@@ -324,11 +319,8 @@ const RejectContentDialog = ({rejectionTemplates, onClose, rejectContent, displa
   const currentUser = useCurrentUser();
   const [selections, setSelections] = useState<Record<string,boolean>>({});
   const [hideTextField, setHideTextField] = useState(true);
-  // The editor's live contents are kept in a ref rather than in state, so that
-  // typing in the editor doesn't re-render the (fairly expensive) template
-  // list on every keystroke.  `editorHtml` is only the value the editor is
-  // (re)mounted with, and `hasRejectedReason` only flips between empty and
-  // non-empty, so neither changes while typing.
+  // Live editor contents go in a ref so typing doesn't re-render the template
+  // list; editorHtml is only the value the editor is (re)mounted with.
   const rejectedReasonRef = useRef('');
   const [editorHtml, setEditorHtml] = useState('');
   const [hasRejectedReason, setHasRejectedReason] = useState(false);
@@ -484,9 +476,7 @@ const RejectContentDialog = ({rejectionTemplates, onClose, rejectContent, displa
 
   const handleEditorChange = useCallback((html: string) => {
     rejectedReasonRef.current = html;
-    // Setting this to the value it already has is a no-op for React, so this
-    // only causes a re-render when the editor goes from empty to non-empty (or
-    // vice versa), which is the only thing the rest of the dialog cares about.
+    // Same-value setState bails out, so typing costs no re-render.
     setHasRejectedReason(!!html);
   }, []);
 

--- a/packages/lesswrong/components/sunshineDashboard/RejectContentDialog.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/RejectContentDialog.tsx
@@ -305,8 +305,6 @@ const SortableTemplateRow = ({ contents: templateId }: { contents: string }) => 
 
 const SortableTemplateList = makeSortableListComponent({ RenderItem: SortableTemplateRow });
 
-const noop = () => {};
-
 const STORAGE_KEY_PREFIX = 'rejectionTemplateConfig_';
 
 const RejectContentDialog = ({rejectionTemplates, onClose, rejectContent, displayName}: {
@@ -476,7 +474,7 @@ const RejectContentDialog = ({rejectionTemplates, onClose, rejectContent, displa
 
   const handleEditorChange = useCallback((html: string) => {
     rejectedReasonRef.current = html;
-    // Same-value setState bails out, so typing costs no re-render.
+    // Same-value setState bails out, so typing doesn't re-render the list.
     setHasRejectedReason(!!html);
   }, []);
 
@@ -637,7 +635,6 @@ const RejectContentDialog = ({rejectionTemplates, onClose, rejectContent, displa
           data={editorHtml}
           placeholder="Enter rejection reason..."
           onChange={handleEditorChange}
-          onReady={noop}
           commentEditor
         />
       </ContentStyles>


### PR DESCRIPTION
Typing in the rejection notice editor was sluggish. The cause:

`LexicalEditor`'s `onChange` fires on every keystroke (undebounced outside collaborative mode) and was wired straight to `setRejectedReason`. That re-rendered `RejectContentDialog`, whose render body called `makeSortableListComponent(...)` — producing a **new component type on every render**. React can't reconcile a changed component type, so the entire drag-and-drop tree was unmounted and remounted per character: a `DndContext`, a `SortableContext`, and one `useSortable` + `LWTooltip` + template row for every rejection template.

Fixes:

- **Sortable list built once at module scope.** `SortableTemplateRow` reads what it needs from a new `SortableTemplateRowContext` instead of a render closure, so `SortableTemplateList` has a stable identity and the dnd-kit tree is never remounted.
- **Editor contents live in a ref, not state.** The dialog keeps `hasRejectedReason` (a boolean used for the Reject button and the Ctrl+Enter handler) and `editorHtml` (only the value the editor is mounted with, set when a template checkbox changes). Typing now causes no dialog re-render at all after the first character.
- **Memoized derived data** — the per-template rejection HTML, the id→template map, and the visible/hidden template lists — and replaced the inline `onReady={() => {}}` with a stable `noop`.

No behavior changes: the Reject button's enabled state, Ctrl+Enter, Tab-to-editor, template hiding, and drag reordering all work the same.

Per the request, this was found by reading the code rather than by manual profiling — worth a quick spot-check in the supermod UI before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1217097301149158) by [Unito](https://www.unito.io)
