### PR TITLE
Keep the research doc column pinned when the first margin comment opens

### DIFF
--- a/packages/lesswrong/components/research/DocumentPane.tsx
+++ b/packages/lesswrong/components/research/DocumentPane.tsx
@@ -110,6 +110,12 @@ const styles = defineStyles('DocumentPane', (theme: ThemeType) => ({
     // :where() for the same specificity-tie reason as in ContentStylesValues.
     '& [contenteditable="true"]:not(.research-query-input-content):not(.research-chat-composer *):not(:where(.LexicalContentEditable-rootComment))': {
       marginRight: COMMENTS_MARGIN_WIDTH + COMMENTS_MARGIN_RIGHT + 24,
+      // Pin the left edge at the centered no-comments offset (824px is the
+      // contenteditable's maxWidth from researchDocumentBodyStyles) so the
+      // first open thread never slides the column sideways: the comments
+      // margin comes out of free right-hand space first, and the column
+      // narrows from its right edge only under genuine space contention.
+      marginLeft: 'max(0px, calc((100% - 824px) / 2))',
     },
   },
   commentsMargin: {


### PR DESCRIPTION
## Summary
- Opening the first comment thread on a research document adds `margin-right` to the centered contenteditable; the auto left margin then re-resolves and the whole column slides sideways by `(1504 − paneWidth)/2` px — left on panes narrower than ~1500px, right on wider ones. (At a ~1500px doc pane, e.g. a 16" MBP with no chat pane, the slide happens to be ≈0, which masks the bug.)
- Fix: pin `margin-left` at exactly the centered no-comments offset (`max(0px, calc((100% − 824px)/2))`, 824px matching the contenteditable's maxWidth). The comments margin now comes out of free right-hand space first; under genuine contention the column narrows from its right edge and rewraps in place — the left edge never moves.
- Counterpart to LessWrong2/lightcone-commons#152, which applies the same left-edge-pinning treatment to the equivalent (differently-implemented) layout there.

## Test plan
- `yarn tsc` clean apart from the pre-existing `.next/types/routes` generated-file errors
- The lightcone-commons counterpart was verified by Playwright measurement of the column rect before/after creating the first comment (0px left-edge delta at both 1900px and 1500px viewports); this FM change follows the same geometry but wasn't exercised live in this environment — worth a quick check that creating the first inline comment no longer moves the text at a narrow pane width (e.g. with the chat pane open)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1217140636862084) by [Unito](https://www.unito.io)
