### PR TITLE
Research comment fixes: Cmd+Enter submit, margin-card styling, no-slide layout

### DIFF
--- a/packages/lesswrong/components/common/ContentStylesValues.ts
+++ b/packages/lesswrong/components/common/ContentStylesValues.ts
@@ -14,14 +14,16 @@ import { researchAccentTint } from '../research/researchStyleUtils';
  *
  * Keep editor-specific rules scoped to the contenteditable so they don't leak
  * onto floating menus, toolbars, or popovers that share the wrapper. The
- * `:not(.research-query-input-content)`, `:not(.research-chat-composer *)`, and
- * `:not(.research-agent-block *)` guards exclude the query input, the nested
- * conversation-block composer, and agent transcript/presentation content,
- * which carry their own chat voice rather than the document's reading column.
+ * `:not(.research-query-input-content)`, `:not(.research-chat-composer *)`,
+ * `:not(.research-agent-block *)`, and `:not(.LexicalContentEditable-rootComment)`
+ * guards exclude the query input, the nested conversation-block composer,
+ * agent transcript/presentation content, and the comment composers (margin
+ * cards portal inside this wrapper), which carry their own compact styling
+ * rather than the document's reading column.
  */
 const researchDocumentBodyStyles = (theme: ThemeType) => ({
   ...postBodyStyles(theme),
-  '& [contenteditable="true"]:not(.research-query-input-content):not(.research-chat-composer *)': {
+  '& [contenteditable="true"]:not(.research-query-input-content):not(.research-chat-composer *):not(.LexicalContentEditable-rootComment)': {
     minHeight: 'calc(100vh - var(--header-height, 0px))',
     boxSizing: 'border-box',
     fontSize: 18,
@@ -33,7 +35,7 @@ const researchDocumentBodyStyles = (theme: ThemeType) => ({
     padding: '44px 32px 160px',
   },
   // Collapsible sections share the paragraph rule so they can't drift from it.
-  '& [contenteditable="true"] p:not(.research-agent-block *), & [contenteditable="true"] .detailsBlock:not(.research-agent-block *)': {
+  '& [contenteditable="true"] p:not(.research-agent-block *):not(.LexicalContentEditable-rootComment *), & [contenteditable="true"] .detailsBlock:not(.research-agent-block *)': {
     margin: '0 0 0.7em',
   },
   '& [contenteditable="true"] h1:not(.research-agent-block *)': {
@@ -93,7 +95,7 @@ const researchDocumentBodyStyles = (theme: ThemeType) => ({
   },
   // Placeholder is a sibling of the contenteditable, absolutely positioned
   // at the top-left of the editor shell, so it doesn't pick up the
-  '& .LexicalContentEditable-placeholder:not(.research-chat-composer *)': {
+  '& .LexicalContentEditable-placeholder:not(.research-chat-composer *):not(.LexicalContentEditable-placeholderComment)': {
     top: 44,
     left: 0,
     right: 0,

--- a/packages/lesswrong/components/common/ContentStylesValues.ts
+++ b/packages/lesswrong/components/common/ContentStylesValues.ts
@@ -27,6 +27,8 @@ import { researchAccentTint } from '../research/researchStyleUtils';
  * bare `:not(.x)` raises specificity and silently re-centers the column
  * while comment threads are open.
  */
+export const RESEARCH_DOC_EDITOR_MAX_WIDTH = 760 + (2 * 32);
+
 const researchDocumentBodyStyles = (theme: ThemeType) => ({
   ...postBodyStyles(theme),
   '& [contenteditable="true"]:not(.research-query-input-content):not(.research-chat-composer *):not(:where(.LexicalContentEditable-rootComment))': {
@@ -36,7 +38,7 @@ const researchDocumentBodyStyles = (theme: ThemeType) => ({
     lineHeight: 1.65,
     fontFamily: theme.palette.fonts.serifStack,
     color: theme.palette.text.primary,
-    maxWidth: 760 + (2 * 32),
+    maxWidth: RESEARCH_DOC_EDITOR_MAX_WIDTH,
     margin: '0 auto',
     padding: '44px 32px 160px',
   },

--- a/packages/lesswrong/components/common/ContentStylesValues.ts
+++ b/packages/lesswrong/components/common/ContentStylesValues.ts
@@ -15,15 +15,21 @@ import { researchAccentTint } from '../research/researchStyleUtils';
  * Keep editor-specific rules scoped to the contenteditable so they don't leak
  * onto floating menus, toolbars, or popovers that share the wrapper. The
  * `:not(.research-query-input-content)`, `:not(.research-chat-composer *)`,
- * `:not(.research-agent-block *)`, and `:not(.LexicalContentEditable-rootComment)`
+ * `:not(.research-agent-block *)`, and `:not(:where(.LexicalContentEditable-rootComment))`
  * guards exclude the query input, the nested conversation-block composer,
  * agent transcript/presentation content, and the comment composers (margin
  * cards portal inside this wrapper), which carry their own compact styling
  * rather than the document's reading column.
+ *
+ * The comment-composer guards are wrapped in `:where()` because these
+ * selectors tie with DocumentPane's `editorWrapWithComments` margin override
+ * at equal specificity and must keep losing that tie by source order — a
+ * bare `:not(.x)` raises specificity and silently re-centers the column
+ * while comment threads are open.
  */
 const researchDocumentBodyStyles = (theme: ThemeType) => ({
   ...postBodyStyles(theme),
-  '& [contenteditable="true"]:not(.research-query-input-content):not(.research-chat-composer *):not(.LexicalContentEditable-rootComment)': {
+  '& [contenteditable="true"]:not(.research-query-input-content):not(.research-chat-composer *):not(:where(.LexicalContentEditable-rootComment))': {
     minHeight: 'calc(100vh - var(--header-height, 0px))',
     boxSizing: 'border-box',
     fontSize: 18,
@@ -35,7 +41,7 @@ const researchDocumentBodyStyles = (theme: ThemeType) => ({
     padding: '44px 32px 160px',
   },
   // Collapsible sections share the paragraph rule so they can't drift from it.
-  '& [contenteditable="true"] p:not(.research-agent-block *):not(.LexicalContentEditable-rootComment *), & [contenteditable="true"] .detailsBlock:not(.research-agent-block *)': {
+  '& [contenteditable="true"] p:not(.research-agent-block *):not(:where(.LexicalContentEditable-rootComment *)), & [contenteditable="true"] .detailsBlock:not(.research-agent-block *)': {
     margin: '0 0 0.7em',
   },
   '& [contenteditable="true"] h1:not(.research-agent-block *)': {
@@ -95,7 +101,7 @@ const researchDocumentBodyStyles = (theme: ThemeType) => ({
   },
   // Placeholder is a sibling of the contenteditable, absolutely positioned
   // at the top-left of the editor shell, so it doesn't pick up the
-  '& .LexicalContentEditable-placeholder:not(.research-chat-composer *):not(.LexicalContentEditable-placeholderComment)': {
+  '& .LexicalContentEditable-placeholder:not(.research-chat-composer *):not(:where(.LexicalContentEditable-placeholderComment))': {
     top: 44,
     left: 0,
     right: 0,

--- a/packages/lesswrong/components/lexical/plugins/CommentPlugin/CommentPluginComponents.tsx
+++ b/packages/lesswrong/components/lexical/plugins/CommentPlugin/CommentPluginComponents.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useRef, useState, type JSX } from 'react';
 import type { EditorState, LexicalCommand, LexicalEditor } from 'lexical';
-import { CLEAR_EDITOR_COMMAND, COMMAND_PRIORITY_NORMAL, KEY_ESCAPE_COMMAND, createCommand } from 'lexical';
+import { CLEAR_EDITOR_COMMAND, COMMAND_PRIORITY_NORMAL, KEY_ENTER_COMMAND, KEY_ESCAPE_COMMAND, createCommand } from 'lexical';
 import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext';
 import { LexicalComposer } from '@lexical/react/LexicalComposer';
 import { PlainTextPlugin } from '@lexical/react/LexicalPlainTextPlugin';
@@ -124,6 +124,36 @@ function EscapeHandlerPlugin({
   return null;
 }
 
+function EnterSubmitPlugin({
+  onEnterSubmit,
+}: {
+  onEnterSubmit: () => void;
+}): null {
+  const [editor] = useLexicalComposerContext();
+  const onEnterSubmitRef = useRef(onEnterSubmit);
+
+  useEffect(() => {
+    onEnterSubmitRef.current = onEnterSubmit;
+  }, [onEnterSubmit]);
+
+  useEffect(() => {
+    return editor.registerCommand(
+      KEY_ENTER_COMMAND,
+      (event: KeyboardEvent | null) => {
+        if (event === null || !(event.metaKey || event.ctrlKey)) {
+          return false;
+        }
+        event.preventDefault();
+        onEnterSubmitRef.current();
+        return true;
+      },
+      COMMAND_PRIORITY_NORMAL,
+    );
+  }, [editor]);
+
+  return null;
+}
+
 const commentEditorInitialConfig = {
   namespace: 'Commenting',
   nodes: [] as const,
@@ -138,6 +168,7 @@ export function PlainTextEditor({
   autoFocus,
   onEscape,
   onChange,
+  onEnterSubmit,
   editorRef,
   placeholder = 'Type a comment...',
 }: {
@@ -145,6 +176,7 @@ export function PlainTextEditor({
   className?: string;
   editorRef?: { current: null | LexicalEditor };
   onChange: (editorState: EditorState, editor: LexicalEditor) => void;
+  onEnterSubmit?: () => void;
   onEscape: (e: KeyboardEvent) => boolean;
   placeholder?: string;
 }) {
@@ -162,6 +194,7 @@ export function PlainTextEditor({
         <HistoryPlugin />
         {autoFocus !== false && <AutoFocusPlugin />}
         <EscapeHandlerPlugin onEscape={onEscape} />
+        {onEnterSubmit !== undefined && <EnterSubmitPlugin onEnterSubmit={onEnterSubmit} />}
         <ClearEditorPlugin />
         {editorRef !== undefined && <EditorRefPlugin editorRef={editorRef} />}
       </div>
@@ -225,6 +258,7 @@ export function CommentsComposer({
           return true;
         }}
         onChange={onChange}
+        onEnterSubmit={submitComment}
         editorRef={editorRef}
         placeholder={placeholder}
       />

--- a/packages/lesswrong/components/lexical/plugins/CommentPlugin/CommentPluginComponents.tsx
+++ b/packages/lesswrong/components/lexical/plugins/CommentPlugin/CommentPluginComponents.tsx
@@ -28,8 +28,8 @@ const styles = defineStyles('CommentPluginComponents', (theme: ThemeType) => ({
     position: 'relative',
     margin: 10,
     borderRadius: 5,
-    '--lexical-comment-placeholder-top': '10px',
-    '--lexical-comment-placeholder-left': '10px',
+    '--lexical-comment-placeholder-top': '9px',
+    '--lexical-comment-placeholder-left': '9px',
     '--lexical-comment-min-height': '30px',
   },
   editor: {

--- a/packages/lesswrong/components/lexical/plugins/CommentPlugin/CommentPluginComponents.tsx
+++ b/packages/lesswrong/components/lexical/plugins/CommentPlugin/CommentPluginComponents.tsx
@@ -176,7 +176,7 @@ export function PlainTextEditor({
   className?: string;
   editorRef?: { current: null | LexicalEditor };
   onChange: (editorState: EditorState, editor: LexicalEditor) => void;
-  onEnterSubmit?: () => void;
+  onEnterSubmit: () => void;
   onEscape: (e: KeyboardEvent) => boolean;
   placeholder?: string;
 }) {
@@ -194,7 +194,7 @@ export function PlainTextEditor({
         <HistoryPlugin />
         {autoFocus !== false && <AutoFocusPlugin />}
         <EscapeHandlerPlugin onEscape={onEscape} />
-        {onEnterSubmit !== undefined && <EnterSubmitPlugin onEnterSubmit={onEnterSubmit} />}
+        <EnterSubmitPlugin onEnterSubmit={onEnterSubmit} />
         <ClearEditorPlugin />
         {editorRef !== undefined && <EditorRefPlugin editorRef={editorRef} />}
       </div>

--- a/packages/lesswrong/components/lexical/plugins/CommentPlugin/index.tsx
+++ b/packages/lesswrong/components/lexical/plugins/CommentPlugin/index.tsx
@@ -709,6 +709,7 @@ function CommentInputBox({
         className={classes.commentInputBoxEditor}
         onEscape={onEscape}
         onChange={onChange}
+        onEnterSubmit={submitComment}
       />
       <div className={classes.commentInputBoxButtons}>
         <Button

--- a/packages/lesswrong/components/research/DocumentPane.tsx
+++ b/packages/lesswrong/components/research/DocumentPane.tsx
@@ -22,6 +22,7 @@ import {
 import Loading from '../vulcan-core/Loading';
 import LexicalEditor from '../editor/LexicalEditor';
 import ContentStyles from '../common/ContentStyles';
+import { RESEARCH_DOC_EDITOR_MAX_WIDTH } from '../common/ContentStylesValues';
 import classNames from 'classnames';
 import {
   ResearchCommentsMarginHostProvider,
@@ -110,6 +111,8 @@ const styles = defineStyles('DocumentPane', (theme: ThemeType) => ({
     // :where() for the same specificity-tie reason as in ContentStylesValues.
     '& [contenteditable="true"]:not(.research-query-input-content):not(.research-chat-composer *):not(:where(.LexicalContentEditable-rootComment))': {
       marginRight: COMMENTS_MARGIN_WIDTH + COMMENTS_MARGIN_RIGHT + 24,
+      // Pin the left edge at the centered no-comments offset.
+      marginLeft: `max(0px, calc((100% - ${RESEARCH_DOC_EDITOR_MAX_WIDTH}px) / 2))`,
     },
   },
   commentsMargin: {

--- a/packages/lesswrong/components/research/DocumentPane.tsx
+++ b/packages/lesswrong/components/research/DocumentPane.tsx
@@ -105,7 +105,10 @@ const styles = defineStyles('DocumentPane', (theme: ThemeType) => ({
     // so it doesn't leak onto floating menus or popovers inside this wrap.
   },
   editorWrapWithComments: {
-    '& [contenteditable="true"]:not(.research-query-input-content):not(.research-chat-composer *)': {
+    // The rootComment guard keeps this off the margin-card reply composers,
+    // which portal inside this wrap and render exactly when threads are open;
+    // :where() for the same specificity-tie reason as in ContentStylesValues.
+    '& [contenteditable="true"]:not(.research-query-input-content):not(.research-chat-composer *):not(:where(.LexicalContentEditable-rootComment))': {
       marginRight: COMMENTS_MARGIN_WIDTH + COMMENTS_MARGIN_RIGHT + 24,
     },
   },

--- a/packages/lesswrong/components/research/lexical/ResearchCommentsMargin.tsx
+++ b/packages/lesswrong/components/research/lexical/ResearchCommentsMargin.tsx
@@ -131,14 +131,22 @@ const styles = defineStyles('ResearchCommentsMargin', (theme: ThemeType) => ({
     '--icon-size': '13px',
   },
   composerWrap: {
-    display: 'flex',
-    alignItems: 'flex-end',
-    gap: 4,
+    // Positioning context for the composer's absolutely-positioned send
+    // button — without it the button anchors to the card and lands on top
+    // of the resolve/delete actions.
+    position: 'relative',
     marginTop: 6,
     borderTop: `1px solid ${researchWarmAlpha(0.07)}`,
     paddingTop: 6,
     '& [contenteditable="true"]': {
       fontSize: 12.5,
+    },
+    '& > div': {
+      margin: '6px 0 0',
+    },
+    '& > button': {
+      right: 6,
+      top: 19,
     },
   },
 }));

--- a/packages/lesswrong/components/research/lexical/ResearchCommentsMargin.tsx
+++ b/packages/lesswrong/components/research/lexical/ResearchCommentsMargin.tsx
@@ -140,13 +140,22 @@ const styles = defineStyles('ResearchCommentsMargin', (theme: ThemeType) => ({
     paddingTop: 6,
     '& [contenteditable="true"]': {
       fontSize: 12.5,
+      background: researchWarmAlpha(0.04),
     },
     '& > div': {
       margin: '6px 0 0',
     },
+    // Neutralizes the Lexical Button padding locally (changing the shared
+    // Button or sendButton styles would move the panel/side-comment icons).
     '& > button': {
       right: 6,
       top: 19,
+      padding: 0,
+      width: 24,
+      height: 24,
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
     },
   },
 }));

--- a/packages/lesswrong/components/research/lexical/ResearchCommentsMargin.tsx
+++ b/packages/lesswrong/components/research/lexical/ResearchCommentsMargin.tsx
@@ -131,9 +131,6 @@ const styles = defineStyles('ResearchCommentsMargin', (theme: ThemeType) => ({
     '--icon-size': '13px',
   },
   composerWrap: {
-    // Positioning context for the composer's absolutely-positioned send
-    // button — without it the button anchors to the card and lands on top
-    // of the resolve/delete actions.
     position: 'relative',
     marginTop: 6,
     borderTop: `1px solid ${researchWarmAlpha(0.07)}`,
@@ -145,8 +142,6 @@ const styles = defineStyles('ResearchCommentsMargin', (theme: ThemeType) => ({
     '& > div': {
       margin: '6px 0 0',
     },
-    // Neutralizes the Lexical Button padding locally (changing the shared
-    // Button or sendButton styles would move the panel/side-comment icons).
     '& > button': {
       right: 6,
       top: 19,


### PR DESCRIPTION
## Summary
- **Cmd/Ctrl+Enter submits comments**: adds an `EnterSubmitPlugin` to the shared comment `PlainTextEditor`, wired into `CommentsComposer` (margin-card replies, comments panel, side comments) and `CommentInputBox` (new-thread box). Plain Enter still inserts a newline. A matching change landed in lightcone-commons (LessWrong2/lightcone-commons#151).
- **Fix the research margin-card reply composer**, which was broken two ways:
  - The send button anchored to the card (its `composerWrap` had no positioning context), landing at the card's top-right nearly on top of the resolve/delete actions. Now contained inside the composer, sitting in the reply field.
  - The reply editor inherited the research-document reading-column styles — `min-height: calc(100vh - header)`, 18px serif type, essay padding — because the margin cards portal inside the `ContentStyles` wrapper and matched its `[contenteditable="true"]` rules. The comment-variant editor/placeholder are now excluded via the same stable-class `:not()` guard pattern already used for the query input and chat composer. The guards are wrapped in `:where()` so they stay specificity-neutral — a bare `:not()` raised these rules above the `editorWrapWithComments` margin override (which wins a same-specificity tie by source order) and re-centered the column while threads were open. The margin override also gains the same guard so it stays off the card composers.
- **Opening the first comment thread no longer slides the column sideways**: `editorWrapWithComments` previously added only `margin-right`, letting the auto left margin re-resolve and move the column by `(1504 − paneWidth)/2` px. `margin-left` is now pinned at the centered no-comments offset (via a new shared `RESEARCH_DOC_EDITOR_MAX_WIDTH` constant), so the comments margin comes out of free right-hand space first and the column narrows from its right edge only under genuine contention. Counterpart to LessWrong2/lightcone-commons#152.

## Test plan
- `yarn tsc` clean apart from the pre-existing `.next/types/routes` generated-file errors (absent in a fresh clone)
- The identical Cmd+Enter change was E2E-verified in the lightcone-commons app; the lightcone-commons layout counterpart was verified by Playwright rect measurement (0px left-edge delta before/after the first comment at 1900px and 1500px viewports)
- Worth a visual pass on a research doc with threads open: compact reply composer with the send icon inside the field and clickable; collapsing the left sidebar should not move the text (matches production); creating the first comment should not move the text

🤖 Generated with [Claude Code](https://claude.com/claude-code)