### PR TITLE
Escape trailing inline code via ArrowRight (selection-format clear)

### DIFF
--- a/packages/lesswrong/components/editor/lexicalPlugins/inlineCodeEscape/index.tsx
+++ b/packages/lesswrong/components/editor/lexicalPlugins/inlineCodeEscape/index.tsx
@@ -1,0 +1,52 @@
+import { useEffect } from 'react';
+import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext';
+import {
+  $createTextNode,
+  $getSelection,
+  $isRangeSelection,
+  $isTextNode,
+  COMMAND_PRIORITY_LOW,
+  KEY_ARROW_RIGHT_COMMAND,
+} from 'lexical';
+
+/**
+ * Escape hatch for inline code at the end of a block. With the caret at the
+ * right edge of a code-format text node and nothing after it, the selection
+ * keeps the code format, every keystroke extends the code, and ArrowRight has
+ * nowhere to move — the format is inescapable. Match Slack: ArrowRight at
+ * that boundary inserts an unformatted space after the code.
+ */
+export default function InlineCodeEscapePlugin({
+  disabled = false,
+}: {
+  disabled?: boolean;
+}): null {
+  const [editor] = useLexicalComposerContext();
+
+  useEffect(() => {
+    if (disabled) return;
+    return editor.registerCommand(
+      KEY_ARROW_RIGHT_COMMAND,
+      (event) => {
+        if (!editor.isEditable()) return false;
+        if (event.shiftKey || event.metaKey || event.ctrlKey || event.altKey) return false;
+        const selection = $getSelection();
+        if (!$isRangeSelection(selection) || !selection.isCollapsed()) return false;
+        const anchor = selection.anchor;
+        if (anchor.type !== 'text') return false;
+        const node = anchor.getNode();
+        if (!$isTextNode(node) || !node.hasFormat('code')) return false;
+        if (anchor.offset !== node.getTextContentSize()) return false;
+        if (node.getNextSibling() !== null) return false;
+        event.preventDefault();
+        const spacer = $createTextNode(' ');
+        node.insertAfter(spacer);
+        spacer.select(1, 1);
+        return true;
+      },
+      COMMAND_PRIORITY_LOW,
+    );
+  }, [editor, disabled]);
+
+  return null;
+}

--- a/packages/lesswrong/components/editor/lexicalPlugins/inlineCodeEscape/index.tsx
+++ b/packages/lesswrong/components/editor/lexicalPlugins/inlineCodeEscape/index.tsx
@@ -1,7 +1,6 @@
 import { useEffect } from 'react';
 import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext';
 import {
-  $createTextNode,
   $getSelection,
   $isRangeSelection,
   $isTextNode,
@@ -10,21 +9,20 @@ import {
 } from 'lexical';
 
 /**
- * Escape hatch for inline code at the end of a block. With the caret at the
- * right edge of a code-format text node and nothing after it, the selection
- * keeps the code format, every keystroke extends the code, and ArrowRight has
- * nowhere to move — the format is inescapable. Match Slack: ArrowRight at
- * that boundary inserts an unformatted space after the code.
+ * Escape hatch for inline code at the end of the document. With the caret at
+ * the right edge of a trailing code-format text node, the selection keeps the
+ * code format, every keystroke extends the code, and ArrowRight has nowhere
+ * to move — the format is inescapable. ArrowRight at that boundary clears the
+ * code bit from the selection, so subsequent typing is unformatted. A
+ * selection-only change: it works identically in suggesting mode (suggested
+ * text takes the selection's format) and leaves no undo entry. When another
+ * block follows, ArrowRight navigates into it natively instead (Slack's
+ * behavior), so the escape must not fire.
  */
-export default function InlineCodeEscapePlugin({
-  disabled = false,
-}: {
-  disabled?: boolean;
-}): null {
+export default function InlineCodeEscapePlugin(): null {
   const [editor] = useLexicalComposerContext();
 
   useEffect(() => {
-    if (disabled) return;
     return editor.registerCommand(
       KEY_ARROW_RIGHT_COMMAND,
       (event) => {
@@ -32,21 +30,22 @@ export default function InlineCodeEscapePlugin({
         if (event.shiftKey || event.metaKey || event.ctrlKey || event.altKey) return false;
         const selection = $getSelection();
         if (!$isRangeSelection(selection) || !selection.isCollapsed()) return false;
+        if (!selection.hasFormat('code')) return false;
         const anchor = selection.anchor;
         if (anchor.type !== 'text') return false;
         const node = anchor.getNode();
         if (!$isTextNode(node) || !node.hasFormat('code')) return false;
         if (anchor.offset !== node.getTextContentSize()) return false;
-        if (node.getTopLevelElementOrThrow().getLastDescendant()?.getKey() !== node.getKey()) return false;
+        const block = node.getTopLevelElementOrThrow();
+        if (block.getLastDescendant()?.getKey() !== node.getKey()) return false;
+        if (block.getNextSibling() !== null) return false;
         event.preventDefault();
-        const spacer = $createTextNode(' ');
-        node.insertAfter(spacer);
-        spacer.select(1, 1);
+        selection.toggleFormat('code');
         return true;
       },
       COMMAND_PRIORITY_LOW,
     );
-  }, [editor, disabled]);
+  }, [editor]);
 
   return null;
 }

--- a/packages/lesswrong/components/editor/lexicalPlugins/inlineCodeEscape/index.tsx
+++ b/packages/lesswrong/components/editor/lexicalPlugins/inlineCodeEscape/index.tsx
@@ -37,7 +37,7 @@ export default function InlineCodeEscapePlugin({
         const node = anchor.getNode();
         if (!$isTextNode(node) || !node.hasFormat('code')) return false;
         if (anchor.offset !== node.getTextContentSize()) return false;
-        if (node.getNextSibling() !== null) return false;
+        if (node.getTopLevelElementOrThrow().getLastDescendant()?.getKey() !== node.getKey()) return false;
         event.preventDefault();
         const spacer = $createTextNode(' ');
         node.insertAfter(spacer);

--- a/packages/lesswrong/components/editor/lexicalPlugins/suggestedEdits/SuggestionModePlugin.tsx
+++ b/packages/lesswrong/components/editor/lexicalPlugins/suggestedEdits/SuggestionModePlugin.tsx
@@ -16,6 +16,7 @@ import {
   FORMAT_TEXT_COMMAND,
   INDENT_CONTENT_COMMAND,
   INSERT_TAB_COMMAND,
+  KEY_ARROW_RIGHT_COMMAND,
   KEY_BACKSPACE_COMMAND,
   KEY_DELETE_COMMAND,
   KEY_DOWN_COMMAND,
@@ -46,7 +47,7 @@ import { accessLevelCan } from '@/lib/collections/posts/collabEditingPermissions
 import { randomId } from '@/lib/random'
 import { $acceptSuggestion } from './acceptSuggestion'
 import { $rejectSuggestion } from './rejectSuggestion'
-import { $handleBeforeInputEvent, $handleDeleteInputType, $handleInsertParagraph, $handleInsertParagraphOnEmptyListItem } from './handleBeforeInputEvent'
+import { $handleBeforeInputEvent, $handleDeleteInputType, $handleInlineCodeEscapeArrowRight, $handleInsertParagraph, $handleInsertParagraphOnEmptyListItem } from './handleBeforeInputEvent'
 import { $formatTextAsSuggestion } from './formatTextAsSuggestion'
 import { ConsoleLogger } from '@/lib/vendor/proton/logger'
 import { $selectionInsertClipboardNodes } from './selectionInsertClipboardNodes'
@@ -690,6 +691,20 @@ export function SuggestionModePlugin({
         BEFOREINPUT_EVENT_COMMAND,
         (event) => {
           return $handleBeforeInputEvent(editor, event, addCreatedIDtoSet, suggestionModeLogger, createNotification)
+        },
+        COMMAND_PRIORITY_CRITICAL,
+      ),
+      editor.registerCommand(
+        KEY_ARROW_RIGHT_COMMAND,
+        (event) => {
+          if (event.shiftKey || event.metaKey || event.ctrlKey || event.altKey) {
+            return false
+          }
+          const handled = $handleInlineCodeEscapeArrowRight(addCreatedIDtoSet)
+          if (handled) {
+            event.preventDefault()
+          }
+          return handled
         },
         COMMAND_PRIORITY_CRITICAL,
       ),

--- a/packages/lesswrong/components/editor/lexicalPlugins/suggestedEdits/SuggestionModePlugin.tsx
+++ b/packages/lesswrong/components/editor/lexicalPlugins/suggestedEdits/SuggestionModePlugin.tsx
@@ -16,7 +16,6 @@ import {
   FORMAT_TEXT_COMMAND,
   INDENT_CONTENT_COMMAND,
   INSERT_TAB_COMMAND,
-  KEY_ARROW_RIGHT_COMMAND,
   KEY_BACKSPACE_COMMAND,
   KEY_DELETE_COMMAND,
   KEY_DOWN_COMMAND,
@@ -47,7 +46,7 @@ import { accessLevelCan } from '@/lib/collections/posts/collabEditingPermissions
 import { randomId } from '@/lib/random'
 import { $acceptSuggestion } from './acceptSuggestion'
 import { $rejectSuggestion } from './rejectSuggestion'
-import { $handleBeforeInputEvent, $handleDeleteInputType, $handleInlineCodeEscapeArrowRight, $handleInsertParagraph, $handleInsertParagraphOnEmptyListItem } from './handleBeforeInputEvent'
+import { $handleBeforeInputEvent, $handleDeleteInputType, $handleInsertParagraph, $handleInsertParagraphOnEmptyListItem } from './handleBeforeInputEvent'
 import { $formatTextAsSuggestion } from './formatTextAsSuggestion'
 import { ConsoleLogger } from '@/lib/vendor/proton/logger'
 import { $selectionInsertClipboardNodes } from './selectionInsertClipboardNodes'
@@ -691,20 +690,6 @@ export function SuggestionModePlugin({
         BEFOREINPUT_EVENT_COMMAND,
         (event) => {
           return $handleBeforeInputEvent(editor, event, addCreatedIDtoSet, suggestionModeLogger, createNotification)
-        },
-        COMMAND_PRIORITY_CRITICAL,
-      ),
-      editor.registerCommand(
-        KEY_ARROW_RIGHT_COMMAND,
-        (event) => {
-          if (event.shiftKey || event.metaKey || event.ctrlKey || event.altKey) {
-            return false
-          }
-          const handled = $handleInlineCodeEscapeArrowRight(addCreatedIDtoSet)
-          if (handled) {
-            event.preventDefault()
-          }
-          return handled
         },
         COMMAND_PRIORITY_CRITICAL,
       ),

--- a/packages/lesswrong/components/editor/lexicalPlugins/suggestedEdits/handleBeforeInputEvent.ts
+++ b/packages/lesswrong/components/editor/lexicalPlugins/suggestedEdits/handleBeforeInputEvent.ts
@@ -535,43 +535,6 @@ function $canTextDataBeInsertedDirectlyIntoSuggestion(suggestion: ProtonNode | n
   return false
 }
 
-/**
- * ArrowRight twin of the `shouldExitInlineCode` branch below: with the caret
- * at the right edge of an inline-code text node and nothing after it in the
- * block, insert an unformatted space after the code as a tracked insert
- * suggestion (or as plain text when already inside one).
- */
-export function $handleInlineCodeEscapeArrowRight(onSuggestionCreation: (id: string) => void): boolean {
-  const selection = $getSelection()
-  if (!$isRangeSelection(selection) || !selection.isCollapsed()) {
-    return false
-  }
-  const focusNode = selection.focus.getNode()
-  if (!$isTextNode(focusNode) || !focusNode.hasFormat('code')) {
-    return false
-  }
-  if (selection.focus.offset !== focusNode.getTextContentSize()) {
-    return false
-  }
-  if (focusNode.getTopLevelElementOrThrow().getLastDescendant()?.getKey() !== focusNode.getKey()) {
-    return false
-  }
-  const existingParentSuggestion = $findMatchingParent(focusNode, $isSuggestionNode)
-  const isInsideExistingInsertSuggestion =
-    existingParentSuggestion && existingParentSuggestion.getSuggestionTypeOrThrow() === 'insert'
-  const textNode = $createTextNode(' ')
-  const suggestionID = randomId()
-  const node = isInsideExistingInsertSuggestion
-    ? textNode
-    : $createSuggestionNode(suggestionID, 'insert').append(textNode)
-  focusNode.insertAfter(node)
-  node.selectEnd()
-  if (!isInsideExistingInsertSuggestion) {
-    onSuggestionCreation(suggestionID)
-  }
-  return true
-}
-
 function $handleInsertTextData(
   data: string,
   selection: RangeSelection,
@@ -684,11 +647,19 @@ function $handleInsertTextData(
   const shouldExitInlineCode = isAtEndOfInlineCode && data === ' '
   if (shouldExitInlineCode) {
     const textNode = $createTextNode(data)
-    const node = isInsideExistingInsertSuggestion
-      ? textNode
-      : $createSuggestionNode(suggestionID, 'insert').append(textNode)
-    focusNode.insertAfter(node)
-    node.selectEnd()
+    if (isInsideExistingInsertSuggestion) {
+      focusNode.insertAfter(textNode)
+      textNode.selectEnd()
+      return true
+    }
+    const suggestionNode = $createSuggestionNode(suggestionID, 'insert')
+    suggestionNode.append(textNode)
+    // After the enclosing suggestion wrapper, if any — nesting the insert
+    // inside e.g. a delete suggestion puts the new content inside the deleted
+    // region, where accepting the delete destroys it.
+    ;(existingParentSuggestion ?? focusNode).insertAfter(suggestionNode)
+    suggestionNode.selectEnd()
+    onSuggestionCreation(suggestionID)
     return true
   }
 

--- a/packages/lesswrong/components/editor/lexicalPlugins/suggestedEdits/handleBeforeInputEvent.ts
+++ b/packages/lesswrong/components/editor/lexicalPlugins/suggestedEdits/handleBeforeInputEvent.ts
@@ -535,6 +535,43 @@ function $canTextDataBeInsertedDirectlyIntoSuggestion(suggestion: ProtonNode | n
   return false
 }
 
+/**
+ * ArrowRight twin of the `shouldExitInlineCode` branch below: with the caret
+ * at the right edge of an inline-code text node and nothing after it in the
+ * block, insert an unformatted space after the code as a tracked insert
+ * suggestion (or as plain text when already inside one).
+ */
+export function $handleInlineCodeEscapeArrowRight(onSuggestionCreation: (id: string) => void): boolean {
+  const selection = $getSelection()
+  if (!$isRangeSelection(selection) || !selection.isCollapsed()) {
+    return false
+  }
+  const focusNode = selection.focus.getNode()
+  if (!$isTextNode(focusNode) || !focusNode.hasFormat('code')) {
+    return false
+  }
+  if (selection.focus.offset !== focusNode.getTextContentSize()) {
+    return false
+  }
+  if (focusNode.getTopLevelElementOrThrow().getLastDescendant()?.getKey() !== focusNode.getKey()) {
+    return false
+  }
+  const existingParentSuggestion = $findMatchingParent(focusNode, $isSuggestionNode)
+  const isInsideExistingInsertSuggestion =
+    existingParentSuggestion && existingParentSuggestion.getSuggestionTypeOrThrow() === 'insert'
+  const textNode = $createTextNode(' ')
+  const suggestionID = randomId()
+  const node = isInsideExistingInsertSuggestion
+    ? textNode
+    : $createSuggestionNode(suggestionID, 'insert').append(textNode)
+  focusNode.insertAfter(node)
+  node.selectEnd()
+  if (!isInsideExistingInsertSuggestion) {
+    onSuggestionCreation(suggestionID)
+  }
+  return true
+}
+
 function $handleInsertTextData(
   data: string,
   selection: RangeSelection,

--- a/packages/lesswrong/components/lexical/Editor.tsx
+++ b/packages/lesswrong/components/lexical/Editor.tsx
@@ -986,7 +986,7 @@ export default function Editor({
             <ClickableLinkPlugin disabled={isEditable} />
             <HorizontalRulePlugin />
             <HorizontalRuleEnterPlugin />
-            <InlineCodeEscapePlugin disabled={isSuggestionMode} />
+            <InlineCodeEscapePlugin />
             <BlockCursorNavigationPlugin />
             <MathPlugin />
             {/* <ExcalidrawPlugin /> */}

--- a/packages/lesswrong/components/lexical/Editor.tsx
+++ b/packages/lesswrong/components/lexical/Editor.tsx
@@ -128,6 +128,7 @@ import BlockCursorNavigationPlugin from '../editor/lexicalPlugins/blockCursorNav
 import { SideCommentsPlugin } from '../editor/lexicalPlugins/sideComments/SideCommentsPlugin';
 import { useLexicalEditorContext } from '../editor/LexicalEditorContext';
 import HorizontalRuleEnterPlugin from '../editor/lexicalPlugins/horizontalRuleEnter';
+import InlineCodeEscapePlugin from '../editor/lexicalPlugins/inlineCodeEscape';
 import {
   preprocessHtmlForImport,
   restoreInternalIds,
@@ -985,6 +986,7 @@ export default function Editor({
             <ClickableLinkPlugin disabled={isEditable} />
             <HorizontalRulePlugin />
             <HorizontalRuleEnterPlugin />
+            <InlineCodeEscapePlugin disabled={isSuggestionMode} />
             <BlockCursorNavigationPlugin />
             <MathPlugin />
             {/* <ExcalidrawPlugin /> */}


### PR DESCRIPTION
## Summary
- With the caret at the right edge of an inline-code text node at the very end of the document, the selection keeps the code format — every keystroke extends the code and ArrowRight is a no-op, making the format inescapable. (The state arises whenever the caret reaches the boundary from inside the code run; other caret paths happen to reset the selection format, which is why the bug feels intermittent.)
- New `InlineCodeEscapePlugin`: ArrowRight at that boundary clears the code bit from the collapsed selection, so subsequent typing is unformatted. Selection-only — no content mutation, no undo entry, and it works identically in suggesting mode (Proton applies `selection.format` to suggested text), so no suggest-mode routing is needed. When another block follows, ArrowRight navigates into it natively (Slack's behavior) and the escape does not fire.
- Fixes two pre-existing defects in Proton's typed-space escape branch (`shouldExitInlineCode`): the new insert suggestion nested **inside** the enclosing suggestion wrapper — accepting an enclosing delete-suggestion silently destroyed the user's pending insertion — and the created suggestion never registered via `onSuggestionCreation`, so it never got a thread. Inserts now land after the enclosing wrapper and register properly.

Counterpart to LessWrong2/lightcone-commons#158 (identical logic; all behaviors E2E-verified there against the shared vendored code).

## Test plan
- `yarn tsc` clean apart from the pre-existing `.next/types/routes` generated-file errors
- E2E-verified in lightcone-commons: document-end boundary ArrowRight then typing produces plain text (edit mode) / a plain tracked insert suggestion with its thread (suggesting mode); mid-document boundary ArrowRight navigates to the next block with zero mutation; typed-space escape inside a delete-suggestion lands outside the wrapper and survives the delete being accepted