### PR TITLE
Supermod: full-width mod template rows with hide/unhide

### DIFF
--- a/packages/lesswrong/components/sunshineDashboard/GroupedModerationTemplateList.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/GroupedModerationTemplateList.tsx
@@ -19,6 +19,8 @@ import { ModerationTemplateSunshineItem } from './ModerationTemplateSunshineItem
 import { ModerationTemplatesForm } from '../moderationTemplates/ModerationTemplateForm';
 import ForumIcon from '../common/ForumIcon';
 import LWTooltip from '../common/LWTooltip';
+import { useCurrentUser } from '../common/withUser';
+import { getBrowserLocalStorage } from '../editor/localStorageHandlers';
 import type { TemplateType } from '@/lib/collections/moderationTemplates/constants';
 
 const ModerationTemplatesListQuery = gql(`
@@ -43,6 +45,32 @@ const UpdateModerationTemplateGroupMutation = gql(`
 `);
 
 const UNGROUPED_TEMPLATES_LABEL = "Other";
+const HIDDEN_TEMPLATES_LABEL = "Hidden";
+
+// Hiding is per-moderator, so it lives in localStorage
+const HIDDEN_TEMPLATES_STORAGE_PREFIX = 'hiddenModerationTemplates_';
+
+function getHiddenTemplatesStorageKey(userId: string, collectionName: TemplateType) {
+  return `${HIDDEN_TEMPLATES_STORAGE_PREFIX}${collectionName}_${userId}`;
+}
+
+function loadHiddenTemplateIds(userId: string, collectionName: TemplateType): string[] {
+  const ls = getBrowserLocalStorage();
+  const stored = ls?.getItem(getHiddenTemplatesStorageKey(userId, collectionName));
+  if (!stored) return [];
+  try {
+    const parsed: unknown = JSON.parse(stored);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter((id): id is string => typeof id === 'string');
+  } catch {
+    return [];
+  }
+}
+
+function saveHiddenTemplateIds(userId: string, collectionName: TemplateType, hiddenTemplateIds: Set<string>) {
+  const ls = getBrowserLocalStorage();
+  ls?.setItem(getHiddenTemplatesStorageKey(userId, collectionName), JSON.stringify([...hiddenTemplateIds]));
+}
 
 function getModerationTemplatesQueryVariables(collectionName: TemplateType) {
   return {
@@ -283,10 +311,11 @@ const TemplateSearchBar = ({searchOpen, searchQuery, onOpen, onClose, onQueryCha
   );
 };
 
-const DraggableTemplateItem = ({template, onTemplateClick, highlighted}: {
+const DraggableTemplateItem = ({template, onTemplateClick, highlighted, onHideTemplate}: {
   template: ModerationTemplateFragment,
   onTemplateClick: (template: ModerationTemplateFragment) => void,
   highlighted: boolean,
+  onHideTemplate: (template: ModerationTemplateFragment) => void,
 }) => {
   const classes = useStyles(styles);
   const {attributes, listeners, setNodeRef, setActivatorNodeRef, transform, isDragging} = useDraggable({
@@ -304,18 +333,20 @@ const DraggableTemplateItem = ({template, onTemplateClick, highlighted}: {
         onTemplateClick={onTemplateClick}
         highlighted={highlighted}
         dragHandleProps={{ref: setActivatorNodeRef, attributes, listeners}}
+        onHide={onHideTemplate}
       />
     </div>
   );
 };
 
-const TemplateGroup = ({group, templatesInGroup, expanded, onToggleExpanded, onTemplateClick, onRenameGroup, highlightedTemplateNames}: {
+const TemplateGroup = ({group, templatesInGroup, expanded, onToggleExpanded, onTemplateClick, onRenameGroup, onHideTemplate, highlightedTemplateNames}: {
   group: string,
   templatesInGroup: ModerationTemplateFragment[],
   expanded: boolean,
   onToggleExpanded: (group: string, expanded: boolean) => void,
   onTemplateClick: (template: ModerationTemplateFragment) => void,
   onRenameGroup: (group: string, newGroup: string) => void,
+  onHideTemplate: (template: ModerationTemplateFragment) => void,
   highlightedTemplateNames?: Set<string>,
 }) => {
   const classes = useStyles(styles);
@@ -369,6 +400,34 @@ const TemplateGroup = ({group, templatesInGroup, expanded, onToggleExpanded, onT
           template={template}
           onTemplateClick={onTemplateClick}
           highlighted={!!highlightedTemplateNames?.has(template.name)}
+          onHideTemplate={onHideTemplate}
+        />
+      ))}
+    </div>
+  );
+};
+
+const HiddenTemplatesSection = ({hiddenTemplates, expanded, onToggleExpanded, onTemplateClick, onUnhideTemplate}: {
+  hiddenTemplates: ModerationTemplateFragment[],
+  expanded: boolean,
+  onToggleExpanded: (expanded: boolean) => void,
+  onTemplateClick: (template: ModerationTemplateFragment) => void,
+  onUnhideTemplate: (template: ModerationTemplateFragment) => void,
+}) => {
+  const classes = useStyles(styles);
+
+  return (
+    <div className={classes.templateGroup}>
+      <div className={classes.templateGroupHeader} onClick={() => onToggleExpanded(!expanded)}>
+        <ForumIcon icon={expanded ? "ExpandLess" : "ExpandMore"} className={classes.templateGroupExpandIcon} />
+        <span className={classes.templateGroupLabel}>{HIDDEN_TEMPLATES_LABEL} ({hiddenTemplates.length})</span>
+      </div>
+      {expanded && hiddenTemplates.map(template => (
+        <ModerationTemplateSunshineItem
+          key={template._id}
+          template={template}
+          onTemplateClick={onTemplateClick}
+          onUnhide={onUnhideTemplate}
         />
       ))}
     </div>
@@ -387,10 +446,19 @@ const GroupedModerationTemplateList = ({ collectionName, onTemplateClick, highli
   highlightedTemplateNames?: Set<string>,
 }) => {
   const classes = useStyles(styles);
+  const currentUser = useCurrentUser();
   const [showNewTemplateForm, setShowNewTemplateForm] = useState(false);
   const [groupExpandedOverrides, setGroupExpandedOverrides] = useState<Record<string, boolean>>({});
   const [searchOpen, setSearchOpen] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
+  const [hiddenTemplateIds, setHiddenTemplateIds] = useState<Set<string>>(new Set());
+  const [hiddenSectionExpanded, setHiddenSectionExpanded] = useState(false);
+
+  // In an effect, not render: localStorage would break hydration
+  useEffect(() => {
+    if (!currentUser) return;
+    setHiddenTemplateIds(new Set(loadHiddenTemplateIds(currentUser._id, collectionName)));
+  }, [currentUser, collectionName]);
 
   const queryVariables = getModerationTemplatesQueryVariables(collectionName);
   const { data } = useQuery(ModerationTemplatesListQuery, { variables: queryVariables });
@@ -403,6 +471,21 @@ const GroupedModerationTemplateList = ({ collectionName, onTemplateClick, highli
   const handleToggleGroupExpanded = (group: string, expanded: boolean) => {
     setGroupExpandedOverrides(prev => ({...prev, [group]: expanded}));
   };
+
+  const setTemplateHidden = (template: ModerationTemplateFragment, hidden: boolean) => {
+    if (!currentUser) return;
+    const newHiddenIds = new Set(hiddenTemplateIds);
+    if (hidden) {
+      newHiddenIds.add(template._id);
+    } else {
+      newHiddenIds.delete(template._id);
+    }
+    setHiddenTemplateIds(newHiddenIds);
+    saveHiddenTemplateIds(currentUser._id, collectionName, newHiddenIds);
+  };
+
+  const handleHideTemplate = (template: ModerationTemplateFragment) => setTemplateHidden(template, true);
+  const handleUnhideTemplate = (template: ModerationTemplateFragment) => setTemplateHidden(template, false);
 
   // Dropping manual toggles on a query change reopens anything the moderator collapsed, so matches stay visible
   const handleSearchQueryChange = (query: string) => {
@@ -443,12 +526,12 @@ const GroupedModerationTemplateList = ({ collectionName, onTemplateClick, highli
   };
 
   const lowercaseQuery = searchQuery.trim().toLowerCase();
-  const visibleGroups = groupTemplatesByLabel(templates)
-    .map(([group, templatesInGroup]): [string, ModerationTemplateFragment[]] => [
-      group,
-      lowercaseQuery ? templatesInGroup.filter(template => templateMatchesQuery(template, lowercaseQuery)) : templatesInGroup,
-    ])
-    .filter(([, templatesInGroup]) => templatesInGroup.length > 0);
+  const matchingTemplates = lowercaseQuery
+    ? templates.filter(template => templateMatchesQuery(template, lowercaseQuery))
+    : templates;
+  // Groups are only created when non-empty, so all-hidden ones vanish
+  const visibleGroups = groupTemplatesByLabel(matchingTemplates.filter(template => !hiddenTemplateIds.has(template._id)));
+  const hiddenTemplates = matchingTemplates.filter(template => hiddenTemplateIds.has(template._id));
 
   // DndContext gets an explicit id because the ids dnd-kit puts in aria-describedby
   // otherwise come from a module-level counter, which drifts between the server and
@@ -477,10 +560,20 @@ const GroupedModerationTemplateList = ({ collectionName, onTemplateClick, highli
             onToggleExpanded={handleToggleGroupExpanded}
             onTemplateClick={onTemplateClick}
             onRenameGroup={handleRenameGroup}
+            onHideTemplate={handleHideTemplate}
             highlightedTemplateNames={highlightedTemplateNames}
           />
         ))}
-        {lowercaseQuery && visibleGroups.length === 0 && (
+        {hiddenTemplates.length > 0 && (
+          <HiddenTemplatesSection
+            hiddenTemplates={hiddenTemplates}
+            expanded={hiddenSectionExpanded}
+            onToggleExpanded={setHiddenSectionExpanded}
+            onTemplateClick={onTemplateClick}
+            onUnhideTemplate={handleUnhideTemplate}
+          />
+        )}
+        {lowercaseQuery && visibleGroups.length === 0 && hiddenTemplates.length === 0 && (
           <div className={classes.noSearchResults}>No templates match “{searchQuery.trim()}”</div>
         )}
       </>}

--- a/packages/lesswrong/components/sunshineDashboard/ModerationTemplateSunshineItem.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/ModerationTemplateSunshineItem.tsx
@@ -17,6 +17,7 @@ const styles = defineStyles('ModerationTemplateSunshineItem', (theme: ThemeType)
     cursor: "pointer",
     padding: 2,
     paddingLeft: 24,
+    width: "100%",
     display: "flex",
     alignItems: "center",
     gap: 2,
@@ -25,7 +26,7 @@ const styles = defineStyles('ModerationTemplateSunshineItem', (theme: ThemeType)
     "&:hover": {
       backgroundColor: theme.palette.greyAlpha(0.1),
     },
-    '&:hover .ModerationTemplateSunshineItem-editIcon': {
+    '&:hover .ModerationTemplateSunshineItem-actionIcon': {
       opacity: .5,
     },
     '&:hover .ModerationTemplateSunshineItem-dragHandle': {
@@ -51,9 +52,17 @@ const styles = defineStyles('ModerationTemplateSunshineItem', (theme: ThemeType)
   },
   templateName: {
     flex: 1,
+    minWidth: 0,
   },
-  editButton: {
+  actions: {
+    display: "flex",
+    alignItems: "center",
+    flexShrink: 0,
     marginLeft: 8,
+  },
+  actionButton: {
+    display: "flex",
+    alignItems: "center",
     cursor: "pointer",
     "&:hover": {
       opacity: 0.7,
@@ -93,7 +102,7 @@ const styles = defineStyles('ModerationTemplateSunshineItem', (theme: ThemeType)
     ...theme.typography.body2,
     ...theme.typography.commentStyle,
   },
-  editIcon: {
+  actionIcon: {
     fontSize: 22,
     opacity: 0,
     padding: 4,
@@ -103,11 +112,13 @@ const styles = defineStyles('ModerationTemplateSunshineItem', (theme: ThemeType)
   },
 }));
 
-export const ModerationTemplateSunshineItem = ({template, onTemplateClick, highlighted, dragHandleProps}: {
+export const ModerationTemplateSunshineItem = ({template, onTemplateClick, highlighted, dragHandleProps, onHide, onUnhide}: {
   template: ModerationTemplateFragment,
   onTemplateClick: (template: ModerationTemplateFragment) => void,
   highlighted?: boolean,
   dragHandleProps?: DragHandleProps,
+  onHide?: (template: ModerationTemplateFragment) => void,
+  onUnhide?: (template: ModerationTemplateFragment) => void,
 }) => {
   const classes = useStyles(styles);
   const [edit, setEdit] = useState<boolean>(false);
@@ -134,6 +145,9 @@ export const ModerationTemplateSunshineItem = ({template, onTemplateClick, highl
     <LWTooltip
       tooltip={false}
       placement="left-start"
+      // Not inline-block, so the row fills the sidebar width
+      As="div"
+      inlineBlock={false}
       title={
         <ContentStyles contentType="comment" className={classes.hovercard}>
           <ContentItemBody
@@ -158,15 +172,45 @@ export const ModerationTemplateSunshineItem = ({template, onTemplateClick, highl
           </span>
         )}
         <span className={classes.templateName}>{template.name}</span>
-        <a
-          className={classes.editButton}
-          onClick={(e) => {
-            e.stopPropagation();
-            setEdit(true);
-          }}
-        >
-          <ForumIcon icon="Edit" className={classes.editIcon} />
-        </a>
+        <span className={classes.actions}>
+          {onHide && (
+            <LWTooltip title="Hide this template for you. Other admins will still see it" placement="top">
+              <a
+                className={classes.actionButton}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onHide(template);
+                }}
+              >
+                <ForumIcon icon="NarrowArrowDown" className={classes.actionIcon} />
+              </a>
+            </LWTooltip>
+          )}
+          {onUnhide && (
+            <LWTooltip title="Unhide this template" placement="top">
+              <a
+                className={classes.actionButton}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onUnhide(template);
+                }}
+              >
+                <ForumIcon icon="NarrowArrowUp" className={classes.actionIcon} />
+              </a>
+            </LWTooltip>
+          )}
+          <LWTooltip title="Edit this template" placement="top">
+            <a
+              className={classes.actionButton}
+              onClick={(e) => {
+                e.stopPropagation();
+                setEdit(true);
+              }}
+            >
+              <ForumIcon icon="Edit" className={classes.actionIcon} />
+            </a>
+          </LWTooltip>
+        </span>
       </div>
     </LWTooltip>
   );


### PR DESCRIPTION
Reworks the moderation template list in the `/admin/supermod` sidebar.

- **Full-width rows.** Template rows were shrink-to-fit, because `LWTooltip` wraps its children in an inline-block span by default. They now span the sidebar, with the wide middle (the template name) as the click target and the edit button pinned to the far right.
- **Hide button.** A down-arrow button sits next to the edit pencil, revealed on row hover like the pencil already was, with the tooltip "Hide this template for you. Other admins will still see it".
- **Hidden section.** Hidden templates move to a collapsed `HIDDEN (n)` section at the bottom of the list, where each row gets an up-arrow to unhide.
- **Empty groups disappear.** A group whose templates are all hidden isn't rendered at all.

Hiding is per-moderator and stored in `localStorage`, keyed by user id and template collection, so it never touches the template record other admins see. The set is read in an effect rather than during render, so the server-rendered markup still matches the first client render; the cost is that hidden templates flash visible for one paint on load.

## Testing

Verified against the dev DB on a local dev server:

- Hid all three OFFBOARDING templates → the whole group disappeared from the list.
- Unhid one → it returned to its group, and the group header came back.
- Reloaded the page → the hidden set persisted and the `HIDDEN` section stayed collapsed.
- Clicking a template name still prefills the message composer.
- No console errors.

## Note on icons

Hide/unhide use `NarrowArrowDown` / `NarrowArrowUp`, reading as "send to the section at the bottom" / "bring it back up". The main alternative is `EyeSlash` / `Eye`, which is semantically clearer and is what the rejection dialog's own hidden-template list already uses — happy to switch for cross-UI consistency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1217177078289201) by [Unito](https://www.unito.io)
