### PR TITLE
Fold rejection into the moderation sidebar's message composer

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,6 @@
+[mcp_servers.playwright]
+command = "npx"
+args = [
+    "-y",
+    "@playwright/mcp@latest",
+]

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,6 +1,0 @@
-[mcp_servers.playwright]
-command = "npx"
-args = [
-    "-y",
-    "@playwright/mcp@latest",
-]

--- a/.gitignore
+++ b/.gitignore
@@ -139,3 +139,7 @@ acxMeetupImports/
 
 # Claude Code
 .claude
+.env*
+
+# Local ML rejection-model experiments (large data dumps and model binaries)
+ml-rejection/

--- a/.gitignore
+++ b/.gitignore
@@ -140,6 +140,3 @@ acxMeetupImports/
 # Claude Code
 .claude
 .env*
-
-# Local ML rejection-model experiments (large data dumps and model binaries)
-ml-rejection/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,562 @@
+# AGENTS.md: ForumMagnum Codebase Patterns
+
+This document explains some of the non-standard patterns, conventions, and abstractions used in the ForumMagnum codebase. ForumMagnum is a large web application built on NextJS with Apollo GraphQL and PostgreSQL, which is used to run LessWrong and the Alignment Forum.  (A pre-NextJS fork of the codebase runs the EA Forum.  Work on this codebase does not need to worry about accommodating forums other than LW and AF.) You should use that context to inform your understanding of what features are likely to exist, of the likely relationships between different abstractions, etc.
+
+This document is not comprehensive.  When working on larger features or changes, look for several examples of similar types of code in the codebase to get a sense for the patterns, conventions, and coding style that are not fully described in this document.  Please always read those files yourself, rather than delegating to a subagent.  Here are some "types of code" of the kind that bear looking at previous examples:
+- React components
+- GraphQL query and mutation resolvers
+- API routes
+- Database migrations
+
+One thing to keep in mind is that the codebase has evolved over time, and often has more than one pattern or convention in it for any particular thing.  If the preferred pattern for that concern isn't specified in this document, prefer the more modern one.  If it's not obvious which one is more modern, you can try checking git blame, or pausing and asking the developer.
+
+Do not use deprecated fields or functions defined this codebase, even if existing code uses them in similar contexts.  In almost all such cases, there exist non-deprecated alternatives.  If you can't find an non-deprecated alternative, feel free to write your own but always explicitly leave a TODO comment indicating the developer should review this and flag it for the developer.
+
+Reminder: after you finish making changes, go over them again to check whether any of them violated the style guide, and fix those violations if so.
+
+## Path aliasing
+
+By default, "@/*": ["./packages/lesswrong/*"].
+We also have some aliasing for stub imports in tsconfig-server.json and tsconfig-client.json, which shouldn't come up much.
+In the rest of this file, when referring to filenames, you can assume that `@` should be substitute for with `packages/lesswrong`.
+
+## Collections & Schemas
+
+Collections are our abstraction over database tables and GraphQL types. Each collection has a schema that defines a database table. Most (but not all) collections have associated GraphQL types and interfaces.
+
+Collections must have:
+- Schema definitions: `@/lib/collections/{collectionName}/newSchema.ts`
+- Collection registration: `@/server/collections/{collectionName}/collection.ts`
+- A usage in `@/server/collections/allCollections.ts`
+- A usage in `@/lib/schema/allSchemas.ts`
+
+Collections may have:
+- GraphQL queries: `@/server/collections/{collectionName}/queries.ts`
+- GraphQL mutations: `@/server/collections/{collectionName}/mutations.ts`
+- Fragments: `@/lib/collections/{collectionName}/fragments.ts`
+- Views: `@/lib/collections/{collectionName}/views.ts`
+
+Each field can have a `database` spec (for PostgreSQL) and/or `graphql` spec (for the GraphQL API). If a field has a `database` section but no `graphql` section, it is not accesible via the graphql API. If a field has a graphql section but no database section, it must have a `resolver` function.
+
+Database fields are typed with PostgreSQL types (`VARCHAR(27)`, `TEXT`, `BOOL`, `JSONB`, `TIMESTAMPTZ`, etc.)
+GraphQL fields include permissions (`canRead`, `canUpdate`, `canCreate`) and optional resolvers
+Custom resolvers can be defined inline for computed fields
+
+### Example: Adding a Field with Custom Resolver
+
+```typescript
+// In @/lib/collections/posts/newSchema.ts
+
+const schema = {
+  // ... existing fields ...
+  
+  // Simple field with database storage and GraphQL exposure
+  viewCount: {
+    database: {
+      type: "INTEGER",
+      defaultValue: 0,
+      nullable: false,
+    },
+    graphql: {
+      // `outputType` can only be required if `canRead` includes `guests`.  Otherwise, it must be nullable.
+      outputType: "Int!",
+      // If `inputType` is not provided, it defaults to the value in `outputType`.
+      // Therefore, if `outputType` is required, but you want `inputType` to be nullable,
+      // you must manually specify it: `inputType: "Int"`.
+      canRead: ["guests"],
+      canUpdate: ["admins"],
+      canCreate: ["admins"],
+    },
+  },
+  
+  // Computed field with custom resolver (no database storage)
+  author: {
+    graphql: {
+      outputType: "User",
+      canRead: ["guests"],
+      // Regular resolver - runs in Node.js, can use loaders/context
+      resolver: async (post, args, context) => {
+        return await context.loaders.Users.load(post.userId);
+      },
+    },
+  },
+  
+  // Field with resolver
+  popularComments: {
+    graphql: {
+      outputType: "[Comment!]!",
+      canRead: ["guests"],
+      resolver: async (post, args, context) => {
+        return await context.Comments.find(
+          { postId: post._id, baseScore: { $gt: 10 } },
+          { sort: { baseScore: -1 }, limit: 5 }
+        ).fetch();
+      },
+    },
+  },
+} satisfies Record<string, CollectionFieldSpecification<"Posts">>;
+
+export default schema;
+```
+
+**See Also**:
+- `@/lib/types/schemaTypes.ts` - Type definitions for schema specifications
+- `@/lib/collections/{collectionName}/newSchema.ts` - A complete example schema
+- `@/server/collections/{collectionName}/queries.ts` - Example queries file
+- `@/server/collections/{collectionName}/mutations.ts` - Example mutation file
+
+---
+
+## Collection-Specific Queries & Views
+
+**Purpose**: Views are named, reusable query patterns for collections. They define common selectors, sorts, and limits that can be referenced by name in both server and client code.
+
+**Location**: `@/lib/collections/{collectionName}/views.ts`
+
+**Key Concepts**:
+- Views are defined as part of the GraphQL interface in `@/lib/collections/{collectionName}/queries.ts`, where each view has its own input type, all of which are then aggregated into a single "selector" type like `ChapterSelector`:
+```typescript
+input ChaptersSequenceChaptersInput {
+  sequenceId: String
+  limit: String
+}
+
+input ChapterSelector {
+  default: EmptyViewInput
+  SequenceChapters: ChaptersSequenceChaptersInput
+}
+```
+- `EmptyViewInput` is a shared input type that is defined in `@/server/vulcan-lib/apollo-server/initGraphQL.ts` and doesn't need to be defined in the view file.  It should be used if a view doesn't have any parameters.
+- Views need to have corresponding view functions defined in `@/lib/collections/{collectionName}/views.ts` and added to the `CollectionViewSet` in that file.
+- Views are only used when using the "default" resolvers for a given collection (those returned `getDefaultResolvers`).  These are a "single" and "multi" resolver for the collection, which compile a GraphQL query into a SQL query and automatically handle permissions checks.
+- Importantly, if you write queries which are well-modeled by "fetch one" or "fetch many" with basic selector/sorting/limiting, you *should* use `getDefaultResolvers` to define those queries.  See `pacakges/lesswrong/server/collections/chapters/queries.ts` for an example of how it should be structured. (Do not implement deprecated fields.)
+  - Similarly, if you write mutations which are well-modeled as creating or updating a collection record, possibly with some additional associated business logic, you should follow the pattern in `packages/lesswrong/server/collections/chapters/mutations.ts`.  (But, similarly, do not use deprecated helper functions when implementing these for new collections.  Also avoid using `userCanDo` to check for permissions; in ~all cases it should be possible to check whether a user has permission by way of being an owner of the document, an admin, or a member of a group that's allowed to perform that action.)
+- If you need an access pattern that is not well-modeled by "fetch one" or "fetch many" with basic selector/sorting/limiting, you should write and use a custom query resolver.  By convention, we put these into `@/server/resolvers/{concept}Resolvers.ts`.  You will need to add them to the `initGraphQL.ts` file.  Don't forget about manually applying relevant permissions checks before returning results to users, if applicable.
+
+### Example: Defining and Using Views
+
+```typescript
+// In @/lib/collections/chapters/views.ts
+declare global {
+  interface ChaptersViewTerms extends ViewTermsBase {
+    view: ChaptersViewName
+    sequenceId?: string
+  }
+}
+
+function SequenceChapters(terms: ChaptersSequenceChaptersInput) {
+  return {
+    selector: { sequenceId: terms.sequenceId },
+    options: { sort: { number: 1, createdAt: 1 }, limit: terms.limit ?? 20 },
+  };
+};
+
+export const ChaptersViews = new CollectionViewSet('Chapters', {
+  SequenceChapters
+});
+
+
+// Usage in GraphQL (client-side):
+const ChaptersFragmentMultiQuery = gql(`
+  query multiChapterChaptersListQuery($selector: ChapterSelector, $limit: Int) {
+    chapters(selector: $selector, limit: $limit) {
+      results {
+        ...ChaptersFragment
+      }
+      totalCount
+    }
+  }
+`);
+// Then, later, inside of a component...
+const { data, loading } = useQuery(ChaptersFragmentMultiQuery, {
+  variables: {
+    selector: { SequenceChapters: { sequenceId } },
+    limit: 100,
+  },
+});
+
+```
+
+**See Also**:
+- `@/lib/collections/posts/views.ts` - Comprehensive examples of complex views
+
+---
+
+## Client-Side GraphQL Queries
+
+**Purpose**: Execute type-safe GraphQL queries from React components with proper TypeScript inference.
+
+**Key Concepts**:
+- MUST use `gql` from `@/lib/generated/gql-codegen` (NOT from `graphql-tag` or `@apollo/client`)
+- Use `useQuery` from `@/lib/crud/useQuery` (wrapper around a relatively complicated replacement for Apollo's useQuery, which otherwise has the same interface)
+- Run `yarn generate` after modifying schemas, database indexes, resolvers, GraphQL definitions, or fragments
+- Query results are fully typed based on the generated types.  Do not use `as any` or any other type casts to work around type errors that seem to be caused by missing generated types.
+- Style note: define queries at the top level of the component file they're used in, not nested inside the component function.  Exception: when the same query is used in multiple files, define it in a separate file.
+
+**Important Notes**:
+- Use fragments to share field selections across queries
+- Our `useQuery` wrapper handles SSR with Suspense automatically
+
+**See Also**:
+- `@/components/admin/CurationPage.tsx` - Real example of useQuery usage
+
+---
+
+
+## Client-Side GraphQL Mutations
+
+**Purpose**: Execute type-safe mutations from React components.
+
+**Key Concepts**:
+- Use `useMutation` from `@apollo/client/react` (standard Apollo hook)
+- Define mutations at the top level of the file, same as queries, using `gql` from `@/lib/generated/gql-codegen`
+- Mutations are fully typed with inference for variables and return types
+
+**See Also**:
+- `@/components/admin/CurationNoticesForm.tsx` - Example with both a "create" and "update" mutation
+
+---
+
+## Collection-Based Querying
+
+**Purpose**: Execute database queries from server-side code (resolvers, callbacks, scripts).
+
+**Key Concepts**:
+- For simple queries: use `Collection.find()` or `Collection.findOne()`
+- For complex queries: use collection-specific Repos with raw SQL
+- Queries use MongoDB-style selectors (translated to SQL automatically)
+- Use Repos when you need JOINs, CTEs, or complex SQL features
+
+### Example: Simple Collection Queries
+
+```typescript
+// Simple queries using Collection methods
+const recentPosts = await Posts.find({
+  draft: false,
+  postedAt: { $gt: new Date(Date.now() - 7 * 24 * 60 * 60 * 1000) }
+}, {
+  sort: { postedAt: -1 },
+  limit: 10,
+}).fetch();
+
+// Single document
+const post = await Posts.findOne({
+  slug: "my-post-slug",
+});
+```
+
+### Example: Complex Queries with Repos
+
+```typescript
+// In @/server/repos/PostsRepo.ts
+import AbstractRepo from "./AbstractRepo";
+import Posts from "@/server/collections/posts/collection";
+
+class PostsRepo extends AbstractRepo<"Posts"> {
+  constructor() {
+    super(Posts);
+  }
+  
+  // Query with parameters (use $(argName) syntax with a dictionary of args)
+  async getPostsByTag(tagId: string, minScore: number): Promise<DbPost[]> {
+    return this.any(`
+      -- PostsRepo.getPostsByTag
+      SELECT p.*
+      FROM "Posts" p
+      WHERE p."tagRelevance" ? $(tagId)
+      AND (p."tagRelevance"->$(tagId))::integer >= $(minScore)
+      AND p."draft" IS NOT TRUE
+      ORDER BY p."postedAt" DESC
+    `, { tagId, minScore });
+  }
+}
+
+// Usage in resolver:
+const taggedPosts = await context.repos.posts.getPostsByTag(tagId, 10);
+```
+
+**Important Notes**:
+- Repos inherit from `AbstractRepo` which provides `one()`, `many()`, `any()`, `oneOrNone()`, etc.
+- Use parameterized queries with named parameters (e.g. $startDate, $endDate) for clarity and to prevent SQL injection
+- Repos are available via `context.repos.{collectionName}` in GraphQL resolvers
+
+**See Also**:
+- `@/server/repos/PostsRepo.ts` - Many complex query examples
+- `@/server/sql/PgCollection.ts` - Collection query methods
+
+---
+
+
+## Collection-Based Writes
+
+**Purpose**: Insert and update records in the database from server-side code.
+
+**Key Concepts**:
+- **Raw methods** (`rawInsert`, `rawUpdateOne`, `rawUpdateMany`): Direct database operations, no side effects
+- **Mutation functions** (`createCollectionName`, `updateCollectionName`): Wrapped operations with validation, callbacks, denormalization, etc.
+- **By default, use mutation functions when they exist** - they handle important business logic.
+- Only use raw methods when you explicitly want to bypass all the associated logic
+
+### Example: Raw Database Operations
+
+```typescript
+// Direct insert - no callbacks, no validation, no denormalization
+const postId = await Posts.rawInsert({
+  title: "My Post",
+  userId: currentUser._id,
+  draft: true,
+  contents: null,
+  // Must provide all required fields
+});
+
+// Direct update - no callbacks
+await Posts.rawUpdateOne(
+  { _id: postId },
+  { $set: { draft: false, postedAt: new Date() } }
+);
+
+// Update many documents
+await Posts.rawUpdateMany(
+  { userId: authorId, draft: true },
+  { $set: { deletedDraft: true } }
+);
+```
+
+### Example: Using Mutation Functions (Preferred)
+
+```typescript
+// Usage in a resolver or server-side code:
+const newComment = await createComment({
+  data: {
+    postId: post._id,
+    contents: {
+      originalContents: {
+        type: "html",
+        data: "<p>My comment</p>"
+      }
+    },
+    parentCommentId: null,
+  }
+}, context);
+```
+
+**When to Use Which**:
+- **Use mutation functions** (createX/updateX) when:
+  - Creating/updating user-facing content (posts, comments, etc.)
+  - You need validation, notifications, or denormalization
+  - The document type has business rules or side effects
+  
+- **Use raw methods** when:
+  - Bulk data imports
+  - Migrations
+  - Internal/system updates
+  - You explicitly want to skip all business logic
+
+**See Also**:
+- `@/server/collections/comments/mutations.ts` - Examples of relatively involved create and update mutation functions
+
+---
+
+## Background Tasks
+
+In server-side code, it is not safe to `void` a promise because the serverless environment may halt a server process after the conclusion of the current request. If you run asynchronous server-side code where you don't wish `await` a result, wrap the promise in `backgroundTask(p)`. This guarantees that the server will not terminate before the promise resolves (other than during timeouts or severe crashes) by awaiting it from inside `next/server/after`.
+
+There are no other guarantees about the code inside the promise; it may start immediately, or may be deferred util a later stage of processing the request, or may start after the request has finished. On the client, `backgroundTask(p)` is equivalent to `void p`.
+
+Background tasks are typically used for mutations that do not affect the current request, such as updating search indexes, creating notifications, analytics, etc.
+
+Implementation: `@/server/utils/backgroundTask.ts`
+
+---
+
+## Code Generation
+
+**Purpose**: Generate TypeScript types, GraphQL schemas, and boilerplate code from collection definitions.
+
+**Key Commands**:
+- `yarn generate` - Run after ANY schema or GraphQL changes. Generates types and GraphQL artifacts.
+- `yarn create-collection PascalCasedPluralObjects` - Create a new collection with all boilerplate files.  This is a rare operation; only do this if you're creating a new collection from scratch.
+
+**What `yarn generate` does**:
+Generates TypeScript types for:
+1. GraphQL schemas, queries, mutations, and fragments
+2. Database schemas
+Also updates:
+1. The collectionTypeNames module
+2. The routeManifest module
+
+**When to run `yarn generate`**:
+- After adding a field to any schema file (`newSchema.ts`)
+- After modifying any GraphQL type definitions
+- After adding a new collection view
+- After creating a new custom GraphQL resolver
+- After adding new collections
+- After adding a new page.ts or route.ts under `app/`
+- Before running type checks or builds
+
+---
+
+## Migrations
+
+A migration is required for any change that modifies the database schema. Automatic migrations are at `@/server/migrations/yyyymmddThhmmss.migrationName.ts`; these are run automatically when a new version is deployed, inside a github action runner. Migrations are created from a template by running `yarn migrate create migrationName`. There are also "manual migrations", which are run manually by developers with `yarn repl`. Manual migrations are used when a migration performs operations that could time out if run inside a github action runner.
+
+Migrations are run before the new version is deployed, without downtime, so if a migration modifies the database schema it must be backwards-compatible with the immediately preceding deployment. Eg, if a new column is added it must have a default value, and if a column is deleted it must have already been unused. If a schema change can't be made backwards-compatible, this might require using a manual migration that will be run after deployment finishes, or splitting a PR into two stages that will be deployed separately.
+
+---
+
+## Scripts
+
+In the course of your work, you may occasionally decide (or be asked) to write and/or run scripts.  Despite being a NextJS codebase, we support running scripts that import arbitrary parts of the codebase via `yarn repl`.  If the script you're writing doesn't import any part of the codebase, then you don't need to use `yarn repl` - run it however you normally would.  If it does (for example, because it wants to talk to our database), then you should write it in the `packages/lesswrong/scripts/` directory and export the entrypoint function so that it can be invoked via the repl.  Default to running scripts against the dev db (via `yarn repl dev lw`) unless explicitly asked to do otherwise.
+
+---
+
+## Server and Client Code
+
+Files in app/ are React server components and route handlers.
+Files in @/components are mostly client components and are used on the client and during SSR. If a component is used directly from a page in app/, it should probably be a client component by default ("use client") at the top.  If a page benefits from having substantial server component functionality, that functionality should either be written in the page.tsx file itself, or in a component in the same directory as the page.tsx file.  Some components defined in @/components don't have the "use client" directive, mostly because they were written before the codebase was moved to NextJS.
+Files in @/server are server-side-only.
+Files in @/lib and @/themes are shared between client and server.
+If a server-only or client-only file is imported from the wrong context, and the import uses a path starting with @ like @/server or @/client, it will be redirected to a stub file in @/stubs. This allows shared code, eg in schema files, to import server-only code safely. Stub files typically export the same functions, but throw exceptions if you call any of them. In some cases the stub file may contain an implementation of the same functionality, but using browser APIs. If a file may have some of its imports redirected to stubs, it must typecheck both with and without the redirection.
+
+---
+
+## Fragments
+
+Fragments are reusable field selections that can be shared across queries. They're typically defined in `@/lib/collections/{collectionName}/fragments.ts`. Fragment names correspond to Typescript types with the same name, which are created by `yarn generate`. A fragment can be used inside any graphql query by writing `...FragmentName`. These are expanded at codegen time by `yarn generate`.
+Fragments can inherit from other fragments using `...ParentFragmentName`. 
+If a fragment corresponds to a database object, it must have (or inherit a fragment that has) an `_id` field to be stored correctly in the apollo-client cache.
+If a query will load many results or is on a performance-sensitive page such as the front page, try to use the smallest suitable fragment to minimize loading time. When adding a field to existing fragments, try to add it to the most specific suitable fragment, to avoid downloading that field on pages that do not need it.
+
+### Loading Patterns
+
+Collections are accessed via context in GraphQL resolvers:
+
+```typescript
+// In a GraphQL resolver
+async resolver(root, args, context: ResolverContext) {
+  const { Posts, Comments, currentUser } = context;
+  
+  // Collection findOne
+  const post = await Posts.findOne(args.postId);
+  // Collection find (many) with limit, sorting, and a projection to reduce bandwidth usage if you don't need most of the fields
+  const postIdsAndTitles = await Posts.find(
+    { userId: currentUser._id },
+    { limit: 10, sort: { postedAt: -1 } },
+    { _id: 1, title: 1 }
+  );
+  
+  // Repos for complex queries
+  const topPosts = await context.repos.posts.getTopPosts(10);
+  
+  // DataLoaders for batched loading (prevents N+1).
+  // Collection DataLoaders can only be used to look up collection records by their primary key (_id).
+  // Results are cached within the context of a single request, so if you update a record in the middle of a request
+  // and then fetch it with a DataLoader, it might be stale unless you explicitly cleared that DataLoader's cache.
+  const author = await context.loaders.Users.load(post.userId);
+  
+  return post;
+}
+```
+
+---
+
+## Permissions
+
+Permissions are checked at the GraphQL field level using the `canRead`, `canUpdate`, `canCreate` specifications in schemas. Important helper function:
+- `accessFilter{Single,Multiple}` - Used on the server to run both document-level and field-level access filters on one or multiple collection-shaped documents.  Important to use when defining a custom field `resolver` (automatically applied to the outputs of `sqlResolver` executions) or a custom query resolver that returns collection-shaped objects, or data derived from collection-shaped objects.
+
+Helper functions used on both the client and server:
+- `userIsAdmin(user)` - Check admin status
+- `userOwns(user, document)` - Check ownership
+
+---
+
+## Component Styling
+
+We use jss for styling.  Define styles like so:
+```typescript
+import { defineStyles, useStyles } from '@/components/hooks/useStyles';
+const styles = defineStyles('ComponentName', (theme: ThemeType) => {
+  root: {
+    width: '100%',
+    background: theme.palette.greyAlpha(0.1)
+  },
+});
+```
+
+Then, inside the component:
+```typescript
+const TestComponent = () => {
+  const classes = useStyles(styles);
+  return <div className={classes.root}>Foobar!</div>;
+};
+```
+If an element has multiple classes or conditional classes, combine them them with the `classNames` function.
+If a component needs HoCs or memoization applied, use `export default registerComponent("TestComponent", TestComponent, {})`, but only wrap components this way if an HoC or memoization is used.
+The registerComponent wrapper can take a {styles} option, in which case it calls defineStyles and useStyles in an HoC and passes the result as a prop named `classes`. This method is deprecated; when writing new components you should use `defineStyles` and `useStyles` directly.
+Do not use inline the `style` attribute on JSX elements for styling purposes unless you need to do something dynamic that would be deeply impractical to implement with jss classes.
+
+Colors are defined as part of the theme, as `theme.palette.colorName`; see `@/themes/defaultPalette.ts`. If you use a palette color, it will be automatically inverted in dark mode.  Whenever possible, prefer to use existing colors defined in our palette.  For greyscale, use the methods defined in `defaultShadePalette`:
+```
+  const greyAlpha = (alpha: number) => `rgba(0,0,0,${alpha})`;
+  const inverseGreyAlpha = (alpha: number) => `rgba(255,255,255,${alpha})`;
+  return {
+    // ...
+    greyAlpha,
+    inverseGreyAlpha,
+    boxShadowColor: (alpha: number) => greyAlpha(alpha),
+    greyBorder: (thickness: string, alpha: number) => `${thickness} solid ${greyAlpha(alpha)}`,
+```
+Those are available via `theme.palette`.
+
+If you for some reason need to use a color that does not come from the palette, use either `light-dark(lightModeColor,darkModeColor)`, or, if the component is used in an always-light or always-dark component so that it doesn't need to be inverted, add `allowNonThemeColors:true` as an option in the second argument of `defineStyles`.
+
+`theme.spacing.unit` is deprecated and has the value 8.
+
+---
+
+## Paths and Navigation
+
+Use `useLocation` if you need to get anything related to the current client-side location, i.e. pathname, query parameters, hash, etc.  This is the interface of the object it returns:
+```typescript
+export type RouterLocation = {
+  location: SegmentedUrl,
+  pathname: string,
+  url: string,
+  hash: string,
+  params: Record<string, string>,
+  query: Record<string, string>, // TODO: this should be Record<string,string|string[]>; any client-side code using this needs to be aware it might get an array.  That won't be the case 99% of the time, though.
+};
+```
+
+See `@/components/next/ClientAppGenerator.tsx` for more details about how the value returned by it is computed, if anything unusual comes up.
+
+Use `useNavigate` for performing client-side navigations.  You need to preserve all parts of the path that you don't want changed, i.e. just providing a hash will delete any query parameters if they aren't also provided.  See `@/lib/routeUtil.tsx` for more details if needed.
+
+## Editor
+
+The current default editor provided to users is our implementation of lexical.  Other supported editors are ckEditor (the previous default editor, now only supported for existing documents that were written in ckEditor), markdown, and html (admin-only).  We used to support DraftJS and no longer do, but some older documents may still be written in DraftJS (these are autoconverted to lexical when opened).  If working on editor features, assume lexical is the editor in question unless otherwise specified (or strongly suggested by the surrounding context).  We have a separate [AGENTS.md](packages/lesswrong/components/editor/AGENTS.md) with instructions for doing UI testing in the editor; read that if needed.
+
+## Subagent Guidance
+
+We are not token-constrained and do not need to save money.  As such, strongly prefer to use subagents of the same model family and version as you, even for basic exploration tasks, rather than using smaller/cheaper subagents.
+
+## Style / Conventions
+Never apply `as any` type casts, and try very hard to avoid any other type casts.  Consider whether you are applying a type cast because you've forgotten to run `yarn generate`.  If you absolutely must apply a type cast somewhere, always leave the following comment above it:
+```typescript
+// TODO: I AM AN INSTANCE OF ${MODEL_NAME} AND HAVE APPLIED A TYPE CAST HERE BECAUSE I COULDN'T MAKE IT WORK OTHERWISE, PLEASE FIX THIS
+```
+
+Never add new inline dynamic imports (i.e. `await import(...)` or `require(...)`).
+Strongly prefer to avoid writing classes to encapsulate functionality.  Write top-level functions and only export those that are meant to be used by other parts of the codebase.
+Strongly prefer to avoid declaring inline functions that capture scope; declare them at the top of the module and pass in all the necessary dependencies.  This does not include standard React component patterns like `useEffect` callbacks and defining event handlers inside of the component; those are fine.
+If you need to combine multiple classNames, use `import classNames from 'classnames';` rather than combining them via template string.
+Prefer interfaces to types where possible.
+Do not create barrel import/export files.
+Do not use `ReturnType<...>`.  Instead, check the return type of the relevant function and use that type directly (with an additional import, if necessary).
+If you have access to the typescript LSP, strongly prefer to use the tools it provides to check for type errors in files that you've changed while in the middle of coding, rather than using the project's top-level `yarn lint` or `yarn tsc` (which can take up to 30 seconds).  You should use the project-level command after finishing an entire feature, if you've made any changes to types/type signatures that might have been used from elsewhere in the codebase.
+Avoid using `npx [command]`, like `npx jest` or `npx tsc`, if there's an appropriate command in our package.json that seems like it's intended to perform the relevant function.  (In those two cases, it'll be `yarn unit [test-file-path]` and `yarn tsc`.)
+When asked to conduct a code review against `master`, ensure any diffs you perform are against `origin/master`, not against local `master`, which might be out of date.
+
+Reminder: after you finish making changes, go over them again to check whether any of them violated the style guide, and fix those violations if so.
+

--- a/packages/lesswrong/components/common/LWTooltip.tsx
+++ b/packages/lesswrong/components/common/LWTooltip.tsx
@@ -35,6 +35,8 @@ export type LWTooltipProps = {
   disabledOnMobile?: boolean,
   hideOnTouchScreens?: boolean,
   className?: string,
+  /** Distance in px between the anchor and the tooltip, along the placement axis */
+  distance?: number,
   analyticsProps?: AnalyticsProps,
   otherEventProps?: Record<string, Json | undefined>,
   titleClassName?: string
@@ -63,6 +65,7 @@ const LWTooltip = ({
   disabled=false,
   disabledOnMobile=false,
   hideOnTouchScreens=false,
+  distance,
   analyticsProps,
   otherEventProps,
   titleClassName,
@@ -140,6 +143,7 @@ const LWTooltip = ({
       anchorEl={anchorEl ?? defaultAnchorElRef.current}
       tooltip={tooltip}
       allowOverflow={!flip}
+      distance={distance}
       clickable={delayedClickable}
       hideOnTouchScreens={hideOnTouchScreens}
       className={popperClassName}

--- a/packages/lesswrong/components/editor/EditorFormComponent.tsx
+++ b/packages/lesswrong/components/editor/EditorFormComponent.tsx
@@ -54,6 +54,12 @@ interface EditorFormComponentProps<S, R> {
   revisionsHaveCommitMessages?: boolean;
   hasToc?: boolean;
   setFieldEditorType?: (editorType: EditorTypeString) => void;
+  /**
+   * Called on every editor change with whether the contents are blank. Unlike
+   * the form field value (which is only updated on a throttle), this fires
+   * immediately, so it's suitable for enabling/disabling a submit button.
+   */
+  onBlankStateChange?: (isBlank: boolean) => void;
   addOnSubmitCallback: (fn: EditorSubmitCallback) => () => void;
   addOnSuccessCallback: (fn: EditorSuccessCallback<R>) => () => void;
   getLocalStorageId?: (doc: any, name: string) => { id: string, verify: boolean }
@@ -117,6 +123,7 @@ function InnerEditorFormComponent<S, R>({
   revisionsHaveCommitMessages,
   hasToc,
   setFieldEditorType,
+  onBlankStateChange,
   addOnSubmitCallback,
   addOnSuccessCallback,
   getLocalStorageId,
@@ -256,6 +263,7 @@ function InnerEditorFormComponent<S, R>({
     // callback to improve performance. Note that the contents are always recalculated on
     // submit anyway, setting them here is only for the benefit of other form components (e.g. SocialPreviewUpload)
     setFieldEditorType?.(newContents?.type)
+    onBlankStateChange?.(isBlank(newContents))
     void throttledSetContentsValue(newContents)
     
     if (autosave) {

--- a/packages/lesswrong/components/editor/focusLexicalEditor.ts
+++ b/packages/lesswrong/components/editor/focusLexicalEditor.ts
@@ -1,3 +1,5 @@
+import type { KeyboardEvent as ReactKeyboardEvent } from 'react';
+
 export const focusLexicalEditor = (container: HTMLDivElement | null) => {
   if (!container) return;
   setTimeout(() => {
@@ -5,6 +7,29 @@ export const focusLexicalEditor = (container: HTMLDivElement | null) => {
       '[contenteditable="true"]'
     ) as HTMLElement | null;
     editorElement?.focus?.();
+  }, 0);
+};
+
+/**
+ * Focus an editor with the caret at the end of its contents. A plain
+ * `.focus()` leaves the caret wherever the browser puts it (usually the
+ * start), which is the wrong place when arriving from below the editor.
+ */
+export const focusLexicalEditorAtEnd = (container: HTMLDivElement | null) => {
+  if (!container) return;
+  setTimeout(() => {
+    const editorElement = container.querySelector(
+      '[contenteditable="true"]'
+    ) as HTMLElement | null;
+    if (!editorElement) return;
+    editorElement.focus();
+    const selection = window.getSelection();
+    if (!selection) return;
+    const range = document.createRange();
+    range.selectNodeContents(editorElement);
+    range.collapse(false);
+    selection.removeAllRanges();
+    selection.addRange(range);
   }, 0);
 };
 
@@ -36,4 +61,54 @@ export const focusLexicalEditorWhenReady = (container: HTMLDivElement | null) =>
 
   timeoutId = setTimeout(attemptFocus, 0);
   return () => clearTimeout(timeoutId);
+};
+
+/**
+ * For keydown listeners on a composer container in the supermod sidebar: a
+ * bare Escape blurs the editor instead of reaching the supermod shortcut
+ * handler on document, which would otherwise close the user detail view.
+ * Once the editor is blurred, ArrowUp/ArrowDown navigate the content list
+ * again. React's own listener is on document too, so only
+ * stopImmediatePropagation keeps the event from reaching it.
+ */
+export const blurEditorOnEscape = (event: ReactKeyboardEvent) => {
+  if (event.key !== 'Escape' || event.metaKey || event.ctrlKey || event.altKey || event.shiftKey) return;
+  event.preventDefault();
+  event.nativeEvent.stopImmediatePropagation();
+  if (document.activeElement instanceof HTMLElement) {
+    document.activeElement.blur();
+  }
+};
+
+/**
+ * For keydown listeners on an editor container: if the pressed key was a bare
+ * ArrowDown and the caret doesn't move as a result (i.e. it was already on the
+ * last line of the editor), call `onArrowDownPastEnd`. Whether the caret moved
+ * is checked on the next tick, after the browser's default caret movement, so
+ * wrapped lines inside a paragraph behave correctly.
+ */
+export const callOnArrowDownPastEditorEnd = (event: ReactKeyboardEvent, onArrowDownPastEnd: () => void) => {
+  if (event.key !== 'ArrowDown' || event.metaKey || event.ctrlKey || event.altKey || event.shiftKey) return;
+  if (!(event.target instanceof HTMLElement) || !event.target.isContentEditable) return;
+  // Deliberately no `event.defaultPrevented` check: Lexical's rich-text
+  // KEY_ARROW_DOWN_COMMAND handler preventDefaults exactly when the selection
+  // is at the end of the document (to keep the page from scrolling), which is
+  // precisely the state this helper is trying to detect. Typeahead popups
+  // (mentions, slash commands) also consume ArrowDown while navigating, but
+  // they call stopImmediatePropagation (see the vendored LexicalMenu), so
+  // those events never bubble to this handler in the first place.
+  const selection = window.getSelection();
+  if (!selection) return;
+  const { anchorNode, anchorOffset, focusNode, focusOffset } = selection;
+  setTimeout(() => {
+    const selectionAfter = window.getSelection();
+    if (!selectionAfter) return;
+    const caretDidNotMove = selectionAfter.anchorNode === anchorNode
+      && selectionAfter.anchorOffset === anchorOffset
+      && selectionAfter.focusNode === focusNode
+      && selectionAfter.focusOffset === focusOffset;
+    if (caretDidNotMove) {
+      onArrowDownPastEnd();
+    }
+  }, 0);
 };

--- a/packages/lesswrong/components/editor/focusLexicalEditor.ts
+++ b/packages/lesswrong/components/editor/focusLexicalEditor.ts
@@ -1,5 +1,8 @@
 import type { KeyboardEvent as ReactKeyboardEvent } from 'react';
 
+const FOCUS_RETRY_INTERVAL_MS = 50;
+const FOCUS_RETRY_ATTEMPTS = 20;
+
 export const focusLexicalEditor = (container: HTMLDivElement | null) => {
   if (!container) return;
   setTimeout(() => {
@@ -14,14 +17,23 @@ export const focusLexicalEditor = (container: HTMLDivElement | null) => {
  * Focus an editor with the caret at the end of its contents. A plain
  * `.focus()` leaves the caret wherever the browser puts it (usually the
  * start), which is the wrong place when arriving from below the editor.
+ * Retries briefly in case the editor is still mounting (dynamic import).
  */
 export const focusLexicalEditorAtEnd = (container: HTMLDivElement | null) => {
   if (!container) return;
-  setTimeout(() => {
+
+  let attemptsRemaining = FOCUS_RETRY_ATTEMPTS;
+
+  const attemptFocus = () => {
     const editorElement = container.querySelector(
       '[contenteditable="true"]'
     ) as HTMLElement | null;
-    if (!editorElement) return;
+    if (!editorElement) {
+      if (attemptsRemaining-- > 0) {
+        setTimeout(attemptFocus, FOCUS_RETRY_INTERVAL_MS);
+      }
+      return;
+    }
     editorElement.focus();
     const selection = window.getSelection();
     if (!selection) return;
@@ -30,11 +42,10 @@ export const focusLexicalEditorAtEnd = (container: HTMLDivElement | null) => {
     range.collapse(false);
     selection.removeAllRanges();
     selection.addRange(range);
-  }, 0);
-};
+  };
 
-const FOCUS_RETRY_INTERVAL_MS = 50;
-const FOCUS_RETRY_ATTEMPTS = 20;
+  setTimeout(attemptFocus, 0);
+};
 
 /**
  * Focus an editor that may not have mounted yet (dynamic import, template

--- a/packages/lesswrong/components/editor/focusLexicalEditor.ts
+++ b/packages/lesswrong/components/editor/focusLexicalEditor.ts
@@ -7,3 +7,34 @@ export const focusLexicalEditor = (container: HTMLDivElement | null) => {
     editorElement?.focus?.();
   }, 0);
 };
+
+const FOCUS_RETRY_INTERVAL_MS = 50;
+const FOCUS_RETRY_ATTEMPTS = 20;
+
+/**
+ * Focus an editor that may not have mounted yet — a dynamically imported editor,
+ * or a form that first has to load a template — by retrying briefly.
+ * Returns a cancel function, for callers that unmount before it lands.
+ */
+export const focusLexicalEditorWhenReady = (container: HTMLDivElement | null) => {
+  if (!container) return () => {};
+
+  let attemptsRemaining = FOCUS_RETRY_ATTEMPTS;
+  let timeoutId: ReturnType<typeof setTimeout>;
+
+  const attemptFocus = () => {
+    const editorElement = container.querySelector(
+      '[contenteditable="true"]'
+    ) as HTMLElement | null;
+    if (editorElement) {
+      editorElement.focus?.();
+      return;
+    }
+    if (attemptsRemaining-- > 0) {
+      timeoutId = setTimeout(attemptFocus, FOCUS_RETRY_INTERVAL_MS);
+    }
+  };
+
+  timeoutId = setTimeout(attemptFocus, 0);
+  return () => clearTimeout(timeoutId);
+};

--- a/packages/lesswrong/components/editor/focusLexicalEditor.ts
+++ b/packages/lesswrong/components/editor/focusLexicalEditor.ts
@@ -12,9 +12,8 @@ const FOCUS_RETRY_INTERVAL_MS = 50;
 const FOCUS_RETRY_ATTEMPTS = 20;
 
 /**
- * Focus an editor that may not have mounted yet — a dynamically imported editor,
- * or a form that first has to load a template — by retrying briefly.
- * Returns a cancel function, for callers that unmount before it lands.
+ * Focus an editor that may not have mounted yet (dynamic import, template
+ * fetch) by retrying briefly. Returns a cancel function.
  */
 export const focusLexicalEditorWhenReady = (container: HTMLDivElement | null) => {
   if (!container) return () => {};

--- a/packages/lesswrong/components/messaging/MessagesNewForm.tsx
+++ b/packages/lesswrong/components/messaging/MessagesNewForm.tsx
@@ -19,6 +19,7 @@ import { useFormSubmitOnCmdEnter } from "../hooks/useFormSubmitOnCmdEnter";
 import Loading from "../vulcan-core/Loading";
 import ForumIcon from "../common/ForumIcon";
 import Error404 from "../common/Error404";
+import ComposerSubmitButton from "../sunshineDashboard/supermod/ComposerSubmitButton";
 
 const messageListFragmentMutation = gql(`
   mutation createMessageMessagesNewForm($data: CreateMessageDataInput!) {
@@ -111,6 +112,7 @@ const InnerMessagesNewForm = ({
   isMinimalist,
   submitLabel = "Submit",
   sendEmail = true,
+  keystrokeSubmitButton = false,
   prefilledProps,
   templateQueries,
   conversationId,
@@ -119,6 +121,7 @@ const InnerMessagesNewForm = ({
   isMinimalist: boolean;
   submitLabel?: React.ReactNode;
   sendEmail?: boolean;
+  keystrokeSubmitButton?: boolean;
   prefilledProps: {
     conversationId: string;
     contents: {
@@ -138,6 +141,10 @@ const InnerMessagesNewForm = ({
   const formButtonClass = isMinimalist ? classes.formButtonMinimalist : classes.formButton;
   const hintText = isMinimalist ? "Type a new message..." : getDefaultEditorPlaceholder();
   const commentMinimalistStyle = isMinimalist ? true : false;
+
+  // Tracks emptiness for the keystroke submit button's disabled state; the
+  // form field value only updates on a throttle, so it can't be used for this
+  const [editorIsBlank, setEditorIsBlank] = useState(!prefilledProps.contents.originalContents.data.trim());
 
   const {
     onSubmitCallback,
@@ -181,7 +188,10 @@ const InnerMessagesNewForm = ({
   });
 
 
-  const handleSubmit = useCallback(() => form.handleSubmit(), [form]);
+  const handleSubmit = useCallback(async () => {
+    if (keystrokeSubmitButton && editorIsBlank) return;
+    await form.handleSubmit();
+  }, [form, keystrokeSubmitButton, editorIsBlank]);
   const formRef = useFormSubmitOnCmdEnter(handleSubmit);
 
   return (
@@ -204,6 +214,7 @@ const InnerMessagesNewForm = ({
                 addOnSuccessCallback={addOnSuccessCallback}
                 hintText={hintText}
                 commentMinimalistStyle={commentMinimalistStyle}
+                onBlankStateChange={keystrokeSubmitButton ? setEditorIsBlank : undefined}
                 fieldName="contents"
                 collectionName="Messages"
                 commentEditor={true}
@@ -218,13 +229,19 @@ const InnerMessagesNewForm = ({
         <form.Subscribe selector={(s) => [s.isSubmitting]}>
           {([isSubmitting]) => (
             <div className={classNames("form-submit", { [classes.submitMinimalist]: isMinimalist })}>
-              <Button
-                type="submit"
-                id="new-message-submit"
-                className={classNames("primary-form-submit-button", formButtonClass)}
-              >
-                {isSubmitting ? <Loading /> : isMinimalist ? <ForumIcon icon="ArrowRightOutline" /> : submitLabel}
-              </Button>
+              {keystrokeSubmitButton
+                ? <ComposerSubmitButton
+                    type="submit"
+                    label={isSubmitting ? <Loading /> : submitLabel}
+                    disabled={editorIsBlank}
+                  />
+                : <Button
+                    type="submit"
+                    id="new-message-submit"
+                    className={classNames("primary-form-submit-button", formButtonClass)}
+                  >
+                    {isSubmitting ? <Loading /> : isMinimalist ? <ForumIcon icon="ArrowRightOutline" /> : submitLabel}
+                  </Button>}
             </div>
           )}
         </form.Subscribe>
@@ -239,6 +256,7 @@ export const MessagesNewForm = ({
   successEvent,
   submitLabel,
   sendEmail = true,
+  keystrokeSubmitButton,
   formStyle="default",
 }: {
   conversationId: string;
@@ -246,6 +264,8 @@ export const MessagesNewForm = ({
   successEvent: (newMessage: messageListFragment) => void;
   submitLabel?: string,
   sendEmail?: boolean;
+  /** Supermod sidebar style: Ctrl+Enter badge on the submit button, disabled while empty */
+  keystrokeSubmitButton?: boolean;
   formStyle?: FormDisplayMode;
 }) => {
   const classes = useStyles(styles);
@@ -275,6 +295,7 @@ export const MessagesNewForm = ({
         isMinimalist={isMinimalist}
         submitLabel={submitLabel}
         sendEmail={sendEmail}
+        keystrokeSubmitButton={keystrokeSubmitButton}
         prefilledProps={{
           conversationId,
           contents: {

--- a/packages/lesswrong/components/sunshineDashboard/GroupedModerationTemplateList.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/GroupedModerationTemplateList.tsx
@@ -154,6 +154,22 @@ const styles = defineStyles('GroupedModerationTemplateList', (theme: ThemeType) 
     gap: 4,
     marginBottom: 8,
   },
+  // Collapsed state reads as an unopened search field: icon on the left,
+  // greyed placeholder, underlined like the open input
+  collapsedSearch: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: 6,
+    padding: '4px 0',
+    marginBottom: 8,
+    borderBottom: `1px solid ${theme.palette.grey[300]}`,
+    cursor: 'pointer',
+  },
+  collapsedSearchPlaceholder: {
+    fontSize: 13,
+    fontFamily: theme.palette.fonts.sansSerifStack,
+    color: theme.palette.grey[500],
+  },
   searchIcon: {
     height: 16,
     width: 16,
@@ -293,11 +309,12 @@ const TemplateSearchBar = ({searchOpen, searchQuery, focusToken, onOpen, onClose
 
   if (!searchOpen) {
     return (
-      <div className={classes.listHeader}>
-        <LWTooltip title="Search templates (/)" placement="left">
-          <ForumIcon icon="Search" className={classes.searchIcon} onClick={onOpen} />
-        </LWTooltip>
-      </div>
+      <LWTooltip title="Search templates (/)" placement="left">
+        <div className={classes.collapsedSearch} onClick={onOpen}>
+          <ForumIcon icon="Search" className={classes.searchIcon} />
+          <span className={classes.collapsedSearchPlaceholder}>Search templates...</span>
+        </div>
+      </LWTooltip>
     );
   }
 
@@ -478,13 +495,22 @@ const HiddenTemplatesSection = ({hiddenTemplates, expanded, onToggleExpanded, on
  *
  * The search box drives the same keyboard flow as the rejection dialog: "/" opens and
  * focuses it, up/down move the selection through the visible templates, Enter applies
- * the selected one, Tab jumps to the composer, and Escape closes the search.
+ * the selected one, Tab (or ArrowUp past the top of the list) jumps to the composer,
+ * and Escape closes the search.
+ *
+ * `focusSearchToken` is bumped by the composer above the list when the moderator
+ * presses ArrowDown on its last line; it opens and focuses the search with nothing
+ * selected, so the next ArrowDown steps into the template list.
  */
-const GroupedModerationTemplateList = ({ collectionName, onTemplateClick, highlightedTemplateNames, onFocusComposer }: {
+const GroupedModerationTemplateList = ({ collectionName, onTemplateClick, highlightedTemplateNames, onFocusComposer, focusSearchToken, active = true }: {
   collectionName: TemplateType,
   onTemplateClick: (template: ModerationTemplateFragment) => void,
   highlightedTemplateNames?: Set<string>,
   onFocusComposer?: () => void,
+  focusSearchToken?: number,
+  // False while the list's composer tab is hidden (but kept mounted to
+  // preserve drafts), so the "/" shortcut only reaches the visible list
+  active?: boolean,
 }) => {
   const classes = useStyles(styles);
   const currentUser = useCurrentUser();
@@ -500,13 +526,23 @@ const GroupedModerationTemplateList = ({ collectionName, onTemplateClick, highli
   // "/" is the way into the template list from the rest of the supermod keyboard flow,
   // which is why this listens globally rather than on the list itself
   useGlobalKeydown(useCallback((event: KeyboardEvent) => {
+    if (!active) return;
     if (event.key !== '/' || event.metaKey || event.ctrlKey || event.altKey) return;
     if (isInTextInput(event.target)) return;
     event.preventDefault();
     setSearchOpen(true);
     setSelectedIndex(0);
     setSearchFocusToken(token => token + 1);
-  }, []));
+  }, [active]));
+
+  // ArrowDown from the last line of the composer lands here: the search itself is
+  // the selection (index -1), and the next ArrowDown moves into the template list
+  useEffect(() => {
+    if (!focusSearchToken) return;
+    setSearchOpen(true);
+    setSelectedIndex(-1);
+    setSearchFocusToken(token => token + 1);
+  }, [focusSearchToken]);
 
   // In an effect, not render: localStorage would break hydration
   useEffect(() => {
@@ -619,9 +655,14 @@ const GroupedModerationTemplateList = ({ collectionName, onTemplateClick, highli
         setSelectedIndex(prev => prev >= navigableTemplates.length - 1 ? 0 : prev + 1);
         break;
       case 'ArrowUp':
+        // Mirrors ArrowDown's composer → search → list flow: walk back up the
+        // list, pause at the search level (-1), then continue into the composer
         event.preventDefault();
-        if (navigableTemplates.length === 0) return;
-        setSelectedIndex(prev => prev <= 0 ? navigableTemplates.length - 1 : prev - 1);
+        if (selectedIndex < 0) {
+          onFocusComposer?.();
+          return;
+        }
+        setSelectedIndex(prev => prev - 1);
         break;
       case 'Enter':
         event.preventDefault();

--- a/packages/lesswrong/components/sunshineDashboard/ModerationTemplateSunshineItem.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/ModerationTemplateSunshineItem.tsx
@@ -102,11 +102,26 @@ const styles = defineStyles('ModerationTemplateSunshineItem', (theme: ThemeType)
   hovercard: {
     padding: 16,
     maxWidth: 400,
-    border: theme.palette.border.commentBorder,
+    border: theme.palette.border.slightlyIntense3,
     borderRadius: theme.borderRadius.small,
     background: theme.palette.panelBackground.default,
     ...theme.typography.body2,
     ...theme.typography.commentStyle,
+    // Large soft halo so the preview is readable over the busy page behind it
+    boxShadow: `0 0 200px 200px ${theme.palette.boxShadowColor(0.03)}`,
+    // Crop the halo at the card's right edge so it doesn't dim the sidebar
+    // column the card floats next to. 500px comfortably exceeds the shadow's
+    // blur+spread (400px), so the other three sides show no hard edge. Assumes
+    // the card stays on the left of its row (left-start only flips to the
+    // right if there's no room on the left, which this layout doesn't hit).
+    clipPath: 'inset(-500px 0 -500px -500px)',
+    // The comment ContentStyles on this element add vertical margins, which
+    // push the card out of flush left-start alignment with the hovered row;
+    // && outweighs the commentBody class regardless of injection order
+    '&&': {
+      marginTop: 0,
+      marginBottom: 0,
+    },
   },
   actionIcon: {
     fontSize: 22,
@@ -152,6 +167,9 @@ export const ModerationTemplateSunshineItem = ({template, onTemplateClick, highl
     <LWTooltip
       tooltip={false}
       placement="left-start"
+      // Pushes the card left past the sidebar section's padding, so its
+      // right edge clears the column boundary rather than overlapping the list
+      distance={13}
       // Not inline-block, so the row fills the sidebar width
       As="div"
       inlineBlock={false}

--- a/packages/lesswrong/components/sunshineDashboard/RejectContentButton.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/RejectContentButton.tsx
@@ -32,8 +32,10 @@ const styles = defineStyles('RejectContentButton', (theme: ThemeType) => ({
   }
 }));
 
-export const RejectContentButton = ({contentWrapper}: {
+export const RejectContentButton = ({contentWrapper, onReject}: {
   contentWrapper: RejectContentParams,
+  /** Overrides the rejection dialog, for callers with their own rejection UI. */
+  onReject?: () => void,
 }) => {
   const classes = useStyles(styles);
   const { eventHandlers, anchorEl } = useHover();
@@ -67,7 +69,7 @@ export const RejectContentButton = ({contentWrapper}: {
         <ReplayIcon className={classes.icon} onClick={() => unrejectContent({ ...contentWrapper })}/>
       </LWTooltip>
     </span>}
-    {!document.rejected && document.authorIsUnreviewed && <span className={classes.button} onClick={openRejectionDialog}>
+    {!document.rejected && document.authorIsUnreviewed && <span className={classes.button} onClick={onReject ?? openRejectionDialog}>
       <RejectedIcon className={classes.icon}/> <MetaInfo>Reject</MetaInfo>
     </span>}
     <LWPopper

--- a/packages/lesswrong/components/sunshineDashboard/RejectContentDialog.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/RejectContentDialog.tsx
@@ -18,6 +18,7 @@ import KeystrokeDisplay from './supermod/KeystrokeDisplay';
 import { useGlobalKeydown } from '../common/withGlobalKeydown';
 import { focusLexicalEditor } from '../editor/focusLexicalEditor';
 import { getDraftMessageHtml } from '@/lib/collections/messages/helpers';
+import { standardRejectionIntroHtml } from '@/lib/collections/moderationTemplates/rejectionIntro';
 import dynamic from 'next/dynamic';
 
 const LexicalEditor = dynamic(() => import('@/components/editor/LexicalEditor'));
@@ -496,13 +497,6 @@ const RejectContentDialog = ({rejectionTemplates, onClose, rejectContent, displa
     focusLexicalEditor(editorContainerRef.current);
   }, [rejectionReasons, selections]);
 
-  // Standard rejection intro that will be prepended to the message
-  const standardIntroHtml = `
-    <p>Unfortunately, I rejected your [content].</p>
-    <p>LessWrong aims for particularly high quality (and somewhat oddly-specific) discussion quality. We get a lot of content from new users and sadly can't give detailed feedback on every piece we reject, but I generally recommend checking out our <a href="https://www.lesswrong.com/posts/LbbrnRvc9QwjJeics/new-user-s-guide-to-lesswrong">New User's Guide</a>, in particular the section on <a href="https://www.lesswrong.com/posts/LbbrnRvc9QwjJeics/new-user-s-guide-to-lesswrong#How_to_ensure_your_first_post_or_comment_is_well_received">how to ensure your content is approved</a>.</p>
-    <p>Your content didn't meet the bar for at least the following reason(s):</p>
-  `;
-
   const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
     switch (e.key) {
       case 'ArrowDown':
@@ -625,7 +619,7 @@ const RejectContentDialog = ({rejectionTemplates, onClose, rejectContent, displa
     <div className={classNames(classes.editorContainer, { [classes.hideEditorContainer]: hideTextField })} ref={editorContainerRef}>
       <div className={classes.defaultIntroMessage}>
         <ContentStyles contentType='comment'>
-          <ContentItemBody dangerouslySetInnerHTML={{__html: standardIntroHtml}} />
+          <ContentItemBody dangerouslySetInnerHTML={{__html: standardRejectionIntroHtml}} />
         </ContentStyles>
       </div>
 

--- a/packages/lesswrong/components/sunshineDashboard/SunshineUserMessages.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineUserMessages.tsx
@@ -211,9 +211,7 @@ const SunshineUserMessagesInner = ({user, currentUser, posts, comments, focusedC
   // Start the conversation on tab click, not on a second click on the prompt
   const handleSelectDmTab = () => {
     setSidebarTab('dm');
-    if (!embeddedConversationId) {
-      initiateConversation([user._id]);
-    }
+    handleStartConversation();
   };
 
   useEffect(() => {

--- a/packages/lesswrong/components/sunshineDashboard/SunshineUserMessages.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineUserMessages.tsx
@@ -22,9 +22,11 @@ import FormatDate from '../common/FormatDate';
 import GroupedModerationTemplateList from './GroupedModerationTemplateList';
 import ModerationSectionTitle from './supermod/ModerationSectionTitle';
 import RejectContentPanel from './supermod/RejectContentPanel';
+import KeystrokeDisplay from './supermod/KeystrokeDisplay';
+import ComposerKeydownWrapper from './supermod/ComposerKeydownWrapper';
 import { canRejectContent, getContentTitle, type ContentItem } from './supermod/helpers';
-import type { SidebarTab, SelectedSidebarTab } from './supermod/sidebarTabs';
-import { focusLexicalEditor, focusLexicalEditorWhenReady } from '../editor/focusLexicalEditor';
+import type { SelectedSidebarTab } from './supermod/sidebarTabs';
+import { focusLexicalEditorAtEnd, focusLexicalEditorWhenReady } from '../editor/focusLexicalEditor';
 
 const ConversationsListMultiQuery = gql(`
   query multiConversationSunshineUserMessagesQuery($selector: ConversationSelector, $limit: Int, $enableTotal: Boolean) {
@@ -83,6 +85,15 @@ const styles = defineStyles('SunshineUserMessages', (theme: ThemeType) => ({
   conversationForm: {
     marginBottom: 16,
     paddingBottom: 8,
+    // One line tall until the moderator types or inserts a template (the
+    // lexical min-height var is already 1em via MessagesNewForm's own styles,
+    // but the editor wrapper adds a 100px min-height that we undo here)
+    '& .EditorFormComponent-commentEditorHeight': {
+      minHeight: 'unset',
+    },
+    '& .EditorFormComponent-commentEditorHeight .ck.ck-content': {
+      minHeight: 'unset',
+    },
   },
   messagePrompt: {
     padding: 8,
@@ -124,6 +135,17 @@ const styles = defineStyles('SunshineUserMessages', (theme: ThemeType) => ({
     borderBottom: '2px solid transparent',
     paddingBottom: 2,
   },
+  // KeystrokeDisplay's root is display:flex, so the label needs to be a flex
+  // container for the badge to sit inline with the text
+  rejectTabLabel: {
+    display: 'inline-flex',
+    alignItems: 'center',
+    maxWidth: '100%',
+  },
+  rejectTabTitle: {
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+  },
   dmTab: {
     flexShrink: 0,
   },
@@ -144,6 +166,10 @@ const styles = defineStyles('SunshineUserMessages', (theme: ThemeType) => ({
       color: theme.palette.grey[600],
     },
   },
+  // Deselected composers stay mounted (so drafts survive), just hidden
+  hiddenTabContent: {
+    display: 'none',
+  },
 }));
 
 interface SunshineUserMessagesProps {
@@ -153,7 +179,7 @@ interface SunshineUserMessagesProps {
   comments?: SunshineCommentsList[];
   focusedContent?: ContentItem | null;
   sidebarTab: SelectedSidebarTab;
-  setSidebarTab: (tab: SidebarTab) => void;
+  setSidebarTab: (tab: SelectedSidebarTab) => void;
 }
 
 const SunshineUserMessagesInner = ({user, currentUser, posts, comments, focusedContent, sidebarTab, setSidebarTab}: SunshineUserMessagesProps) => {
@@ -174,6 +200,8 @@ const SunshineUserMessagesInner = ({user, currentUser, posts, comments, focusedC
   const [embeddedConversationId, setEmbeddedConversationId] = useState<string | undefined>();
   const [templateQueries, setTemplateQueries] = useState<TemplateQueryStrings | undefined>();
   const [expandedConversationId, setExpandedConversationId] = useState<string | undefined>();
+  const [templateSearchToken, setTemplateSearchToken] = useState(0);
+  const [pendingComposerFocus, setPendingComposerFocus] = useState(false);
   const dmEditorContainerRef = useRef<HTMLDivElement>(null);
 
   const { captureEvent } = useTracking()
@@ -208,20 +236,35 @@ const SunshineUserMessagesInner = ({user, currentUser, posts, comments, focusedC
   const rejectTabActive = sidebarTab === 'reject' && canReject && !!focusedContent;
   const dmTabActive = sidebarTab === 'dm';
 
-  // Start the conversation on tab click, not on a second click on the prompt
+  // Start the conversation on tab click, not on a second click on the prompt.
+  // Clicking the already-active tab closes the composer.
   const handleSelectDmTab = () => {
+    if (dmTabActive) {
+      setSidebarTab(null);
+      return;
+    }
     setSidebarTab('dm');
     handleStartConversation();
   };
 
+  // The template search is the initial keyboard target whenever the tab is picked
   useEffect(() => {
     if (dmTabActive) {
+      setTemplateSearchToken(token => token + 1);
+    }
+  }, [dmTabActive]);
+
+  // Composer focus has to wait until the conversation (and thus the editor) exists
+  useEffect(() => {
+    if (pendingComposerFocus && dmTabActive && embeddedConversationId) {
+      setPendingComposerFocus(false);
       return focusLexicalEditorWhenReady(dmEditorContainerRef.current);
     }
-  }, [dmTabActive, embeddedConversationId]);
+  }, [pendingComposerFocus, dmTabActive, embeddedConversationId]);
 
   const handleMessageTemplateClick = (template: ModerationTemplateFragment) => {
     if (!embeddedConversationId) {
+      setPendingComposerFocus(true);
       initiateConversation([user._id]);
       const newTemplateQueries = {
         templateId: template._id,
@@ -251,18 +294,31 @@ const SunshineUserMessagesInner = ({user, currentUser, posts, comments, focusedC
   // composer doesn't exist, so start one — the effect above focuses it once it renders.
   const handleFocusComposer = () => {
     if (embeddedConversationId) {
-      focusLexicalEditor(dmEditorContainerRef.current);
+      focusLexicalEditorAtEnd(dmEditorContainerRef.current);
     } else {
+      setPendingComposerFocus(true);
       handleStartConversation();
     }
   };
 
+  // Clicking the prompt is an explicit request to type a message, so the
+  // composer (not the search) gets focus once the conversation exists
+  const handleMessagePromptClick = () => {
+    setPendingComposerFocus(true);
+    handleStartConversation();
+  };
+
   const dmTabContents = <>
     {embeddedConversationId ? (
-      <div className={classes.conversationForm} ref={dmEditorContainerRef}>
+      <ComposerKeydownWrapper
+        className={classes.conversationForm}
+        containerRef={dmEditorContainerRef}
+        onArrowDownPastEnd={() => setTemplateSearchToken(token => token + 1)}
+      >
         <MessagesNewForm
           conversationId={embeddedConversationId}
           templateQueries={templateQueries}
+          keystrokeSubmitButton
           successEvent={async (newMessage) => {
             await refetch();
             captureEvent('messageSent', {
@@ -272,9 +328,9 @@ const SunshineUserMessagesInner = ({user, currentUser, posts, comments, focusedC
             })
           }}
         />
-      </div>
+      </ComposerKeydownWrapper>
     ) : (
-      <div className={classes.messagePrompt} onClick={handleStartConversation}>
+      <div className={classes.messagePrompt} onClick={handleMessagePromptClick}>
         Click to start a new message...
       </div>
     )}
@@ -283,6 +339,8 @@ const SunshineUserMessagesInner = ({user, currentUser, posts, comments, focusedC
       onTemplateClick={handleMessageTemplateClick}
       highlightedTemplateNames={highlightedTemplateNames}
       onFocusComposer={handleFocusComposer}
+      focusSearchToken={templateSearchToken}
+      active={dmTabActive}
     />
   </>;
 
@@ -330,18 +388,23 @@ const SunshineUserMessagesInner = ({user, currentUser, posts, comments, focusedC
       </div>
       {showRejectTab && <div
         className={classNames(classes.tab, classes.rejectTab, { [classes.disabledTab]: !canReject })}
-        onClick={() => canReject && setSidebarTab('reject')}
+        onClick={() => canReject && setSidebarTab(rejectTabActive ? null : 'reject')}
         title={canReject ? undefined : "This content can't be rejected"}
       >
-        <span className={classNames(classes.tabLabel, { [classes.activeTab]: rejectTabActive })}>
-          Reject “{getContentTitle(focusedContent)}”
+        <span className={classNames(classes.tabLabel, classes.rejectTabLabel, { [classes.activeTab]: rejectTabActive })}>
+          <span className={classes.rejectTabTitle}>Reject “{getContentTitle(focusedContent)}”</span>
+          <KeystrokeDisplay keystroke="R" withMargin />
         </span>
       </div>}
     </div>
 
-    {dmTabActive && dmTabContents}
-    {rejectTabActive && focusedContent && (
-      <RejectContentPanel user={user} focusedContent={focusedContent} />
+    <div className={classNames({ [classes.hiddenTabContent]: !dmTabActive })}>
+      {dmTabContents}
+    </div>
+    {canReject && focusedContent && (
+      <div className={classNames({ [classes.hiddenTabContent]: !rejectTabActive })}>
+        <RejectContentPanel user={user} focusedContent={focusedContent} active={rejectTabActive} />
+      </div>
     )}
   </div>;
 }

--- a/packages/lesswrong/components/sunshineDashboard/SunshineUserMessages.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineUserMessages.tsx
@@ -1,9 +1,10 @@
-import React, { useState, useEffect, useMemo } from 'react';
+import React, { useState, useEffect, useMemo, useRef } from 'react';
 import { useTracking } from '../../lib/analyticsEvents';
 import { TemplateQueryStrings } from '../messaging/NewConversationButton';
 import EmailIcon from '@/lib/vendor/@material-ui/icons/src/Email';
 import { Link } from '../../lib/reactRouterWrapper';
 import isEqual from 'lodash/isEqual';
+import classNames from 'classnames';
 import MessagesNewForm from "../messaging/MessagesNewForm";
 import { getDraftMessageHtml } from '../../lib/collections/messages/helpers';
 import UsersName from "../users/UsersName";
@@ -19,6 +20,11 @@ import { useAppendToEditor, AppendToEditorProvider } from '../editor/AppendToEdi
 import { getHighlightedTemplateNames } from './supermod/templateHighlightRules';
 import FormatDate from '../common/FormatDate';
 import GroupedModerationTemplateList from './GroupedModerationTemplateList';
+import ModerationSectionTitle from './supermod/ModerationSectionTitle';
+import RejectContentPanel from './supermod/RejectContentPanel';
+import { canRejectContent, getContentTitle, type ContentItem } from './supermod/helpers';
+import type { SidebarTab, SelectedSidebarTab } from './supermod/sidebarTabs';
+import { focusLexicalEditorWhenReady } from '../editor/focusLexicalEditor';
 
 const ConversationsListMultiQuery = gql(`
   query multiConversationSunshineUserMessagesQuery($selector: ConversationSelector, $limit: Int, $enableTotal: Boolean) {
@@ -69,11 +75,14 @@ const styles = defineStyles('SunshineUserMessages', (theme: ThemeType) => ({
     marginBottom: -1,
     marginLeft: 4,
   },
-  conversationForm: {
-    marginTop: 16,
+  pastMessages: {
     marginBottom: 16,
     paddingBottom: 8,
     borderBottom: theme.palette.border.extraFaint,
+  },
+  conversationForm: {
+    marginBottom: 16,
+    paddingBottom: 8,
   },
   messagePrompt: {
     padding: 8,
@@ -90,7 +99,53 @@ const styles = defineStyles('SunshineUserMessages', (theme: ThemeType) => ({
   conversationPreviewTooltip: {
     maxHeight: "100vh",
     overflow: "hidden",
-  }
+  },
+  tabs: {
+    display: 'flex',
+    alignItems: 'stretch',
+    marginBottom: 8,
+  },
+  tab: {
+    ...theme.typography.commentStyle,
+    minWidth: 0,
+    padding: '6px 8px',
+    fontSize: 13,
+    color: theme.palette.grey[600],
+    cursor: 'pointer',
+    whiteSpace: 'nowrap',
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    '&:hover': {
+      color: theme.palette.grey[900],
+    },
+  },
+  // The underline marks the selected tab, so it tracks the label rather than running
+  // the width of the tab's click target.
+  tabLabel: {
+    borderBottom: '2px solid transparent',
+    paddingBottom: 2,
+  },
+  dmTab: {
+    flexShrink: 0,
+  },
+  rejectTab: {
+    flexShrink: 1,
+    // Sits against the right edge, so the two tabs read as separate choices rather
+    // than a pair. The title is already capped, so this only shrinks in a narrow column.
+    marginLeft: 'auto',
+  },
+  activeTab: {
+    color: theme.palette.grey[900],
+    fontWeight: 600,
+    borderBottomColor: theme.palette.primary.main,
+  },
+  disabledTab: {
+    opacity: 0.4,
+    cursor: 'default',
+    '&:hover': {
+      color: theme.palette.grey[600],
+    },
+  },
 }));
 
 interface SunshineUserMessagesProps {
@@ -98,12 +153,14 @@ interface SunshineUserMessagesProps {
   currentUser: UsersCurrent;
   posts?: SunshinePostsList[];
   comments?: SunshineCommentsList[];
-  showExpandablePreview?: boolean;
+  focusedContent?: ContentItem | null;
+  sidebarTab: SelectedSidebarTab;
+  setSidebarTab: (tab: SidebarTab) => void;
 }
 
-const SunshineUserMessagesInner = ({user, currentUser, posts, comments, showExpandablePreview}: SunshineUserMessagesProps) => {
+const SunshineUserMessagesInner = ({user, currentUser, posts, comments, focusedContent, sidebarTab, setSidebarTab}: SunshineUserMessagesProps) => {
   const classes = useStyles(styles);
-  
+
   const highlightedTemplateNames = useMemo(() => {
     if (!posts || !comments) return new Set<string>();
     return getHighlightedTemplateNames(
@@ -119,6 +176,7 @@ const SunshineUserMessagesInner = ({user, currentUser, posts, comments, showExpa
   const [embeddedConversationId, setEmbeddedConversationId] = useState<string | undefined>();
   const [templateQueries, setTemplateQueries] = useState<TemplateQueryStrings | undefined>();
   const [expandedConversationId, setExpandedConversationId] = useState<string | undefined>();
+  const dmEditorContainerRef = useRef<HTMLDivElement>(null);
 
   const { captureEvent } = useTracking()
   const { conversation, initiateConversation } = useInitiateConversation({ includeModerators: true });
@@ -130,14 +188,6 @@ const SunshineUserMessagesInner = ({user, currentUser, posts, comments, showExpa
       setEmbeddedConversationId(conversation._id);
     }
   }, [conversation, embeddedConversationId]);
-
-  const embedConversation = (conversationId: string, newTemplateQueries: TemplateQueryStrings) => {
-    setEmbeddedConversationId(conversationId);
-    // Downstream components rely on referential equality of the templateQueries object in a useEffect; we get an infinite loop here if we don't check for value equality
-    if (!isEqual(newTemplateQueries, templateQueries)) {
-      setTemplateQueries(newTemplateQueries);
-    }
-  }
 
   const toggleConversationPreview = (conversationId: string) => {
     setExpandedConversationId(prev => prev === conversationId ? undefined : conversationId);
@@ -155,15 +205,39 @@ const SunshineUserMessagesInner = ({user, currentUser, posts, comments, showExpa
 
   const results = data?.conversations?.results;
 
-  const handleTemplateClick = (template: ModerationTemplateFragment) => {
+  const canReject = canRejectContent(focusedContent);
+  const showRejectTab = !!focusedContent;
+  const rejectTabActive = sidebarTab === 'reject' && canReject && !!focusedContent;
+  const dmTabActive = sidebarTab === 'dm';
+
+  // Opening the DM tab should land the moderator in a ready-to-type message, so it
+  // starts the conversation rather than waiting for a second click on the prompt.
+  const handleSelectDmTab = () => {
+    setSidebarTab('dm');
+    if (!embeddedConversationId) {
+      initiateConversation([user._id]);
+    }
+  };
+
+  useEffect(() => {
+    if (dmTabActive) {
+      return focusLexicalEditorWhenReady(dmEditorContainerRef.current);
+    }
+  }, [dmTabActive, embeddedConversationId]);
+
+  const handleMessageTemplateClick = (template: ModerationTemplateFragment) => {
     // Initiate conversation if we don't have one yet
     if (!embeddedConversationId) {
       initiateConversation([user._id]);
       // For new conversations, use templateQueries to prefill
-      setTemplateQueries({
+      // Downstream components rely on referential equality of the templateQueries object in a useEffect; we get an infinite loop here if we don't check for value equality
+      const newTemplateQueries = {
         templateId: template._id,
         displayName: user.displayName,
-      });
+      };
+      if (!isEqual(newTemplateQueries, templateQueries)) {
+        setTemplateQueries(newTemplateQueries);
+      }
     } else if (template.contents?.html) {
       // Append to editor via context
       const processedHtml = getDraftMessageHtml({
@@ -180,39 +254,11 @@ const SunshineUserMessagesInner = ({user, currentUser, posts, comments, showExpa
     }
   };
 
-  return <div>
-    {results?.map(conversation => {
-      const isExpanded = expandedConversationId === conversation._id;
-      return (
-        <LWTooltip key={conversation._id} placement="left-start" tooltip={false} titleClassName={classes.conversationPreviewTooltip} title={<div><ConversationPreview conversationId={conversation._id} showTitle={false} showFullWidth /></div>}>
-          <div  className={classes.conversationItem}>
-            <div className={classes.conversationHeader} onClick={() => toggleConversationPreview(conversation._id)}>
-              <MetaInfo><EmailIcon className={classes.icon}/> {conversation.messageCount}</MetaInfo>
-              <span>
-                Conversation with{" "} 
-                {conversation.participants?.filter(participant => participant._id !== user._id).map(participant => {
-                  return <MetaInfo key={`${conversation._id}${participant._id}`}>
-                    <UsersName simple user={participant}/>
-                  </MetaInfo>
-                })}
-              </span>
-              {conversation.latestActivity && <span className={classes.date}><FormatDate date={conversation.latestActivity} /></span>}
-              <Link to={`/inbox?isModInbox=true&conversation=${conversation._id}`} onClick={(e) => e.stopPropagation()}>
-                <ForumIcon icon="Link" className={classes.linkIcon} />
-              </Link> 
-              <ForumIcon icon={isExpanded ? "ExpandLess" : "ExpandMore"} className={classes.expandIcon} />
-            </div>
-            {isExpanded && (
-              <ConversationPreview conversationId={conversation._id} showTitle={false} showFullWidth />
-            )}
-          </div>
-        </LWTooltip>
-      );
-    })}
+  const dmTabContents = <>
     {embeddedConversationId ? (
-      <div className={classes.conversationForm}>
-        <MessagesNewForm 
-          conversationId={embeddedConversationId} 
+      <div className={classes.conversationForm} ref={dmEditorContainerRef}>
+        <MessagesNewForm
+          conversationId={embeddedConversationId}
           templateQueries={templateQueries}
           successEvent={async (newMessage) => {
             await refetch();
@@ -231,9 +277,68 @@ const SunshineUserMessagesInner = ({user, currentUser, posts, comments, showExpa
     )}
     <GroupedModerationTemplateList
       collectionName="Messages"
-      onTemplateClick={handleTemplateClick}
+      onTemplateClick={handleMessageTemplateClick}
       highlightedTemplateNames={highlightedTemplateNames}
     />
+  </>;
+
+  return <div>
+    {!!results?.length && <div className={classes.pastMessages}>
+      <ModerationSectionTitle>User Messages</ModerationSectionTitle>
+      {results.map(conversation => {
+        const isExpanded = expandedConversationId === conversation._id;
+        return (
+          <LWTooltip key={conversation._id} placement="left-start" tooltip={false} titleClassName={classes.conversationPreviewTooltip} title={<div><ConversationPreview conversationId={conversation._id} showTitle={false} showFullWidth /></div>}>
+            <div className={classes.conversationItem}>
+              <div className={classes.conversationHeader} onClick={() => toggleConversationPreview(conversation._id)}>
+                <MetaInfo><EmailIcon className={classes.icon}/> {conversation.messageCount}</MetaInfo>
+                <span>
+                  Conversation with{" "}
+                  {conversation.participants?.filter(participant => participant._id !== user._id).map(participant => {
+                    return <MetaInfo key={`${conversation._id}${participant._id}`}>
+                      <UsersName simple user={participant}/>
+                    </MetaInfo>
+                  })}
+                </span>
+                {conversation.latestActivity && <span className={classes.date}><FormatDate date={conversation.latestActivity} /></span>}
+                <Link to={`/inbox?isModInbox=true&conversation=${conversation._id}`} onClick={(e) => e.stopPropagation()}>
+                  <ForumIcon icon="Link" className={classes.linkIcon} />
+                </Link>
+                <ForumIcon icon={isExpanded ? "ExpandLess" : "ExpandMore"} className={classes.expandIcon} />
+              </div>
+              {isExpanded && (
+                <ConversationPreview conversationId={conversation._id} showTitle={false} showFullWidth />
+              )}
+            </div>
+          </LWTooltip>
+        );
+      })}
+    </div>}
+
+    <div className={classes.tabs}>
+      <div
+        className={classNames(classes.tab, classes.dmTab)}
+        onClick={handleSelectDmTab}
+      >
+        <span className={classNames(classes.tabLabel, { [classes.activeTab]: dmTabActive })}>
+          Send DM
+        </span>
+      </div>
+      {showRejectTab && <div
+        className={classNames(classes.tab, classes.rejectTab, { [classes.disabledTab]: !canReject })}
+        onClick={() => canReject && setSidebarTab('reject')}
+        title={canReject ? undefined : "This content can't be rejected"}
+      >
+        <span className={classNames(classes.tabLabel, { [classes.activeTab]: rejectTabActive })}>
+          Reject “{getContentTitle(focusedContent)}”
+        </span>
+      </div>}
+    </div>
+
+    {dmTabActive && dmTabContents}
+    {rejectTabActive && focusedContent && (
+      <RejectContentPanel user={user} focusedContent={focusedContent} />
+    )}
   </div>;
 }
 

--- a/packages/lesswrong/components/sunshineDashboard/SunshineUserMessages.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineUserMessages.tsx
@@ -119,8 +119,7 @@ const styles = defineStyles('SunshineUserMessages', (theme: ThemeType) => ({
       color: theme.palette.grey[900],
     },
   },
-  // The underline marks the selected tab, so it tracks the label rather than running
-  // the width of the tab's click target.
+  // Underlines the label only, not the tab's full-width click target
   tabLabel: {
     borderBottom: '2px solid transparent',
     paddingBottom: 2,
@@ -130,8 +129,7 @@ const styles = defineStyles('SunshineUserMessages', (theme: ThemeType) => ({
   },
   rejectTab: {
     flexShrink: 1,
-    // Sits against the right edge, so the two tabs read as separate choices rather
-    // than a pair. The title is already capped, so this only shrinks in a narrow column.
+    // Pushed to the right edge so the tabs read as separate choices
     marginLeft: 'auto',
   },
   activeTab: {
@@ -210,8 +208,7 @@ const SunshineUserMessagesInner = ({user, currentUser, posts, comments, focusedC
   const rejectTabActive = sidebarTab === 'reject' && canReject && !!focusedContent;
   const dmTabActive = sidebarTab === 'dm';
 
-  // Opening the DM tab should land the moderator in a ready-to-type message, so it
-  // starts the conversation rather than waiting for a second click on the prompt.
+  // Start the conversation on tab click, not on a second click on the prompt
   const handleSelectDmTab = () => {
     setSidebarTab('dm');
     if (!embeddedConversationId) {
@@ -226,20 +223,18 @@ const SunshineUserMessagesInner = ({user, currentUser, posts, comments, focusedC
   }, [dmTabActive, embeddedConversationId]);
 
   const handleMessageTemplateClick = (template: ModerationTemplateFragment) => {
-    // Initiate conversation if we don't have one yet
     if (!embeddedConversationId) {
       initiateConversation([user._id]);
-      // For new conversations, use templateQueries to prefill
-      // Downstream components rely on referential equality of the templateQueries object in a useEffect; we get an infinite loop here if we don't check for value equality
       const newTemplateQueries = {
         templateId: template._id,
         displayName: user.displayName,
       };
+      // A downstream useEffect keys on this object's identity; a fresh but
+      // equal object loops forever
       if (!isEqual(newTemplateQueries, templateQueries)) {
         setTemplateQueries(newTemplateQueries);
       }
     } else if (template.contents?.html) {
-      // Append to editor via context
       const processedHtml = getDraftMessageHtml({
         html: template.contents.html,
         displayName: user.displayName,

--- a/packages/lesswrong/components/sunshineDashboard/supermod/ComposerKeydownWrapper.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/supermod/ComposerKeydownWrapper.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { blurEditorOnEscape, callOnArrowDownPastEditorEnd } from '@/components/editor/focusLexicalEditor';
+
+/**
+ * Wrapper div for a supermod sidebar composer. Escape blurs the editor
+ * (rather than letting the supermod Escape handler on document close the
+ * detail view), and ArrowDown on the composer's last line hands focus to the
+ * template search below it.
+ */
+const ComposerKeydownWrapper = ({ containerRef, onArrowDownPastEnd, className, children }: {
+  containerRef: React.RefObject<HTMLDivElement | null>,
+  onArrowDownPastEnd: () => void,
+  className?: string,
+  children: React.ReactNode,
+}) => {
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    blurEditorOnEscape(e);
+    callOnArrowDownPastEditorEnd(e, onArrowDownPastEnd);
+  };
+  return <div className={className} ref={containerRef} onKeyDown={handleKeyDown}>
+    {children}
+  </div>;
+};
+
+export default ComposerKeydownWrapper;

--- a/packages/lesswrong/components/sunshineDashboard/supermod/ComposerSubmitButton.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/supermod/ComposerSubmitButton.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import Button from '@/lib/vendor/@material-ui/core/src/Button';
+import KeystrokeDisplay from './KeystrokeDisplay';
+
+/**
+ * Submit button for the supermod sidebar composers (Send DM / Reject): shows
+ * a Ctrl+Enter badge matching the actual keyboard shortcut, and is greyed out
+ * while the composer is empty.
+ */
+const ComposerSubmitButton = ({ label, disabled, onClick, type = 'button' }: {
+  label: React.ReactNode,
+  disabled: boolean,
+  onClick?: () => void,
+  type?: 'button' | 'submit',
+}) => {
+  return <Button type={type} onClick={onClick} disabled={disabled}>
+    {label}
+    <KeystrokeDisplay keystroke="Ctrl+Enter" withMargin splitBeforeTranslation />
+  </Button>;
+};
+
+export default ComposerSubmitButton;

--- a/packages/lesswrong/components/sunshineDashboard/supermod/ModerationContentList.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/supermod/ModerationContentList.tsx
@@ -80,6 +80,7 @@ const ModerationContentList = ({
               isFocused={item._id === focusedItemId}
               isRunningLlmCheck={item._id === runningLlmCheckId}
               onOpen={() => dispatch({ type: 'OPEN_CONTENT', contentIndex: idx })}
+              onReject={() => dispatch({ type: 'OPEN_CONTENT', contentIndex: idx, sidebarTab: 'reject' })}
               dispatch={dispatch}
             />
           ))}

--- a/packages/lesswrong/components/sunshineDashboard/supermod/ModerationInbox.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/supermod/ModerationInbox.tsx
@@ -135,7 +135,8 @@ const ModerationInboxInner = ({ users, posts, classifiedPosts, curationPosts, la
 
   const [state, dispatch] = useReducer(
     inboxStateReducer,
-    { users: [], posts: [], classifiedPosts: [], curationPosts: [], activeTab: 'all', focusedUserId: null, openedUserId: initialOpenedUserId, focusedPostId: null, focusedContentIndex: 0, undoQueue: [], history: [], runningLlmCheckId: null },
+    { users: [], posts: [], classifiedPosts: [], curationPosts: [], activeTab: 'all', focusedUserId: null, openedUserId: initialOpenedUserId, focusedPostId: null, focusedContentIndex: 0,
+          sidebarTab: null, undoQueue: [], history: [], runningLlmCheckId: null },
     (): InboxState => {
       const initialUsers = directUser ? [directUser, ...users] : users;
       if (initialUsers.length === 0 && posts.length === 0 && classifiedPosts.length === 0 && curationPosts.length === 0) {
@@ -149,6 +150,7 @@ const ModerationInboxInner = ({ users, posts, classifiedPosts, curationPosts, la
           openedUserId: null,
           focusedPostId: null,
           focusedContentIndex: 0,
+          sidebarTab: null,
           undoQueue: [],
           history: [],
           runningLlmCheckId: null,
@@ -166,6 +168,7 @@ const ModerationInboxInner = ({ users, posts, classifiedPosts, curationPosts, la
           openedUserId: initialOpenedUserId,
           focusedPostId: null,
           focusedContentIndex: 0,
+          sidebarTab: null,
           undoQueue: [],
           history: [],
           runningLlmCheckId: null,
@@ -194,6 +197,7 @@ const ModerationInboxInner = ({ users, posts, classifiedPosts, curationPosts, la
           openedUserId: null,
           focusedPostId: curationPosts[0]?._id ?? null,
           focusedContentIndex: 0,
+          sidebarTab: null,
           undoQueue: [],
           history: [],
           runningLlmCheckId: null,
@@ -211,6 +215,7 @@ const ModerationInboxInner = ({ users, posts, classifiedPosts, curationPosts, la
           openedUserId: null,
           focusedPostId: posts[0]?._id ?? null,
           focusedContentIndex: 0,
+          sidebarTab: null,
           undoQueue: [],
           history: [],
           runningLlmCheckId: null,
@@ -228,6 +233,7 @@ const ModerationInboxInner = ({ users, posts, classifiedPosts, curationPosts, la
           openedUserId: null,
           focusedPostId: classifiedPosts[0]?._id ?? null,
           focusedContentIndex: 0,
+          sidebarTab: null,
           undoQueue: [],
           history: [],
           runningLlmCheckId: null,
@@ -247,6 +253,7 @@ const ModerationInboxInner = ({ users, posts, classifiedPosts, curationPosts, la
         openedUserId: initialOpenedUserId,
         focusedPostId: null,
         focusedContentIndex: 0,
+          sidebarTab: null,
         undoQueue: [],
         history: [],
         runningLlmCheckId: null,
@@ -419,6 +426,7 @@ const ModerationInboxInner = ({ users, posts, classifiedPosts, curationPosts, la
           addToUndoQueue={addToUndoQueue}
           undoQueue={state.undoQueue}
           isDetailView={!!state.openedUserId}
+          onFocusRejectTab={() => dispatch({ type: 'SET_SIDEBAR_TAB', tab: 'reject' })}
           dispatch={dispatch}
         />
       )}
@@ -440,6 +448,7 @@ const ModerationInboxInner = ({ users, posts, classifiedPosts, curationPosts, la
               comments={userComments}
               focusedContentIndex={state.focusedContentIndex}
               runningLlmCheckId={state.runningLlmCheckId}
+              sidebarTab={state.sidebarTab}
               dispatch={dispatch}
               state={state}
             />

--- a/packages/lesswrong/components/sunshineDashboard/supermod/ModerationInbox.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/supermod/ModerationInbox.tsx
@@ -135,8 +135,7 @@ const ModerationInboxInner = ({ users, posts, classifiedPosts, curationPosts, la
 
   const [state, dispatch] = useReducer(
     inboxStateReducer,
-    { users: [], posts: [], classifiedPosts: [], curationPosts: [], activeTab: 'all', focusedUserId: null, openedUserId: initialOpenedUserId, focusedPostId: null, focusedContentIndex: 0,
-          sidebarTab: null, undoQueue: [], history: [], runningLlmCheckId: null },
+    { users: [], posts: [], classifiedPosts: [], curationPosts: [], activeTab: 'all', focusedUserId: null, openedUserId: initialOpenedUserId, focusedPostId: null, focusedContentIndex: 0, sidebarTab: null, undoQueue: [], history: [], runningLlmCheckId: null },
     (): InboxState => {
       const initialUsers = directUser ? [directUser, ...users] : users;
       if (initialUsers.length === 0 && posts.length === 0 && classifiedPosts.length === 0 && curationPosts.length === 0) {
@@ -253,7 +252,7 @@ const ModerationInboxInner = ({ users, posts, classifiedPosts, curationPosts, la
         openedUserId: initialOpenedUserId,
         focusedPostId: null,
         focusedContentIndex: 0,
-          sidebarTab: null,
+        sidebarTab: null,
         undoQueue: [],
         history: [],
         runningLlmCheckId: null,

--- a/packages/lesswrong/components/sunshineDashboard/supermod/ModerationSectionTitle.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/supermod/ModerationSectionTitle.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { defineStyles, useStyles } from '@/components/hooks/useStyles';
+
+const styles = defineStyles('ModerationSectionTitle', (theme: ThemeType) => ({
+  root: {
+    fontSize: 12,
+    fontWeight: 600,
+    textTransform: 'uppercase',
+    color: theme.palette.grey[600],
+    letterSpacing: '0.5px',
+    flexShrink: 0,
+  },
+}));
+
+const ModerationSectionTitle = ({ children }: { children: React.ReactNode }) => {
+  const classes = useStyles(styles);
+  return <div className={classes.root}>{children}</div>;
+};
+
+export default ModerationSectionTitle;

--- a/packages/lesswrong/components/sunshineDashboard/supermod/ModerationSidebar.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/supermod/ModerationSidebar.tsx
@@ -2,7 +2,10 @@ import React from 'react';
 import { defineStyles, useStyles } from '@/components/hooks/useStyles';
 import SunshineUserMessages from '../SunshineUserMessages';
 import SupermodModeratorActions from './SupermodModeratorActions';
+import ModerationSectionTitle from './ModerationSectionTitle';
 import type { InboxAction } from './inboxReducer';
+import type { ContentItem } from './helpers';
+import type { SidebarTab, SelectedSidebarTab } from './sidebarTabs';
 
 const styles = defineStyles('ModerationSidebar', (theme: ThemeType) => ({
   root: {
@@ -26,14 +29,6 @@ const styles = defineStyles('ModerationSidebar', (theme: ThemeType) => ({
       borderBottom: theme.palette.border.normal,
     },
   },
-  sectionTitle: {
-    fontSize: 12,
-    fontWeight: 600,
-    textTransform: 'uppercase',
-    color: theme.palette.grey[600],
-    letterSpacing: '0.5px',
-    flexShrink: 0,
-  },
   userMessages: {
     overflow: 'auto',
   },
@@ -44,12 +39,18 @@ const ModerationSidebar = ({
   currentUser,
   posts,
   comments,
+  focusedContent,
+  sidebarTab,
+  setSidebarTab,
   dispatch,
 }: {
   user: SunshineUsersList;
   currentUser: UsersCurrent;
   posts: SunshinePostsList[];
   comments: SunshineCommentsList[];
+  focusedContent: ContentItem | null;
+  sidebarTab: SelectedSidebarTab;
+  setSidebarTab: (tab: SidebarTab) => void;
   dispatch: React.ActionDispatch<[action: InboxAction]>;
 }) => {
   const classes = useStyles(styles);
@@ -67,15 +68,22 @@ const ModerationSidebar = ({
   return (
     <div className={classes.root}>
       <div className={classes.section}>
-        <div className={classes.sectionTitle}>Moderator Actions</div>
+        <ModerationSectionTitle>Moderator Actions</ModerationSectionTitle>
         <SupermodModeratorActions user={user} dispatch={dispatch} />
       </div>
       <div className={classes.section}>
-        <div className={classes.sectionTitle}>User Messages</div>
-
         <div className={classes.userMessages}>
           {/* TODO: maybe "expand" should actually open a model with the contents, since expanding a conversation inline is kind of annoying with the "no overflow" thing */}
-          <SunshineUserMessages key={user._id} user={user} currentUser={currentUser} posts={posts} comments={comments} showExpandablePreview />
+          <SunshineUserMessages
+            key={user._id}
+            user={user}
+            currentUser={currentUser}
+            posts={posts}
+            comments={comments}
+            focusedContent={focusedContent}
+            sidebarTab={sidebarTab}
+            setSidebarTab={setSidebarTab}
+          />
         </div>
       </div>
     </div>

--- a/packages/lesswrong/components/sunshineDashboard/supermod/ModerationSidebar.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/supermod/ModerationSidebar.tsx
@@ -5,7 +5,7 @@ import SupermodModeratorActions from './SupermodModeratorActions';
 import ModerationSectionTitle from './ModerationSectionTitle';
 import type { InboxAction } from './inboxReducer';
 import type { ContentItem } from './helpers';
-import type { SidebarTab, SelectedSidebarTab } from './sidebarTabs';
+import type { SelectedSidebarTab } from './sidebarTabs';
 
 const styles = defineStyles('ModerationSidebar', (theme: ThemeType) => ({
   root: {
@@ -50,7 +50,7 @@ const ModerationSidebar = ({
   comments: SunshineCommentsList[];
   focusedContent: ContentItem | null;
   sidebarTab: SelectedSidebarTab;
-  setSidebarTab: (tab: SidebarTab) => void;
+  setSidebarTab: (tab: SelectedSidebarTab) => void;
   dispatch: React.ActionDispatch<[action: InboxAction]>;
 }) => {
   const classes = useStyles(styles);

--- a/packages/lesswrong/components/sunshineDashboard/supermod/ModerationUserContentItem.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/supermod/ModerationUserContentItem.tsx
@@ -201,12 +201,15 @@ const ModerationUserContentItem = ({
   isFocused,
   isRunningLlmCheck,
   onOpen,
+  onReject,
   dispatch,
 }: {
   item: ContentItem;
   isFocused: boolean;
   isRunningLlmCheck: boolean;
   onOpen: () => void;
+  /** Selects this item and opens the sidebar's reject composer for it. */
+  onReject: () => void;
   dispatch: React.Dispatch<InboxAction>;
 }) => {
   const classes = useStyles(styles);
@@ -344,7 +347,7 @@ const ModerationUserContentItem = ({
 
       {!item.rejected && item.authorIsUnreviewed && (
         <div className={classes.rejectButtonContainer} onClick={(e) => e.stopPropagation()}>
-          <RejectContentButton contentWrapper={contentWrapper} />
+          <RejectContentButton contentWrapper={contentWrapper} onReject={onReject} />
           <KeystrokeDisplay keystroke="R" />
         </div>
       )}

--- a/packages/lesswrong/components/sunshineDashboard/supermod/ModerationUserDetailView.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/supermod/ModerationUserDetailView.tsx
@@ -7,7 +7,7 @@ import ModerationSidebar from './ModerationSidebar';
 import ModerationUndoHistory from './ModerationUndoHistory';
 import ModerationUserInfoColumn from './ModerationUserInfoColumn';
 import { prettyScrollbars } from '@/themes/styleUtils';
-import type { SidebarTab, SelectedSidebarTab } from './sidebarTabs';
+import type { SelectedSidebarTab } from './sidebarTabs';
 
 const styles = defineStyles('ModerationUserDetailView', (theme: ThemeType) => ({
   root: {
@@ -69,7 +69,7 @@ const ModerationUserDetailView = ({
   const classes = useStyles(styles);
 
   const setSidebarTab = useCallback(
-    (tab: SidebarTab) => dispatch({ type: 'SET_SIDEBAR_TAB', tab }),
+    (tab: SelectedSidebarTab) => dispatch({ type: 'SET_SIDEBAR_TAB', tab }),
     [dispatch]
   );
 

--- a/packages/lesswrong/components/sunshineDashboard/supermod/ModerationUserDetailView.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/supermod/ModerationUserDetailView.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import { defineStyles, useStyles } from '@/components/hooks/useStyles';
 import ModerationContentList from './ModerationContentList';
 import ModerationContentDetail from './ModerationContentDetail';
@@ -7,6 +7,7 @@ import ModerationSidebar from './ModerationSidebar';
 import ModerationUndoHistory from './ModerationUndoHistory';
 import ModerationUserInfoColumn from './ModerationUserInfoColumn';
 import { prettyScrollbars } from '@/themes/styleUtils';
+import type { SidebarTab, SelectedSidebarTab } from './sidebarTabs';
 
 const styles = defineStyles('ModerationUserDetailView', (theme: ThemeType) => ({
   root: {
@@ -50,6 +51,7 @@ const ModerationUserDetailView = ({
   comments,
   focusedContentIndex,
   runningLlmCheckId,
+  sidebarTab,
   dispatch,
   state,
   currentUser,
@@ -59,13 +61,19 @@ const ModerationUserDetailView = ({
   comments: SunshineCommentsList[];
   focusedContentIndex: number;
   runningLlmCheckId: string | null;
+  sidebarTab: SelectedSidebarTab;
   dispatch: React.ActionDispatch<[action: InboxAction]>;
   state: InboxState;
   currentUser: UsersCurrent;
 }) => {
   const classes = useStyles(styles);
 
-  const allContent = useMemo(() => [...posts, ...comments].sort((a, b) => 
+  const setSidebarTab = useCallback(
+    (tab: SidebarTab) => dispatch({ type: 'SET_SIDEBAR_TAB', tab }),
+    [dispatch]
+  );
+
+  const allContent = useMemo(() => [...posts, ...comments].sort((a, b) =>
     new Date(b.postedAt).getTime() - new Date(a.postedAt).getTime()
   ), [posts, comments]);
 
@@ -110,6 +118,9 @@ const ModerationUserDetailView = ({
             currentUser={currentUser}
             posts={posts}
             comments={comments}
+            focusedContent={focusedContent}
+            sidebarTab={sidebarTab}
+            setSidebarTab={setSidebarTab}
             dispatch={dispatch}
           />
         </div>

--- a/packages/lesswrong/components/sunshineDashboard/supermod/ModerationUserKeyboardHandler.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/supermod/ModerationUserKeyboardHandler.tsx
@@ -14,7 +14,7 @@ import type { InboxAction, UndoHistoryItem } from './inboxReducer';
 import { useUserContentPermissions } from './useUserContentPermissions';
 import RejectContentDialog from '../RejectContentDialog';
 import { useRejectContent } from '@/components/hooks/useRejectContent';
-import { ContentItem, isPost } from './helpers';
+import { canRejectContent, ContentItem, isPost } from './helpers';
 import { useMessages } from '@/components/common/withMessages';
 import { useRerunLlmCheck } from './useRerunLlmCheck';
 
@@ -39,10 +39,6 @@ const ApproveCurrentContentOnlyMutation = gql(`
     approveUserCurrentContentOnly(userId: $userId)
   }
 `);
-
-function canRejectCurrentlySelectedContent(selectedContent?: ContentItem) {
-  return selectedContent && !selectedContent.rejected && selectedContent.authorIsUnreviewed;
-}
 
 function canRerunLlmCheck(selectedContent?: ContentItem) {
   if (!selectedContent) return false;
@@ -81,6 +77,7 @@ const ModerationUserKeyboardHandler = ({
   addToUndoQueue,
   undoQueue,
   isDetailView,
+  onFocusRejectTab,
   dispatch,
 }: {
   onNextUser: () => void;
@@ -95,6 +92,8 @@ const ModerationUserKeyboardHandler = ({
   currentUser: UsersCurrent;
   addToUndoQueue: (actionLabel: string, executeAction: () => Promise<void>) => void;
   undoQueue: UndoHistoryItem[];
+  /** Moves the moderation sidebar to its "reject the selected content" tab. */
+  onFocusRejectTab: () => void;
   dispatch: React.ActionDispatch<[action: InboxAction]>;
 }) => {
   const { openDialog } = useDialog();
@@ -106,7 +105,6 @@ const ModerationUserKeyboardHandler = ({
   const { posts, comments } = useModeratedUserContents(selectedUser?._id ?? '', 20);
 
   const {
-    rejectContent,
     unrejectContent,
     rejectionTemplates,
   } = useRejectContent();
@@ -266,33 +264,6 @@ const ModerationUserKeyboardHandler = ({
       sunshineNotes: newNotes,
     });
   }, [selectedUser, getModSignatureWithNote, dispatch, updateUserWith]);
-
-  const handleRejectCurrentContent = useCallback(() => {
-    if (!selectedUser) return;
-    if (!selectedContent || !canRejectCurrentlySelectedContent(selectedContent)) return;
-
-    const contentWrapper = isPost(selectedContent) ? {
-      collectionName: 'Posts' as const,
-      document: selectedContent,
-    } : {
-      collectionName: 'Comments' as const,
-      document: selectedContent,
-    };
-
-    const handleRejectContent = (reason: string) => { void rejectContent({ ...contentWrapper, reason }); };
-
-    openDialog({
-      name: 'RejectContentDialog',
-      contents: ({ onClose }) => (
-        <RejectContentDialog
-          rejectionTemplates={rejectionTemplates}
-          rejectContent={handleRejectContent}
-          displayName={selectedUser.displayName}
-          onClose={onClose}
-        />
-      ),
-    });
-  }, [openDialog, rejectContent, rejectionTemplates, selectedContent, selectedUser]);
 
   const handleUnrejectCurrentContent = useCallback(() => {
     if (!selectedUser) return;
@@ -488,12 +459,12 @@ const ModerationUserKeyboardHandler = ({
       || !selectedUser
       || (selectedContent?.rejected
           ? !selectedContent.rejected
-          : !canRejectCurrentlySelectedContent(selectedContent))
+          : !canRejectContent(selectedContent))
     ),
     execute: selectedContent?.rejected
       ? handleUnrejectCurrentContent
-      : handleRejectCurrentContent,
-  }), [isDetailView, selectedUser, selectedContent, handleRejectCurrentContent, handleUnrejectCurrentContent]);
+      : onFocusRejectTab,
+  }), [isDetailView, selectedUser, selectedContent, onFocusRejectTab, handleUnrejectCurrentContent]);
 
   const rejectLatestAndRemoveCommand: CommandPaletteItem = useMemo(() => ({
     label: 'Reject Latest & Remove',

--- a/packages/lesswrong/components/sunshineDashboard/supermod/RejectContentPanel.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/supermod/RejectContentPanel.tsx
@@ -2,9 +2,7 @@ import React, { useCallback, useEffect, useRef, useState } from 'react';
 import dynamic from 'next/dynamic';
 import { defineStyles, useStyles } from '@/components/hooks/useStyles';
 import ContentStyles from '@/components/common/ContentStyles';
-import { ContentItemBody } from '@/components/contents/ContentItemBody';
-import { AppendToEditorProvider, useAppendToEditor } from '@/components/editor/AppendToEditorContext';
-import { focusLexicalEditor, focusLexicalEditorAtEnd } from '@/components/editor/focusLexicalEditor';
+import { focusLexicalEditorAtEnd } from '@/components/editor/focusLexicalEditor';
 import { useGlobalKeydown } from '@/components/common/withGlobalKeydown';
 import { useRejectContent } from '@/components/hooks/useRejectContent';
 import { standardRejectionIntroHtml, standardRejectionIntroPlaintext } from '@/lib/collections/moderationTemplates/rejectionIntro';
@@ -20,83 +18,229 @@ const styles = defineStyles('RejectContentPanel', (theme: ThemeType) => ({
   root: {
     marginTop: 16,
   },
-  introMessage: {
+  // Read-only preview of the message being composed; clicking it swaps in
+  // the full editor for the rare case where the message needs hand-editing
+  messagePreview: {
     marginBottom: 10,
     padding: 12,
     backgroundColor: theme.palette.grey[100],
     borderRadius: 4,
     fontSize: 14,
     cursor: 'pointer',
-    '& p': {
-      margin: '0 0 10px 0',
-      '&:last-child': {
-        margin: 0,
-      }
-    },
-    '& a': {
-      color: theme.palette.primary.main,
-    }
   },
-  // Boilerplate the moderator has read a thousand times; one line until clicked
+  // Boilerplate the moderator has read a thousand times; one line only
   collapsedIntro: {
     whiteSpace: 'nowrap',
     overflow: 'hidden',
     textOverflow: 'ellipsis',
   },
+  reasonLead: {
+    fontWeight: 600,
+    marginTop: 6,
+  },
   editorContainer: {
+    marginBottom: 10,
     // One line tall until the moderator types or inserts a template
     '--lexical-comment-min-height': '1em',
   },
 }));
 
+const TEMPLATE_SEPARATOR = '<p><br></p>';
+
+interface AddedRejectionTemplate {
+  templateId: string;
+  lead: string;
+  html: string;
+}
+
 function appendHtml(existingHtml: string, newHtml: string) {
-  const separator = existingHtml.trim() ? '<p><br></p>' : '';
+  const separator = existingHtml.trim() ? TEMPLATE_SEPARATOR : '';
   return `${existingHtml}${separator}${newHtml}`;
 }
 
-const RejectContentEditor = ({ user, focusedContent, active, editorContainerRef, onArrowDownPastEnd }: {
+function joinTemplateHtml(templates: AddedRejectionTemplate[]) {
+  return templates.map(t => t.html).join(TEMPLATE_SEPARATOR);
+}
+
+function normalizeText(text: string) {
+  return text.replace(/\s+/g, ' ').trim();
+}
+
+/**
+ * Removal of an inserted template's html from a hand-editable document.
+ * First tries excising the chunk verbatim (exact while the document hasn't
+ * been re-serialized by the editor). Once the moderator has typed, the editor
+ * rewrites the whole document's markup, so it falls back to finding the
+ * contiguous run of block elements whose text matches the template's text and
+ * removing those (plus one adjacent separator paragraph). Returns null when
+ * the template can't be found — i.e. its own text has been edited — in which
+ * case the caller leaves the document alone.
+ */
+function removeTemplateChunk(fullHtml: string, chunkHtml: string): string | null {
+  const candidates = [TEMPLATE_SEPARATOR + chunkHtml, chunkHtml + TEMPLATE_SEPARATOR, chunkHtml];
+  const foundCandidate = candidates.find(candidate => fullHtml.includes(candidate));
+  if (foundCandidate) {
+    return fullHtml.replace(foundCandidate, '');
+  }
+  return removeTemplateChunkByText(fullHtml, chunkHtml);
+}
+
+function removeTemplateChunkByText(fullHtml: string, chunkHtml: string): string | null {
+  const parser = new DOMParser();
+  const targetText = normalizeText(parser.parseFromString(chunkHtml, 'text/html').body.textContent ?? '');
+  if (!targetText) return null;
+
+  const doc = parser.parseFromString(fullHtml, 'text/html');
+  const blocks = Array.from(doc.body.children);
+  for (let start = 0; start < blocks.length; start++) {
+    // Runs start on a block with text, so separator paragraphs stay adjacent
+    // to their own template and the cleanup below removes exactly one
+    if (!normalizeText(blocks[start].textContent ?? '')) continue;
+    let combined = '';
+    for (let end = start; end < blocks.length; end++) {
+      const blockText = normalizeText(blocks[end].textContent ?? '');
+      if (blockText) {
+        combined = combined ? `${combined} ${blockText}` : blockText;
+      }
+      if (combined === targetText) {
+        const blocksToRemove = blocks.slice(start, end + 1);
+        // The separator paragraph between templates would otherwise linger
+        // as a stray blank line
+        const previousBlock = blocks[start - 1];
+        const nextBlock = blocks[end + 1];
+        if (previousBlock && !normalizeText(previousBlock.textContent ?? '')) {
+          blocksToRemove.push(previousBlock);
+        } else if (nextBlock && !normalizeText(nextBlock.textContent ?? '')) {
+          blocksToRemove.push(nextBlock);
+        }
+        blocksToRemove.forEach(block => block.remove());
+        return doc.body.innerHTML;
+      }
+      if (combined && !targetText.startsWith(combined)) break;
+    }
+  }
+  return null;
+}
+
+/**
+ * The bolded lead-in a rejection template opens with (e.g. "Missing some
+ * rationality basics."), shown in the collapsed preview as each rejection
+ * reason is added. Falls back to the start of the template's text.
+ */
+function extractBoldLead(html: string): string {
+  const doc = new DOMParser().parseFromString(html, 'text/html');
+  const lead = doc.querySelector('strong, b')?.textContent?.trim();
+  if (lead) return lead;
+  const text = doc.body.textContent?.replace(/\s+/g, ' ').trim() ?? '';
+  return text.length > 60 ? `${text.slice(0, 60)}…` : text;
+}
+
+/**
+ * Composer for the rejection message. By default the message is never edited
+ * directly: a grey preview shows the intro boilerplate plus the bold lead-in
+ * of each rejection template added from the list below, so the moderator sees
+ * the message being composed without an editor in the way. Clicking or
+ * hitting Enter on a template toggles it: already-inserted templates are
+ * removed from the message, leaving the others. Clicking the preview (or
+ * Tab/ArrowUp from the template search) opens a full editor over the entire
+ * message — intro included — for hand-editing.
+ *
+ * While previewing, the submitted reason is just the added templates and the
+ * server prepends its canonical intro (with a link to the rejected content).
+ * Once the editor is opened, the whole document is submitted and the server
+ * uses it verbatim, substituting the content link for the "[content]"
+ * placeholder.
+ */
+const RejectContentEditor = ({ user, focusedContent, active, editorContainerRef, composerFocusToken, registerToggleTemplate, onArrowDownPastEnd }: {
   user: SunshineUsersList,
   focusedContent: ContentItem,
   // False while the panel is hidden (but kept mounted to preserve the draft)
   active: boolean,
   editorContainerRef: React.RefObject<HTMLDivElement | null>,
+  // Bumped when the template list hands focus to the composer; opens the editor
+  composerFocusToken: number,
+  registerToggleTemplate: (fn: (template: ModerationTemplateFragment) => void) => void,
   onArrowDownPastEnd: () => void,
 }) => {
   const classes = useStyles(styles);
   const { rejectContent } = useRejectContent();
-  const { registerAppendToEditor } = useAppendToEditor();
 
-  // Contents live in a ref so typing doesn't re-render the template list;
-  // editorHtml only seeds (re)mounts
-  const rejectedReasonRef = useRef('');
+  // Source of truth while the preview is showing; the reasons html is derived
+  const [addedTemplates, setAddedTemplates] = useState<AddedRejectionTemplate[]>([]);
+  // Full message (intro + reasons), canonical once the editor is open
+  const fullMessageRef = useRef('');
+  const [editorOpen, setEditorOpen] = useState(false);
   const [editorHtml, setEditorHtml] = useState('');
-  const [hasRejectedReason, setHasRejectedReason] = useState(false);
   const [lexicalEditorVersion, setLexicalEditorVersion] = useState(0);
-  const [introExpanded, setIntroExpanded] = useState(false);
+  const handledFocusTokenRef = useRef(0);
 
-  const setEditorContents = useCallback((html: string) => {
-    rejectedReasonRef.current = html;
-    setEditorHtml(html);
-    setHasRejectedReason(!!html);
+  const openEditor = useCallback(() => {
+    if (editorOpen) return;
+    fullMessageRef.current = standardRejectionIntroHtml + joinTemplateHtml(addedTemplates);
+    setEditorHtml(fullMessageRef.current);
     setLexicalEditorVersion(prev => prev + 1);
-  }, []);
+    setEditorOpen(true);
+  }, [editorOpen, addedTemplates]);
 
-  const handleEditorChange = useCallback((html: string) => {
-    rejectedReasonRef.current = html;
-    // Same-value setState bails out, so typing doesn't re-render the list.
-    setHasRejectedReason(!!html);
-  }, []);
+  // Focus once the editor has mounted after opening
+  useEffect(() => {
+    if (editorOpen) {
+      focusLexicalEditorAtEnd(editorContainerRef.current);
+    }
+  }, [editorOpen, editorContainerRef]);
 
   useEffect(() => {
-    registerAppendToEditor((html: string) => {
-      setEditorContents(appendHtml(rejectedReasonRef.current, html));
-      focusLexicalEditor(editorContainerRef.current);
-    });
-    return () => registerAppendToEditor(() => {});
-  }, [registerAppendToEditor, setEditorContents, editorContainerRef]);
+    if (composerFocusToken && composerFocusToken !== handledFocusTokenRef.current) {
+      handledFocusTokenRef.current = composerFocusToken;
+      openEditor();
+      // No-op while the editor is still mounting (the effect above covers it)
+      focusLexicalEditorAtEnd(editorContainerRef.current);
+    }
+  }, [composerFocusToken, openEditor, editorContainerRef]);
+
+  const handleEditorChange = useCallback((html: string) => {
+    // Contents live in a ref so typing doesn't re-render the template list
+    fullMessageRef.current = html;
+  }, []);
+
+  const toggleTemplate = useCallback((template: ModerationTemplateFragment) => {
+    if (!template.contents?.html) return;
+    const html = getDraftMessageHtml({ html: template.contents.html, displayName: user.displayName });
+    const existing = addedTemplates.find(t => t.templateId === template._id);
+
+    if (!existing) {
+      setAddedTemplates(prev => [...prev, { templateId: template._id, lead: extractBoldLead(html), html }]);
+      if (editorOpen) {
+        fullMessageRef.current = appendHtml(fullMessageRef.current, html);
+        setEditorHtml(fullMessageRef.current);
+        setLexicalEditorVersion(prev => prev + 1);
+        focusLexicalEditorAtEnd(editorContainerRef.current);
+      }
+      return;
+    }
+
+    if (editorOpen) {
+      // Only drop the entry if the template was actually excised; if the
+      // moderator has edited the template's own text it can't be identified
+      // anymore, and the toggle leaves everything (custom edits included) alone
+      const withChunkRemoved = removeTemplateChunk(fullMessageRef.current, existing.html);
+      if (withChunkRemoved === null) return;
+      fullMessageRef.current = withChunkRemoved;
+      setEditorHtml(withChunkRemoved);
+      setLexicalEditorVersion(prev => prev + 1);
+    }
+    setAddedTemplates(prev => prev.filter(t => t.templateId !== template._id));
+  }, [addedTemplates, editorOpen, user.displayName, editorContainerRef]);
+
+  useEffect(() => {
+    registerToggleTemplate(toggleTemplate);
+    return () => registerToggleTemplate(() => {});
+  }, [registerToggleTemplate, toggleTemplate]);
+
+  const hasRejectedReason = editorOpen || addedTemplates.length > 0;
 
   const handleReject = useCallback(() => {
-    const reason = rejectedReasonRef.current;
+    const reason = editorOpen ? fullMessageRef.current : joinTemplateHtml(addedTemplates);
     if (!reason) return;
 
     if (isPost(focusedContent)) {
@@ -104,8 +248,12 @@ const RejectContentEditor = ({ user, focusedContent, active, editorContainerRef,
     } else {
       void rejectContent({ collectionName: 'Comments', document: focusedContent, reason });
     }
-    setEditorContents('');
-  }, [focusedContent, rejectContent, setEditorContents]);
+    fullMessageRef.current = '';
+    setAddedTemplates([]);
+    setEditorOpen(false);
+    setEditorHtml('');
+    setLexicalEditorVersion(prev => prev + 1);
+  }, [editorOpen, addedTemplates, focusedContent, rejectContent]);
 
   useGlobalKeydown(useCallback((e: KeyboardEvent) => {
     if (!active) return;
@@ -116,14 +264,11 @@ const RejectContentEditor = ({ user, focusedContent, active, editorContainerRef,
   }, [active, hasRejectedReason, handleReject]));
 
   return <div className={classes.root}>
-    <div className={classes.introMessage} onClick={() => setIntroExpanded(!introExpanded)}>
-      {introExpanded
-        ? <ContentStyles contentType='comment'>
-            <ContentItemBody dangerouslySetInnerHTML={{__html: standardRejectionIntroHtml}} />
-          </ContentStyles>
-        : <div className={classes.collapsedIntro}>{standardRejectionIntroPlaintext}</div>}
-    </div>
-    <ComposerKeydownWrapper className={classes.editorContainer} containerRef={editorContainerRef} onArrowDownPastEnd={onArrowDownPastEnd}>
+    {!editorOpen && <div className={classes.messagePreview} onClick={openEditor}>
+      <div className={classes.collapsedIntro}>{standardRejectionIntroPlaintext}</div>
+      {addedTemplates.map(template => <div key={template.templateId} className={classes.reasonLead}>{template.lead}</div>)}
+    </div>}
+    {editorOpen && <ComposerKeydownWrapper className={classes.editorContainer} containerRef={editorContainerRef} onArrowDownPastEnd={onArrowDownPastEnd}>
       <ContentStyles contentType='comment'>
         <LexicalEditor
           key={lexicalEditorVersion}
@@ -133,36 +278,14 @@ const RejectContentEditor = ({ user, focusedContent, active, editorContainerRef,
           commentEditor
         />
       </ContentStyles>
-    </ComposerKeydownWrapper>
+    </ComposerKeydownWrapper>}
     <ComposerSubmitButton label="Reject" disabled={!hasRejectedReason} onClick={handleReject} />
   </div>;
 };
 
-const RejectionTemplateList = ({ displayName, focusSearchToken, active, onFocusComposer }: {
-  displayName: string,
-  focusSearchToken: number,
-  active: boolean,
-  onFocusComposer: () => void,
-}) => {
-  const { appendToEditor } = useAppendToEditor();
-
-  const handleTemplateClick = (template: ModerationTemplateFragment) => {
-    if (!template.contents?.html) return;
-    appendToEditor(getDraftMessageHtml({ html: template.contents.html, displayName }));
-  };
-
-  return <GroupedModerationTemplateList
-    collectionName="Rejections"
-    onTemplateClick={handleTemplateClick}
-    focusSearchToken={focusSearchToken}
-    active={active}
-    onFocusComposer={onFocusComposer}
-  />;
-};
-
 /**
  * Inline replacement for RejectContentDialog in the moderation sidebar:
- * clicking a template below the editor appends its text as a reason.
+ * clicking a template below the composer toggles it as a rejection reason.
  * Stays mounted while `active` is false so the draft survives the tab
  * being toggled closed and reopened.
  */
@@ -172,7 +295,13 @@ const RejectContentPanel = ({ user, focusedContent, active }: {
   active: boolean,
 }) => {
   const [templateSearchToken, setTemplateSearchToken] = useState(0);
+  const [composerFocusToken, setComposerFocusToken] = useState(0);
   const editorContainerRef = useRef<HTMLDivElement>(null);
+  const toggleTemplateRef = useRef<(template: ModerationTemplateFragment) => void>(() => {});
+
+  const registerToggleTemplate = useCallback((fn: (template: ModerationTemplateFragment) => void) => {
+    toggleTemplateRef.current = fn;
+  }, []);
 
   // The template search is the initial keyboard target whenever the tab is picked
   useEffect(() => {
@@ -181,21 +310,24 @@ const RejectContentPanel = ({ user, focusedContent, active }: {
     }
   }, [active]);
 
-  return <AppendToEditorProvider>
+  return <>
     <RejectContentEditor
       user={user}
       focusedContent={focusedContent}
       active={active}
       editorContainerRef={editorContainerRef}
+      composerFocusToken={composerFocusToken}
+      registerToggleTemplate={registerToggleTemplate}
       onArrowDownPastEnd={() => setTemplateSearchToken(token => token + 1)}
     />
-    <RejectionTemplateList
-      displayName={user.displayName}
+    <GroupedModerationTemplateList
+      collectionName="Rejections"
+      onTemplateClick={(template) => toggleTemplateRef.current(template)}
       focusSearchToken={templateSearchToken}
       active={active}
-      onFocusComposer={() => focusLexicalEditorAtEnd(editorContainerRef.current)}
+      onFocusComposer={() => setComposerFocusToken(token => token + 1)}
     />
-  </AppendToEditorProvider>;
+  </>;
 };
 
 export default RejectContentPanel;

--- a/packages/lesswrong/components/sunshineDashboard/supermod/RejectContentPanel.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/supermod/RejectContentPanel.tsx
@@ -1,27 +1,24 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import dynamic from 'next/dynamic';
-import Button from '@/lib/vendor/@material-ui/core/src/Button';
 import { defineStyles, useStyles } from '@/components/hooks/useStyles';
 import ContentStyles from '@/components/common/ContentStyles';
 import { ContentItemBody } from '@/components/contents/ContentItemBody';
 import { AppendToEditorProvider, useAppendToEditor } from '@/components/editor/AppendToEditorContext';
-import { focusLexicalEditor, focusLexicalEditorWhenReady } from '@/components/editor/focusLexicalEditor';
+import { focusLexicalEditor, focusLexicalEditorAtEnd } from '@/components/editor/focusLexicalEditor';
 import { useGlobalKeydown } from '@/components/common/withGlobalKeydown';
 import { useRejectContent } from '@/components/hooks/useRejectContent';
 import { standardRejectionIntroHtml, standardRejectionIntroPlaintext } from '@/lib/collections/moderationTemplates/rejectionIntro';
 import { getDraftMessageHtml } from '@/lib/collections/messages/helpers';
 import GroupedModerationTemplateList from '../GroupedModerationTemplateList';
-import KeystrokeDisplay from './KeystrokeDisplay';
+import ComposerKeydownWrapper from './ComposerKeydownWrapper';
+import ComposerSubmitButton from './ComposerSubmitButton';
 import { isPost, type ContentItem } from './helpers';
 
 const LexicalEditor = dynamic(() => import('@/components/editor/LexicalEditor'));
 
 const styles = defineStyles('RejectContentPanel', (theme: ThemeType) => ({
-  // Rule separating the editor from the template list above it
   root: {
     marginTop: 16,
-    paddingTop: 16,
-    borderTop: theme.palette.border.normal,
   },
   introMessage: {
     marginBottom: 10,
@@ -47,7 +44,8 @@ const styles = defineStyles('RejectContentPanel', (theme: ThemeType) => ({
     textOverflow: 'ellipsis',
   },
   editorContainer: {
-    minHeight: 100,
+    // One line tall until the moderator types or inserts a template
+    '--lexical-comment-min-height': '1em',
   },
 }));
 
@@ -56,9 +54,13 @@ function appendHtml(existingHtml: string, newHtml: string) {
   return `${existingHtml}${separator}${newHtml}`;
 }
 
-const RejectContentEditor = ({ user, focusedContent }: {
+const RejectContentEditor = ({ user, focusedContent, active, editorContainerRef, onArrowDownPastEnd }: {
   user: SunshineUsersList,
   focusedContent: ContentItem,
+  // False while the panel is hidden (but kept mounted to preserve the draft)
+  active: boolean,
+  editorContainerRef: React.RefObject<HTMLDivElement | null>,
+  onArrowDownPastEnd: () => void,
 }) => {
   const classes = useStyles(styles);
   const { rejectContent } = useRejectContent();
@@ -71,7 +73,6 @@ const RejectContentEditor = ({ user, focusedContent }: {
   const [hasRejectedReason, setHasRejectedReason] = useState(false);
   const [lexicalEditorVersion, setLexicalEditorVersion] = useState(0);
   const [introExpanded, setIntroExpanded] = useState(false);
-  const editorContainerRef = useRef<HTMLDivElement>(null);
 
   const setEditorContents = useCallback((html: string) => {
     rejectedReasonRef.current = html;
@@ -92,10 +93,7 @@ const RejectContentEditor = ({ user, focusedContent }: {
       focusLexicalEditor(editorContainerRef.current);
     });
     return () => registerAppendToEditor(() => {});
-  }, [registerAppendToEditor, setEditorContents]);
-
-  // The panel only mounts on a deliberate tab pick, so taking focus is safe
-  useEffect(() => focusLexicalEditorWhenReady(editorContainerRef.current), []);
+  }, [registerAppendToEditor, setEditorContents, editorContainerRef]);
 
   const handleReject = useCallback(() => {
     const reason = rejectedReasonRef.current;
@@ -110,11 +108,12 @@ const RejectContentEditor = ({ user, focusedContent }: {
   }, [focusedContent, rejectContent, setEditorContents]);
 
   useGlobalKeydown(useCallback((e: KeyboardEvent) => {
+    if (!active) return;
     if ((e.ctrlKey || e.metaKey) && e.key === 'Enter' && hasRejectedReason) {
       e.preventDefault();
       handleReject();
     }
-  }, [hasRejectedReason, handleReject]));
+  }, [active, hasRejectedReason, handleReject]));
 
   return <div className={classes.root}>
     <div className={classes.introMessage} onClick={() => setIntroExpanded(!introExpanded)}>
@@ -124,7 +123,7 @@ const RejectContentEditor = ({ user, focusedContent }: {
           </ContentStyles>
         : <div className={classes.collapsedIntro}>{standardRejectionIntroPlaintext}</div>}
     </div>
-    <div className={classes.editorContainer} ref={editorContainerRef}>
+    <ComposerKeydownWrapper className={classes.editorContainer} containerRef={editorContainerRef} onArrowDownPastEnd={onArrowDownPastEnd}>
       <ContentStyles contentType='comment'>
         <LexicalEditor
           key={lexicalEditorVersion}
@@ -134,15 +133,17 @@ const RejectContentEditor = ({ user, focusedContent }: {
           commentEditor
         />
       </ContentStyles>
-    </div>
-    <Button onClick={handleReject} disabled={!hasRejectedReason}>
-      Reject
-      <KeystrokeDisplay keystroke="Ctrl+Enter" withMargin splitBeforeTranslation />
-    </Button>
+    </ComposerKeydownWrapper>
+    <ComposerSubmitButton label="Reject" disabled={!hasRejectedReason} onClick={handleReject} />
   </div>;
 };
 
-const RejectionTemplateList = ({ displayName }: { displayName: string }) => {
+const RejectionTemplateList = ({ displayName, focusSearchToken, active, onFocusComposer }: {
+  displayName: string,
+  focusSearchToken: number,
+  active: boolean,
+  onFocusComposer: () => void,
+}) => {
   const { appendToEditor } = useAppendToEditor();
 
   const handleTemplateClick = (template: ModerationTemplateFragment) => {
@@ -153,20 +154,47 @@ const RejectionTemplateList = ({ displayName }: { displayName: string }) => {
   return <GroupedModerationTemplateList
     collectionName="Rejections"
     onTemplateClick={handleTemplateClick}
+    focusSearchToken={focusSearchToken}
+    active={active}
+    onFocusComposer={onFocusComposer}
   />;
 };
 
 /**
  * Inline replacement for RejectContentDialog in the moderation sidebar:
- * clicking a template above the editor appends its text as a reason.
+ * clicking a template below the editor appends its text as a reason.
+ * Stays mounted while `active` is false so the draft survives the tab
+ * being toggled closed and reopened.
  */
-const RejectContentPanel = ({ user, focusedContent }: {
+const RejectContentPanel = ({ user, focusedContent, active }: {
   user: SunshineUsersList,
   focusedContent: ContentItem,
+  active: boolean,
 }) => {
+  const [templateSearchToken, setTemplateSearchToken] = useState(0);
+  const editorContainerRef = useRef<HTMLDivElement>(null);
+
+  // The template search is the initial keyboard target whenever the tab is picked
+  useEffect(() => {
+    if (active) {
+      setTemplateSearchToken(token => token + 1);
+    }
+  }, [active]);
+
   return <AppendToEditorProvider>
-    <RejectionTemplateList displayName={user.displayName} />
-    <RejectContentEditor user={user} focusedContent={focusedContent} />
+    <RejectContentEditor
+      user={user}
+      focusedContent={focusedContent}
+      active={active}
+      editorContainerRef={editorContainerRef}
+      onArrowDownPastEnd={() => setTemplateSearchToken(token => token + 1)}
+    />
+    <RejectionTemplateList
+      displayName={user.displayName}
+      focusSearchToken={templateSearchToken}
+      active={active}
+      onFocusComposer={() => focusLexicalEditorAtEnd(editorContainerRef.current)}
+    />
   </AppendToEditorProvider>;
 };
 

--- a/packages/lesswrong/components/sunshineDashboard/supermod/RejectContentPanel.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/supermod/RejectContentPanel.tsx
@@ -17,8 +17,7 @@ import { isPost, type ContentItem } from './helpers';
 const LexicalEditor = dynamic(() => import('@/components/editor/LexicalEditor'));
 
 const styles = defineStyles('RejectContentPanel', (theme: ThemeType) => ({
-  // The editor sits below the template list, so the rule separates it from the
-  // "New Rejection Reason" button above it.
+  // Rule separating the editor from the template list above it
   root: {
     marginTop: 16,
     paddingTop: 16,
@@ -41,8 +40,7 @@ const styles = defineStyles('RejectContentPanel', (theme: ThemeType) => ({
       color: theme.palette.primary.main,
     }
   },
-  // The intro is boilerplate the moderator has read a thousand times, so it
-  // starts as a single clickable line and only expands on demand.
+  // Boilerplate the moderator has read a thousand times; one line until clicked
   collapsedIntro: {
     whiteSpace: 'nowrap',
     overflow: 'hidden',
@@ -66,8 +64,8 @@ const RejectContentEditor = ({ user, focusedContent }: {
   const { rejectContent } = useRejectContent();
   const { registerAppendToEditor } = useAppendToEditor();
 
-  // Live editor contents go in a ref so typing doesn't re-render the template
-  // list; editorHtml is only the value the editor is (re)mounted with.
+  // Contents live in a ref so typing doesn't re-render the template list;
+  // editorHtml only seeds (re)mounts
   const rejectedReasonRef = useRef('');
   const [editorHtml, setEditorHtml] = useState('');
   const [hasRejectedReason, setHasRejectedReason] = useState(false);
@@ -96,8 +94,7 @@ const RejectContentEditor = ({ user, focusedContent }: {
     return () => registerAppendToEditor(() => {});
   }, [registerAppendToEditor, setEditorContents]);
 
-  // This panel only mounts once the moderator has picked the reject tab, so taking
-  // focus here is always deliberate — no tab is selected until they choose one.
+  // The panel only mounts on a deliberate tab pick, so taking focus is safe
   useEffect(() => focusLexicalEditorWhenReady(editorContainerRef.current), []);
 
   const handleReject = useCallback(() => {
@@ -160,9 +157,8 @@ const RejectionTemplateList = ({ displayName }: { displayName: string }) => {
 };
 
 /**
- * Inline replacement for RejectContentDialog inside the moderation sidebar. Rejection
- * reasons are appended into the editor by clicking the templates above it, rather than
- * composed from checkboxes in a modal.
+ * Inline replacement for RejectContentDialog in the moderation sidebar:
+ * clicking a template above the editor appends its text as a reason.
  */
 const RejectContentPanel = ({ user, focusedContent }: {
   user: SunshineUsersList,

--- a/packages/lesswrong/components/sunshineDashboard/supermod/RejectContentPanel.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/supermod/RejectContentPanel.tsx
@@ -1,0 +1,177 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import dynamic from 'next/dynamic';
+import Button from '@/lib/vendor/@material-ui/core/src/Button';
+import { defineStyles, useStyles } from '@/components/hooks/useStyles';
+import ContentStyles from '@/components/common/ContentStyles';
+import { ContentItemBody } from '@/components/contents/ContentItemBody';
+import { AppendToEditorProvider, useAppendToEditor } from '@/components/editor/AppendToEditorContext';
+import { focusLexicalEditor, focusLexicalEditorWhenReady } from '@/components/editor/focusLexicalEditor';
+import { useGlobalKeydown } from '@/components/common/withGlobalKeydown';
+import { useRejectContent } from '@/components/hooks/useRejectContent';
+import { standardRejectionIntroHtml, standardRejectionIntroPlaintext } from '@/lib/collections/moderationTemplates/rejectionIntro';
+import { getDraftMessageHtml } from '@/lib/collections/messages/helpers';
+import GroupedModerationTemplateList from '../GroupedModerationTemplateList';
+import KeystrokeDisplay from './KeystrokeDisplay';
+import { isPost, type ContentItem } from './helpers';
+
+const LexicalEditor = dynamic(() => import('@/components/editor/LexicalEditor'));
+
+const styles = defineStyles('RejectContentPanel', (theme: ThemeType) => ({
+  // The editor sits below the template list, so the rule separates it from the
+  // "New Rejection Reason" button above it.
+  root: {
+    marginTop: 16,
+    paddingTop: 16,
+    borderTop: theme.palette.border.normal,
+  },
+  introMessage: {
+    marginBottom: 10,
+    padding: 12,
+    backgroundColor: theme.palette.grey[100],
+    borderRadius: 4,
+    fontSize: 14,
+    cursor: 'pointer',
+    '& p': {
+      margin: '0 0 10px 0',
+      '&:last-child': {
+        margin: 0,
+      }
+    },
+    '& a': {
+      color: theme.palette.primary.main,
+    }
+  },
+  // The intro is boilerplate the moderator has read a thousand times, so it
+  // starts as a single clickable line and only expands on demand.
+  collapsedIntro: {
+    whiteSpace: 'nowrap',
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+  },
+  editorContainer: {
+    minHeight: 100,
+  },
+}));
+
+function appendHtml(existingHtml: string, newHtml: string) {
+  const separator = existingHtml.trim() ? '<p><br></p>' : '';
+  return `${existingHtml}${separator}${newHtml}`;
+}
+
+const RejectContentEditor = ({ user, focusedContent }: {
+  user: SunshineUsersList,
+  focusedContent: ContentItem,
+}) => {
+  const classes = useStyles(styles);
+  const { rejectContent } = useRejectContent();
+  const { registerAppendToEditor } = useAppendToEditor();
+
+  // Live editor contents go in a ref so typing doesn't re-render the template
+  // list; editorHtml is only the value the editor is (re)mounted with.
+  const rejectedReasonRef = useRef('');
+  const [editorHtml, setEditorHtml] = useState('');
+  const [hasRejectedReason, setHasRejectedReason] = useState(false);
+  const [lexicalEditorVersion, setLexicalEditorVersion] = useState(0);
+  const [introExpanded, setIntroExpanded] = useState(false);
+  const editorContainerRef = useRef<HTMLDivElement>(null);
+
+  const setEditorContents = useCallback((html: string) => {
+    rejectedReasonRef.current = html;
+    setEditorHtml(html);
+    setHasRejectedReason(!!html);
+    setLexicalEditorVersion(prev => prev + 1);
+  }, []);
+
+  const handleEditorChange = useCallback((html: string) => {
+    rejectedReasonRef.current = html;
+    // Same-value setState bails out, so typing doesn't re-render the list.
+    setHasRejectedReason(!!html);
+  }, []);
+
+  useEffect(() => {
+    registerAppendToEditor((html: string) => {
+      setEditorContents(appendHtml(rejectedReasonRef.current, html));
+      focusLexicalEditor(editorContainerRef.current);
+    });
+    return () => registerAppendToEditor(() => {});
+  }, [registerAppendToEditor, setEditorContents]);
+
+  // This panel only mounts once the moderator has picked the reject tab, so taking
+  // focus here is always deliberate — no tab is selected until they choose one.
+  useEffect(() => focusLexicalEditorWhenReady(editorContainerRef.current), []);
+
+  const handleReject = useCallback(() => {
+    const reason = rejectedReasonRef.current;
+    if (!reason) return;
+
+    if (isPost(focusedContent)) {
+      void rejectContent({ collectionName: 'Posts', document: focusedContent, reason });
+    } else {
+      void rejectContent({ collectionName: 'Comments', document: focusedContent, reason });
+    }
+    setEditorContents('');
+  }, [focusedContent, rejectContent, setEditorContents]);
+
+  useGlobalKeydown(useCallback((e: KeyboardEvent) => {
+    if ((e.ctrlKey || e.metaKey) && e.key === 'Enter' && hasRejectedReason) {
+      e.preventDefault();
+      handleReject();
+    }
+  }, [hasRejectedReason, handleReject]));
+
+  return <div className={classes.root}>
+    <div className={classes.introMessage} onClick={() => setIntroExpanded(!introExpanded)}>
+      {introExpanded
+        ? <ContentStyles contentType='comment'>
+            <ContentItemBody dangerouslySetInnerHTML={{__html: standardRejectionIntroHtml}} />
+          </ContentStyles>
+        : <div className={classes.collapsedIntro}>{standardRejectionIntroPlaintext}</div>}
+    </div>
+    <div className={classes.editorContainer} ref={editorContainerRef}>
+      <ContentStyles contentType='comment'>
+        <LexicalEditor
+          key={lexicalEditorVersion}
+          data={editorHtml}
+          placeholder={`Why is ${user.displayName}'s content being rejected?`}
+          onChange={handleEditorChange}
+          commentEditor
+        />
+      </ContentStyles>
+    </div>
+    <Button onClick={handleReject} disabled={!hasRejectedReason}>
+      Reject
+      <KeystrokeDisplay keystroke="Ctrl+Enter" withMargin splitBeforeTranslation />
+    </Button>
+  </div>;
+};
+
+const RejectionTemplateList = ({ displayName }: { displayName: string }) => {
+  const { appendToEditor } = useAppendToEditor();
+
+  const handleTemplateClick = (template: ModerationTemplateFragment) => {
+    if (!template.contents?.html) return;
+    appendToEditor(getDraftMessageHtml({ html: template.contents.html, displayName }));
+  };
+
+  return <GroupedModerationTemplateList
+    collectionName="Rejections"
+    onTemplateClick={handleTemplateClick}
+  />;
+};
+
+/**
+ * Inline replacement for RejectContentDialog inside the moderation sidebar. Rejection
+ * reasons are appended into the editor by clicking the templates above it, rather than
+ * composed from checkboxes in a modal.
+ */
+const RejectContentPanel = ({ user, focusedContent }: {
+  user: SunshineUsersList,
+  focusedContent: ContentItem,
+}) => {
+  return <AppendToEditorProvider>
+    <RejectionTemplateList displayName={user.displayName} />
+    <RejectContentEditor user={user} focusedContent={focusedContent} />
+  </AppendToEditorProvider>;
+};
+
+export default RejectContentPanel;

--- a/packages/lesswrong/components/sunshineDashboard/supermod/helpers.ts
+++ b/packages/lesswrong/components/sunshineDashboard/supermod/helpers.ts
@@ -3,3 +3,17 @@ export type ContentItem = SunshinePostsList | SunshineCommentsList;
 export function isPost(item: ContentItem): item is SunshinePostsList {
   return 'title' in item && item.title !== null;
 };
+
+export function canRejectContent(item: ContentItem | null | undefined) {
+  return !!item && !item.rejected && item.authorIsUnreviewed;
+}
+
+const CONTENT_TITLE_MAX_LENGTH = 25;
+
+/** A short label for a post or comment, for use where there's only room for one line. */
+export function getContentTitle(item: ContentItem) {
+  const title = (isPost(item) ? item.title : item.contents?.plaintextMainText) ?? "comment";
+  return title.length > CONTENT_TITLE_MAX_LENGTH
+    ? `${title.slice(0, CONTENT_TITLE_MAX_LENGTH).trimEnd()}…`
+    : title;
+}

--- a/packages/lesswrong/components/sunshineDashboard/supermod/helpers.ts
+++ b/packages/lesswrong/components/sunshineDashboard/supermod/helpers.ts
@@ -10,7 +10,7 @@ export function canRejectContent(item: ContentItem | null | undefined) {
 
 const CONTENT_TITLE_MAX_LENGTH = 25;
 
-/** A short label for a post or comment, for use where there's only room for one line. */
+/** One-line label for a post or comment */
 export function getContentTitle(item: ContentItem) {
   const title = (isPost(item) ? item.title : item.contents?.plaintextMainText) ?? "comment";
   return title.length > CONTENT_TITLE_MAX_LENGTH

--- a/packages/lesswrong/components/sunshineDashboard/supermod/inboxReducer.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/supermod/inboxReducer.tsx
@@ -118,11 +118,10 @@ export function getVisibleTabsInOrder(
 }
 
 /**
- * Moving to a different user or content item closes whichever composer was open, so
- * an editor never silently holds focus and swallows the moderation shortcuts. Listed
- * here rather than in each branch, and deliberately excluding actions that fire while
- * a moderator is mid-draft (permission toggles, LLM checks, undo bookkeeping).
- * OPEN_CONTENT is absent because it sets `sidebarTab` itself.
+ * Actions that close the open composer, so an editor never silently holds
+ * focus and swallows the moderation shortcuts. Mid-draft actions (permission
+ * toggles, LLM checks, undo bookkeeping) are deliberately absent, as is
+ * OPEN_CONTENT, which sets `sidebarTab` itself.
  */
 const SIDEBAR_TAB_CLEARING_ACTIONS: ReadonlySet<InboxAction['type']> = new Set([
   'OPEN_USER', 'CLOSE_DETAIL', 'NEXT_CONTENT', 'PREV_CONTENT',
@@ -221,8 +220,8 @@ function reduceInboxAction(state: InboxState, action: InboxAction): InboxState {
       return {
         ...state,
         focusedContentIndex: action.contentIndex,
-        // Selecting a row closes the composers, unless the caller is opening one
-        // (the row's Reject button selects the row and opens the reject tab).
+        // Closes the composer, unless the caller is opening one — the row's
+        // Reject button selects the row and opens the reject tab in one action
         sidebarTab: action.sidebarTab ?? null,
       };
     }

--- a/packages/lesswrong/components/sunshineDashboard/supermod/inboxReducer.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/supermod/inboxReducer.tsx
@@ -6,6 +6,7 @@ import { getUserReviewGroup, getTabsInPriorityOrder, type TabId } from './groupi
 import { REVIEW_GROUP_TO_PRIORITY } from '@/lib/collections/users/reviewGroups';
 import type { GroupEntry } from './ModerationInboxList';
 import type { TabInfo } from './ModerationTabs';
+import type { SelectedSidebarTab } from './sidebarTabs';
 
 export interface HistoryItem {
   user: SunshineUsersList;
@@ -45,6 +46,8 @@ export type InboxState = {
   focusedPostId: string | null;
   // Index of focused content item in detail view
   focusedContentIndex: number;
+  // Which composer is open in the moderation sidebar, or null for neither
+  sidebarTab: SelectedSidebarTab;
   // Undo queue - actions that can be undone (within 30 seconds) - only for users
   undoQueue: UndoHistoryItem[];
   // History - expired actions that can't be undone - only for users
@@ -68,7 +71,8 @@ export type InboxAction =
   | { type: 'REMOVE_POST'; postId: string; }
   | { type: 'NEXT_CONTENT'; contentLength: number; }
   | { type: 'PREV_CONTENT'; contentLength: number; }
-  | { type: 'OPEN_CONTENT'; contentIndex: number; }
+  | { type: 'OPEN_CONTENT'; contentIndex: number; sidebarTab?: SelectedSidebarTab; }
+  | { type: 'SET_SIDEBAR_TAB'; tab: SelectedSidebarTab; }
   | { type: 'UPDATE_USER'; userId: string; fields: Partial<SunshineUsersList>; }
   | { type: 'UPDATE_POST'; postId: string; fields: Partial<SunshinePostsList>; }
   | { type: 'ADD_TO_UNDO_QUEUE'; item: UndoHistoryItem; }
@@ -113,7 +117,28 @@ export function getVisibleTabsInOrder(
   return tabs;
 }
 
+/**
+ * Moving to a different user or content item closes whichever composer was open, so
+ * an editor never silently holds focus and swallows the moderation shortcuts. Listed
+ * here rather than in each branch, and deliberately excluding actions that fire while
+ * a moderator is mid-draft (permission toggles, LLM checks, undo bookkeeping).
+ * OPEN_CONTENT is absent because it sets `sidebarTab` itself.
+ */
+const SIDEBAR_TAB_CLEARING_ACTIONS: ReadonlySet<InboxAction['type']> = new Set([
+  'OPEN_USER', 'CLOSE_DETAIL', 'NEXT_CONTENT', 'PREV_CONTENT',
+  'NEXT_USER', 'PREV_USER', 'CHANGE_TAB', 'NEXT_TAB', 'PREV_TAB',
+  'REMOVE_USER', 'UNDO_ACTION',
+]);
+
 export function inboxStateReducer(state: InboxState, action: InboxAction): InboxState {
+  const newState = reduceInboxAction(state, action);
+  if (newState.sidebarTab === null || !SIDEBAR_TAB_CLEARING_ACTIONS.has(action.type)) {
+    return newState;
+  }
+  return { ...newState, sidebarTab: null };
+}
+
+function reduceInboxAction(state: InboxState, action: InboxAction): InboxState {
   switch (action.type) {
     case 'ADD_TO_UNDO_QUEUE': {
       return {
@@ -196,6 +221,16 @@ export function inboxStateReducer(state: InboxState, action: InboxAction): Inbox
       return {
         ...state,
         focusedContentIndex: action.contentIndex,
+        // Selecting a row closes the composers, unless the caller is opening one
+        // (the row's Reject button selects the row and opens the reject tab).
+        sidebarTab: action.sidebarTab ?? null,
+      };
+    }
+
+    case 'SET_SIDEBAR_TAB': {
+      return {
+        ...state,
+        sidebarTab: action.tab,
       };
     }
 

--- a/packages/lesswrong/components/sunshineDashboard/supermod/sidebarTabs.ts
+++ b/packages/lesswrong/components/sunshineDashboard/supermod/sidebarTabs.ts
@@ -1,7 +1,6 @@
 /**
- * Which composer is showing in the moderation sidebar: a DM to the user, or a
- * rejection of their currently-selected content. Null until the moderator picks
- * one — neither form is open by default, so the keyboard shortcuts keep working.
+ * Which composer is open in the moderation sidebar. Null until the moderator
+ * picks one, so no editor holds focus and the keyboard shortcuts keep working.
  */
 export type SidebarTab = 'dm' | 'reject';
 export type SelectedSidebarTab = SidebarTab | null;

--- a/packages/lesswrong/components/sunshineDashboard/supermod/sidebarTabs.ts
+++ b/packages/lesswrong/components/sunshineDashboard/supermod/sidebarTabs.ts
@@ -1,0 +1,7 @@
+/**
+ * Which composer is showing in the moderation sidebar: a DM to the user, or a
+ * rejection of their currently-selected content. Null until the moderator picks
+ * one — neither form is open by default, so the keyboard shortcuts keep working.
+ */
+export type SidebarTab = 'dm' | 'reject';
+export type SelectedSidebarTab = SidebarTab | null;

--- a/packages/lesswrong/lib/collections/moderationTemplates/rejectionIntro.ts
+++ b/packages/lesswrong/lib/collections/moderationTemplates/rejectionIntro.ts
@@ -1,0 +1,16 @@
+/**
+ * Standard rejection intro, shown above (and prepended to) the moderator-written
+ * rejection reason. Rendered read-only in the UI; the server adds it to the
+ * message the user actually receives.
+ */
+export const standardRejectionIntroHtml = `
+  <p>Unfortunately, I rejected your [content].</p>
+  <p>LessWrong aims for particularly high quality (and somewhat oddly-specific) discussion quality. We get a lot of content from new users and sadly can't give detailed feedback on every piece we reject, but I generally recommend checking out our <a href="https://www.lesswrong.com/posts/LbbrnRvc9QwjJeics/new-user-s-guide-to-lesswrong">New User's Guide</a>, in particular the section on <a href="https://www.lesswrong.com/posts/LbbrnRvc9QwjJeics/new-user-s-guide-to-lesswrong#How_to_ensure_your_first_post_or_comment_is_well_received">how to ensure your content is approved</a>.</p>
+  <p>Your content didn't meet the bar for at least the following reason(s):</p>
+`;
+
+/** Single-line version of the intro, for the collapsed state of the rejection composer. */
+export const standardRejectionIntroPlaintext = standardRejectionIntroHtml
+  .replace(/<[^>]+>/g, ' ')
+  .replace(/\s+/g, ' ')
+  .trim();

--- a/packages/lesswrong/lib/collections/moderationTemplates/rejectionIntro.ts
+++ b/packages/lesswrong/lib/collections/moderationTemplates/rejectionIntro.ts
@@ -1,7 +1,6 @@
 /**
- * Standard rejection intro, shown above (and prepended to) the moderator-written
- * rejection reason. Rendered read-only in the UI; the server adds it to the
- * message the user actually receives.
+ * Standard intro shown read-only above the moderator-written rejection
+ * reason, and prepended to the message the rejected user receives.
  */
 export const standardRejectionIntroHtml = `
   <p>Unfortunately, I rejected your [content].</p>
@@ -9,7 +8,7 @@ export const standardRejectionIntroHtml = `
   <p>Your content didn't meet the bar for at least the following reason(s):</p>
 `;
 
-/** Single-line version of the intro, for the collapsed state of the rejection composer. */
+/** One-line version, for the composer's collapsed intro */
 export const standardRejectionIntroPlaintext = standardRejectionIntroHtml
   .replace(/<[^>]+>/g, ' ')
   .replace(/\s+/g, ' ')

--- a/packages/lesswrong/server/callbacks/helpers.ts
+++ b/packages/lesswrong/server/callbacks/helpers.ts
@@ -1,6 +1,13 @@
 import { randomSecret } from "@/lib/random";
 
 export function getRejectionMessage(rejectedContentLink: string, rejectedReason: string|null) {
+  // The supermod composer can send the entire message (with a possibly
+  // hand-edited intro) rather than just the reasons; recognize it by the
+  // "[content]" placeholder or the intro's opening line, and use it verbatim
+  // with the link to the rejected content substituted for the placeholder.
+  if (rejectedReason && (rejectedReason.includes('[content]') || rejectedReason.includes('Unfortunately, I rejected'))) {
+    return rejectedReason.replace('[content]', rejectedContentLink);
+  }
   let messageContents = `
   <p>Unfortunately, I rejected your ${rejectedContentLink}.</p>
   <p>LessWrong aims for particularly high quality (and somewhat oddly-specific) discussion quality. We get a lot of content from new users and sadly can't give detailed feedback on every piece we reject, but I generally recommend checking out our <a href="https://www.lesswrong.com/posts/LbbrnRvc9QwjJeics/new-user-s-guide-to-lesswrong">New User's Guide</a>, in particular the section on <a href="https://www.lesswrong.com/posts/LbbrnRvc9QwjJeics/new-user-s-guide-to-lesswrong#How_to_ensure_your_first_post_or_comment_is_well_received">how to ensure your content is approved</a>.</p>`

--- a/packages/lesswrong/unitTests/moderationInboxReducer.tests.ts
+++ b/packages/lesswrong/unitTests/moderationInboxReducer.tests.ts
@@ -96,6 +96,7 @@ describe('Moderation Inbox Reducer', () => {
         openedUserId: 'user2',
         focusedPostId: null,
         focusedContentIndex: 0,
+        sidebarTab: null,
         undoQueue: [],
         history: [],
         runningLlmCheckId: null,
@@ -127,6 +128,7 @@ describe('Moderation Inbox Reducer', () => {
         openedUserId: null,
         focusedPostId: null,
         focusedContentIndex: 0,
+        sidebarTab: null,
         undoQueue: [],
         history: [],
         runningLlmCheckId: null,
@@ -154,6 +156,7 @@ describe('Moderation Inbox Reducer', () => {
         openedUserId: null,
         focusedPostId: null,
         focusedContentIndex: 0,
+        sidebarTab: null,
         undoQueue: [],
         history: [],
         runningLlmCheckId: null,
@@ -183,6 +186,7 @@ describe('Moderation Inbox Reducer', () => {
         openedUserId: null,
         focusedPostId: null,
         focusedContentIndex: 0,
+        sidebarTab: null,
         undoQueue: [],
         history: [],
         runningLlmCheckId: null,
@@ -224,6 +228,7 @@ describe('Moderation Inbox Reducer', () => {
         openedUserId: null,
         focusedPostId: null,
         focusedContentIndex: 0,
+        sidebarTab: null,
         undoQueue: [],
         history: [],
         runningLlmCheckId: null,
@@ -261,6 +266,7 @@ describe('Moderation Inbox Reducer', () => {
         openedUserId: null,
         focusedPostId: null,
         focusedContentIndex: 0,
+        sidebarTab: null,
         undoQueue: [],
         history: [],
         runningLlmCheckId: null,
@@ -291,6 +297,7 @@ describe('Moderation Inbox Reducer', () => {
         openedUserId: null,
         focusedPostId: null,
         focusedContentIndex: 0,
+        sidebarTab: null,
         undoQueue: [],
         history: [],
         runningLlmCheckId: null,
@@ -319,6 +326,7 @@ describe('Moderation Inbox Reducer', () => {
         openedUserId: null,
         focusedPostId: null,
         focusedContentIndex: 0,
+        sidebarTab: null,
         undoQueue: [],
         history: [],
         runningLlmCheckId: null,
@@ -351,6 +359,7 @@ describe('Moderation Inbox Reducer', () => {
         openedUserId: 'user2',
         focusedPostId: null,
         focusedContentIndex: 0,
+        sidebarTab: null,
         undoQueue: [],
         history: [],
         runningLlmCheckId: null,
@@ -381,6 +390,7 @@ describe('Moderation Inbox Reducer', () => {
         openedUserId: 'user1',
         focusedPostId: null,
         focusedContentIndex: 0,
+        sidebarTab: null,
         undoQueue: [],
         history: [],
         runningLlmCheckId: null,
@@ -410,6 +420,7 @@ describe('Moderation Inbox Reducer', () => {
         openedUserId: 'user1',
         focusedPostId: null,
         focusedContentIndex: 0,
+        sidebarTab: null,
         undoQueue: [],
         history: [],
         runningLlmCheckId: null,
@@ -442,6 +453,7 @@ describe('Moderation Inbox Reducer', () => {
         openedUserId: 'user2',
         focusedPostId: null,
         focusedContentIndex: 3,
+        sidebarTab: null,
         undoQueue: [createUndoItem(undoneUser, { sourceTab: 'newContent', wasDetailView: true })],
         history: [],
         runningLlmCheckId: null,
@@ -474,6 +486,7 @@ describe('Moderation Inbox Reducer', () => {
         openedUserId: 'user3',
         focusedPostId: null,
         focusedContentIndex: 1,
+        sidebarTab: null,
         undoQueue: [createUndoItem(undoneUser, { sourceTab: 'newContent', wasDetailView: false })],
         history: [],
         runningLlmCheckId: null,
@@ -499,6 +512,7 @@ describe('Moderation Inbox Reducer', () => {
         openedUserId: null,
         focusedPostId: null,
         focusedContentIndex: 0,
+        sidebarTab: null,
         undoQueue: [],
         history: [],
         runningLlmCheckId: null,
@@ -527,6 +541,7 @@ describe('Moderation Inbox Reducer', () => {
         openedUserId: 'user1',
         focusedPostId: null,
         focusedContentIndex: 0,
+        sidebarTab: null,
         undoQueue: [],
         history: [],
         runningLlmCheckId: null,
@@ -537,6 +552,66 @@ describe('Moderation Inbox Reducer', () => {
 
       // State should be unchanged
       expect(newState).toEqual(state);
+    });
+  });
+
+  describe('sidebarTab', () => {
+    function stateWithSidebarTab(sidebarTab: InboxState['sidebarTab']): InboxState {
+      return {
+        users: [createMockUser('user1', 'newContent'), createMockUser('user2', 'newContent')],
+        posts: [],
+        classifiedPosts: [],
+        curationPosts: [],
+        activeTab: 'newContent',
+        focusedUserId: null,
+        openedUserId: 'user1',
+        focusedPostId: null,
+        focusedContentIndex: 0,
+        sidebarTab,
+        undoQueue: [],
+        history: [],
+        runningLlmCheckId: null,
+      };
+    }
+
+    test('no composer is open by default', () => {
+      expect(stateWithSidebarTab(null).sidebarTab).toBe(null);
+    });
+
+    test('SET_SIDEBAR_TAB opens a composer', () => {
+      const state = inboxStateReducer(stateWithSidebarTab(null), { type: 'SET_SIDEBAR_TAB', tab: 'reject' });
+      expect(state.sidebarTab).toBe('reject');
+    });
+
+    test.each([
+      ['NEXT_CONTENT', { type: 'NEXT_CONTENT', contentLength: 3 }],
+      ['PREV_CONTENT', { type: 'PREV_CONTENT', contentLength: 3 }],
+      ['NEXT_USER', { type: 'NEXT_USER' }],
+      ['OPEN_USER', { type: 'OPEN_USER', userId: 'user2' }],
+      ['CLOSE_DETAIL', { type: 'CLOSE_DETAIL' }],
+    ] as const)('%s closes the open composer', (_label, action) => {
+      const state = inboxStateReducer(stateWithSidebarTab('reject'), action);
+      expect(state.sidebarTab).toBe(null);
+    });
+
+    test('selecting a content item closes the open composer', () => {
+      const state = inboxStateReducer(stateWithSidebarTab('dm'), { type: 'OPEN_CONTENT', contentIndex: 2 });
+      expect(state.sidebarTab).toBe(null);
+      expect(state.focusedContentIndex).toBe(2);
+    });
+
+    test("the row's reject button selects that row and opens the reject composer", () => {
+      const state = inboxStateReducer(stateWithSidebarTab(null), { type: 'OPEN_CONTENT', contentIndex: 2, sidebarTab: 'reject' });
+      expect(state.sidebarTab).toBe('reject');
+      expect(state.focusedContentIndex).toBe(2);
+    });
+
+    test('actions taken mid-draft leave the composer open', () => {
+      const state = inboxStateReducer(stateWithSidebarTab('reject'), {
+        type: 'SET_LLM_CHECK_RUNNING',
+        documentId: 'post1',
+      });
+      expect(state.sidebarTab).toBe('reject');
     });
   });
 });


### PR DESCRIPTION
The core of the rejection-composer work, rebuilt on top of the extraction stack.
**Targets `master` as requested, so until #12722 and #12723 merge the diff here
includes their commits too** — the composer itself is the last commit
(`46f3476ed2`), and the diff shrinks to just it as the stack lands underneath.

Rejecting content in supermod opened `RejectContentDialog` as a modal — a
separate flow from the sidebar's User Messages section, with its own bespoke
template picker, and one that discards a half-written reason on Escape.

This folds it into the sidebar:

- **User Messages** holds only past mod conversations, and hides itself when
  there are none.
- Below it, a two-tab composer: **Send DM** and **Reject "«title»"** (capped at
  25 chars, quoted, right-aligned; a comment uses its first line). The Reject
  tab is hidden with nothing selected and disabled once the content is already
  rejected.
- **Neither tab is open by default** — nothing steals focus, so the moderation
  shortcuts keep working — and moving to a different content item or user
  closes whichever composer was open.
- **`R`, the row's Reject button, and the tab itself** all open the reject
  composer and focus its editor. `Ctrl/Cmd+Enter` submits. Escape keeps its
  existing meaning (close the detail view) and no longer costs a draft.
- The reject panel renders the shared grouped template list
  (`collectionName="Rejections"`) above a Lexical editor separated by a rule;
  clicking a template **appends** into the editor, same as the DM tab. The
  standard intro is collapsed to one clickable line.
- Send DM's first click now starts the conversation and drops the caret in the
  editor, instead of showing a prompt that needs a second click.

### Mechanics worth reviewing

- The open composer lives in the **inbox reducer** (`sidebarTab`), not
  component state: the row's Reject button has to select the row *and* open the
  composer in one update, which a reset-effect on the focused index would race
  with. A wrapper clears the tab on navigation actions but deliberately spares
  mid-draft ones (permission toggles, LLM checks, undo bookkeeping). New
  reducer tests cover all of this (25 pass).
- `RejectContentDialog` **stays** for its other call sites: `Shift+R`
  (restrict & notify), `X` (reject latest & remove), `RejectContentButton`
  outside supermod, and `LlmPolicyViolationDropdownItem`.
- Because reasons are appended rather than composed from checkboxes, a
  multi-reason rejection is no longer a single `<ul>` — so
  `extractRejectionReasonSummary` summarizes to the first reason rather than
  one bullet per reason. The notice itself still renders everything.
- `focusLexicalEditorWhenReady` (new) retries briefly because both editors
  mount asynchronously; the single-shot `focusLexicalEditor` fires before the
  contenteditable exists and silently does nothing.

Not included here (stays in #12715 or later): the always-open full-width
template search and search-autofocus-on-reject.

### Testing

`yarn tsc`, eslint and the reducer unit tests are clean. The equivalent code
was exercised end-to-end on the #12715 branch (reject via R and Ctrl+Enter,
template append, tab behaviour, Shift+R still opening the modal); this rebuild
on the stack has not been separately browser-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1217148238168427) by [Unito](https://www.unito.io)
