### PR TITLE
Fix typeahead menu and floating toolbar positioning in short editors

### DIFF
--- a/packages/lesswrong/components/lexical/utils/setFloatingElemPosition.ts
+++ b/packages/lesswrong/components/lexical/utils/setFloatingElemPosition.ts
@@ -51,11 +51,17 @@ export function setFloatingElemPosition(
   }
 
   if (top < editorScrollerRect.top) {
-    // adjusted height for link element if the element is at top
-    top +=
+    const below =
+      top +
       floatingElemRect.height +
       targetRect.height +
       (verticalGap * (isLink ? 9 : 2));
+    // Small editors (chat composers) sit near the viewport bottom, where
+    // falling below the selection pushes the toolbar off-screen — keep the
+    // above position in that case even though it escapes the scroller.
+    if (below + floatingElemRect.height <= window.innerHeight || top < 0) {
+      top = below;
+    }
   }
 
   if (left + floatingElemRect.width > editorScrollerRect.right) {

--- a/packages/lesswrong/lib/vendor/lexical-react/shared/LexicalMenu.tsx
+++ b/packages/lesswrong/lib/vendor/lexical-react/shared/LexicalMenu.tsx
@@ -652,10 +652,14 @@ export function useMenuAnchorRef(
             rootElementRect.right - menuWidth + window.pageXOffset
           }px`;
         }
+        // Flip above when the menu would overflow downward and fits above the
+        // caret within the VIEWPORT. (Upstream required room above within the
+        // editor root element, which never holds for short editors like chat
+        // composers — the menu ran off the bottom of the screen.)
         if (
           (top + menuHeight > window.innerHeight ||
             top + menuHeight > rootElementRect.bottom) &&
-          top - rootElementRect.top > menuHeight + height
+          top - menuHeight - height > 0
         ) {
           containerDiv.style.top = `${
             top -
@@ -686,12 +690,20 @@ export function useMenuAnchorRef(
     if (resolution !== null) {
       positionMenu();
     }
+    // The menu's content can render or change size after positioning (options
+    // fetched async, list filtered while typing) — reposition when it does,
+    // or the overflow flip above runs against a stale/empty menu rect.
+    const containerDiv = anchorElementRef.current;
+    let contentObserver: MutationObserver | null = null;
+    if (resolution !== null && containerDiv !== null) {
+      contentObserver = new MutationObserver(() => positionMenu());
+      contentObserver.observe(containerDiv, {childList: true, subtree: true});
+    }
     return () => {
+      contentObserver?.disconnect();
       if (rootElement !== null) {
         rootElement.removeAttribute('aria-controls');
       }
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-      const containerDiv = anchorElementRef.current;
       if (containerDiv !== null && containerDiv.isConnected) {
         containerDiv.remove();
         containerDiv.removeAttribute('id');


### PR DESCRIPTION
## Summary
- **Mention/typeahead menus rendered off-screen in short editors**: the vendored `LexicalMenu` only flipped the menu above the caret when there was room above it *within the editor root element* — which never holds for a chat-composer-sized editor sitting at the viewport bottom, so the research chat composer's mention dropdown flowed downward off-screen (a couple of entries visible at best). The flip now checks viewport room, and the menu repositions when its content changes size (options fetched async / filtered while typing), since positioning previously ran only against the initial — possibly empty — menu rect.
- **`setFloatingElemPosition` had the same blind spot** for the selection format toolbar: whenever the above position escaped the scroller it fell below the selection, which is off-screen for bottom-anchored editors. It now keeps the above position when below would overflow the viewport.

Backport of the positioning half of LessWrong2/lightcone-commons#157 — both files are shared verbatim between the codebases.

## Test plan
- `yarn tsc` clean apart from the pre-existing `.next/types/routes` generated-file errors
- Verified live in lightcone-commons (identical files): `@` in the bottom-anchored chat composer now shows the full 8-option menu flipped above the caret instead of ~2 cut-off entries, and the selection toolbar renders fully above the composer; document-editor typeahead and toolbar behavior regression-checked
- Worth a quick FM visual check: `@` in the research chat pane composer, and text selection there

🤖 Generated with [Claude Code](https://claude.com/claude-code)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1217145018770334) by [Unito](https://www.unito.io)
