### PR TITLE
Research transcripts: nest subagent activity, collapse tool-call runs

### DIFF
--- a/packages/lesswrong/components/research/ConversationEventRow.tsx
+++ b/packages/lesswrong/components/research/ConversationEventRow.tsx
@@ -215,7 +215,7 @@ function getMetaLineMeta(eventKind: string, chunk: ConversationEventChunk): Meta
   }
 }
 
-function MetaLine({
+export function MetaLine({
   eventKind,
   chunk,
 }: {

--- a/packages/lesswrong/components/research/ConversationTranscript.tsx
+++ b/packages/lesswrong/components/research/ConversationTranscript.tsx
@@ -4,6 +4,8 @@ import React, { useMemo } from 'react';
 import classNames from 'classnames';
 import { defineStyles, useStyles } from '@/components/hooks/useStyles';
 import { ConversationEventRow } from './ConversationEventRow';
+import { TranscriptItemsList } from './ConversationTranscriptItems';
+import { buildTranscriptItems } from './transcriptItems';
 import { ResearchQuestionCard } from './ResearchQuestionCard';
 import { collectAskUserQuestionAnswers, extractAskUserQuestion, toolResultToolUseId } from './researchAskUserQuestion';
 import { researchMono, researchScrollbars } from './researchStyleUtils';
@@ -118,6 +120,17 @@ export const ConversationTranscript = ({
     return { prompts: promptMap, hiddenEventIds: hidden };
   }, [events, turnInFlight]);
 
+  const transcriptItems = useMemo(
+    () =>
+      buildTranscriptItems(events, {
+        isSpecialEvent: (event) => {
+          const key = event._id ?? `${event.conversationId}:${event.seq}`;
+          return prompts.has(key) || hiddenEventIds.has(key);
+        },
+      }),
+    [events, prompts, hiddenEventIds],
+  );
+
   return (
     <div className={classes.root} ref={scrollRef} onScroll={onScroll}>
       <div
@@ -130,23 +143,27 @@ export const ConversationTranscript = ({
             {status === 'loading' ? 'Loading transcript…' : 'No output yet.'}
           </div>
         ) : null}
-        {events.map((event) => {
-          const key = event._id ?? `${event.conversationId}:${event.seq}`;
-          const question = prompts.get(key);
-          if (question?.prompt) {
-            return (
-              <ResearchQuestionCard
-                key={key}
-                conversationId={conversationId}
-                prompt={question.prompt}
-                answers={question.answers}
-                actionable={question.actionable}
-              />
-            );
-          }
-          if (hiddenEventIds.has(key)) return null;
-          return <ConversationEventRow key={key} event={event} />;
-        })}
+        <TranscriptItemsList
+          items={transcriptItems}
+          turnInFlight={turnInFlight}
+          renderEvent={(event) => {
+            const key = event._id ?? `${event.conversationId}:${event.seq}`;
+            const question = prompts.get(key);
+            if (question?.prompt) {
+              return (
+                <ResearchQuestionCard
+                  key={key}
+                  conversationId={conversationId}
+                  prompt={question.prompt}
+                  answers={question.answers}
+                  actionable={question.actionable}
+                />
+              );
+            }
+            if (hiddenEventIds.has(key)) return null;
+            return <ConversationEventRow key={key} event={event} />;
+          }}
+        />
         {turnInFlight ? (
           <div className={classes.statusLine}>
             <span className={classes.workingGlyph}>✻</span>

--- a/packages/lesswrong/components/research/ConversationTranscriptItems.tsx
+++ b/packages/lesswrong/components/research/ConversationTranscriptItems.tsx
@@ -1,0 +1,249 @@
+import React, { useMemo, useState, type ReactNode } from 'react';
+import classNames from 'classnames';
+import { defineStyles, useStyles } from '@/components/hooks/useStyles';
+import { researchMono, researchRadius, researchTransition, researchWarmAlpha } from './researchStyleUtils';
+import { getConversationEventChunks, isPlainRecord } from './conversationEventFormat';
+import { ConversationEventRow, MetaLine } from './ConversationEventRow';
+import {
+  describeToolGroup,
+  getParentToolUseId,
+  groupCalls,
+  type TranscriptItem,
+  type TranscriptRunEntry,
+} from './transcriptItems';
+import type { ConversationEvent } from './hooks/useConversationStream';
+
+const styles = defineStyles('ConversationTranscriptItems', (theme: ThemeType) => ({
+  header: {
+    width: '100%',
+    minWidth: 0,
+    border: 'none',
+    background: 'transparent',
+    cursor: 'pointer',
+    display: 'flex',
+    alignItems: 'baseline',
+    gap: 7,
+    padding: '1px 4px 1px 0',
+    borderRadius: researchRadius.xs,
+    fontFamily: researchMono,
+    fontSize: 11.5,
+    lineHeight: '18px',
+    color: theme.palette.text.dim,
+    textAlign: 'left',
+    transition: `background ${researchTransition}`,
+    '&:hover': {
+      background: researchWarmAlpha(0.04),
+    },
+  },
+  glyph: {
+    flex: 'none',
+    userSelect: 'none',
+    color: researchWarmAlpha(0.45),
+  },
+  glyphTool: {
+    color: theme.palette.primary.main,
+  },
+  label: {
+    flex: 'none',
+    fontWeight: 600,
+    color: researchWarmAlpha(0.6),
+  },
+  summary: {
+    flex: 1,
+    minWidth: 0,
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+  },
+  failed: {
+    color: theme.palette.error?.main ?? theme.palette.text.primary,
+  },
+  body: {
+    marginLeft: 3,
+    paddingLeft: 10,
+    borderLeft: `1px solid ${researchWarmAlpha(0.12)}`,
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 2,
+    minWidth: 0,
+  },
+  reportLabel: {
+    marginTop: 4,
+    fontFamily: researchMono,
+    fontSize: 9.5,
+    fontWeight: 600,
+    letterSpacing: '0.08em',
+    textTransform: 'uppercase',
+    color: researchWarmAlpha(0.5),
+  },
+}));
+
+export interface TranscriptItemsListProps {
+  items: TranscriptItem<ConversationEvent>[];
+  turnInFlight: boolean;
+  renderEvent: (event: ConversationEvent) => ReactNode;
+}
+
+export const TranscriptItemsList = ({ items, turnInFlight, renderEvent }: TranscriptItemsListProps) => {
+  return (
+    <>
+      {items.map((item) => {
+        switch (item.type) {
+          case 'event':
+            return (
+              <React.Fragment key={item.event._id ?? `e:${item.event.seq}`}>
+                {renderEvent(item.event)}
+              </React.Fragment>
+            );
+          case 'tool':
+            return (
+              <ToolEntryRow
+                key={`t:${item.entry.event.seq}:${item.entry.kind}`}
+                entry={item.entry}
+              />
+            );
+          case 'toolGroup':
+            return <ToolGroupRow key={`g:${item.key}`} entries={item.entries} />;
+          case 'subagent':
+            return (
+              <SubagentRow
+                key={`s:${item.key}`}
+                item={item}
+                turnInFlight={turnInFlight}
+                renderEvent={renderEvent}
+              />
+            );
+        }
+      })}
+    </>
+  );
+};
+
+const ToolEntryRow = ({ entry }: { entry: TranscriptRunEntry<ConversationEvent> }) => {
+  if (entry.kind === 'call') {
+    return <MetaLine eventKind="assistant" chunk={entry.chunk} />;
+  }
+  return <ConversationEventRow event={entry.event} />;
+};
+
+const ToolGroupRow = ({ entries }: { entries: TranscriptRunEntry<ConversationEvent>[] }) => {
+  const classes = useStyles(styles);
+  const [expanded, setExpanded] = useState(false);
+  const calls = useMemo(() => groupCalls(entries), [entries]);
+  const label = useMemo(() => describeToolGroup(calls), [calls]);
+  const failedCount = useMemo(
+    () =>
+      entries.filter(
+        (e) =>
+          e.kind === 'result' &&
+          getConversationEventChunks(e.event).some((c) => c.kind === 'tool_result' && c.isError),
+      ).length,
+    [entries],
+  );
+  return (
+    <div>
+      <button
+        type="button"
+        className={classes.header}
+        aria-expanded={expanded}
+        onClick={(e) => {
+          e.stopPropagation();
+          e.preventDefault();
+          setExpanded((v) => !v);
+        }}
+        onMouseDown={(e) => e.preventDefault()}
+      >
+        <span className={classNames(classes.glyph, classes.glyphTool)}>{expanded ? '▾' : '▸'}</span>
+        <span className={classes.summary}>
+          {label}
+          {failedCount > 0 ? <span className={classes.failed}> · {failedCount} failed</span> : null}
+        </span>
+      </button>
+      {expanded ? (
+        <div className={classes.body}>
+          {entries.map((entry, i) => (
+            <ToolEntryRow key={i} entry={entry} />
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+};
+
+const SubagentRow = ({
+  item,
+  turnInFlight,
+  renderEvent,
+}: {
+  item: Extract<TranscriptItem<ConversationEvent>, { type: 'subagent' }>;
+  turnInFlight: boolean;
+  renderEvent: (event: ConversationEvent) => ReactNode;
+}) => {
+  const classes = useStyles(styles);
+  const [expanded, setExpanded] = useState(false);
+
+  const running = item.resultEvent === undefined && turnInFlight;
+  const input = item.call?.chunk.toolInput;
+  const description =
+    isPlainRecord(input) && typeof input.description === 'string'
+      ? input.description
+      : isPlainRecord(input) && typeof input.prompt === 'string'
+        ? input.prompt
+        : null;
+  const agentLabel =
+    isPlainRecord(input) && typeof input.subagent_type === 'string'
+      ? `${input.subagent_type} agent`
+      : item.call
+        ? 'Subagent'
+        : 'Subagent (earlier)';
+
+  const latestActivity = useMemo(() => {
+    if (!running) return null;
+    for (let i = item.events.length - 1; i >= 0; i--) {
+      const chunks = getConversationEventChunks(item.events[i]);
+      const last = chunks[chunks.length - 1];
+      if (last && last.text.trim().length > 0) {
+        return last.text.trim().replace(/\s+/g, ' ').slice(0, 160);
+      }
+    }
+    return null;
+  }, [running, item.events]);
+
+  return (
+    <div>
+      <button
+        type="button"
+        className={classes.header}
+        aria-expanded={expanded}
+        onClick={(e) => {
+          e.stopPropagation();
+          e.preventDefault();
+          setExpanded((v) => !v);
+        }}
+        onMouseDown={(e) => e.preventDefault()}
+      >
+        <span className={classNames(classes.glyph, classes.glyphTool)}>{expanded ? '▾' : '▸'}</span>
+        <span className={classes.label}>
+          {running ? '◌ ' : ''}
+          {agentLabel}
+        </span>
+        <span className={classes.summary}>
+          {description ? `${description} · ` : ''}
+          {item.events.length} events
+          {latestActivity ? ` · ${latestActivity}` : ''}
+        </span>
+      </button>
+      {expanded ? (
+        <div className={classes.body}>
+          <TranscriptItemsList items={item.items} turnInFlight={turnInFlight} renderEvent={renderEvent} />
+          {item.resultEvent ? (
+            <>
+              <div className={classes.reportLabel}>Report</div>
+              <ConversationEventRow event={item.resultEvent} />
+            </>
+          ) : null}
+        </div>
+      ) : null}
+    </div>
+  );
+};

--- a/packages/lesswrong/components/research/conversationEventFormat.ts
+++ b/packages/lesswrong/components/research/conversationEventFormat.ts
@@ -144,6 +144,10 @@ export type ConversationEventChunkKind =
 export interface ConversationEventChunk {
   kind: ConversationEventChunkKind;
   text: string;
+  toolUseId?: string;
+  toolName?: string;
+  toolInput?: unknown;
+  isError?: boolean;
 }
 
 export function renderChunkMarkdownToHtml(text: string): string {
@@ -182,10 +186,21 @@ function toContentChunk(part: unknown): ConversationEventChunk | null {
   }
   if (typeof part.text === 'string') return { kind: 'text', text: part.text };
   if (part.type === 'tool_use' && typeof part.name === 'string') {
-    return { kind: 'tool_use', text: `${part.name}(${formatJSON(part.input)})` };
+    return {
+      kind: 'tool_use',
+      text: `${part.name}(${formatJSON(part.input)})`,
+      toolUseId: typeof part.id === 'string' ? part.id : undefined,
+      toolName: part.name,
+      toolInput: part.input,
+    };
   }
   if (part.type === 'tool_result') {
-    return { kind: 'tool_result', text: formatToolResultContent(part.content) };
+    return {
+      kind: 'tool_result',
+      text: formatToolResultContent(part.content),
+      toolUseId: typeof part.tool_use_id === 'string' ? part.tool_use_id : undefined,
+      isError: part.is_error === true,
+    };
   }
   return null;
 }

--- a/packages/lesswrong/components/research/transcriptItems.ts
+++ b/packages/lesswrong/components/research/transcriptItems.ts
@@ -1,0 +1,240 @@
+import {
+  getConversationEventChunks,
+  isPlainRecord,
+  type ConversationEventChunk,
+} from './conversationEventFormat';
+
+export interface TranscriptEventLike {
+  seq: number;
+  kind: string;
+  payload: unknown;
+}
+
+export interface TranscriptToolCall<T extends TranscriptEventLike> {
+  event: T;
+  chunk: ConversationEventChunk;
+}
+
+export type TranscriptRunEntry<T extends TranscriptEventLike> =
+  | { kind: 'call'; event: T; chunk: ConversationEventChunk }
+  | { kind: 'result'; event: T };
+
+export type TranscriptItem<T extends TranscriptEventLike> =
+  | { type: 'event'; event: T }
+  | { type: 'tool'; entry: TranscriptRunEntry<T> }
+  | { type: 'toolGroup'; key: string; entries: TranscriptRunEntry<T>[] }
+  | {
+      type: 'subagent';
+      key: string;
+      /** The spawning tool call; null for orphans (parent outside the loaded window). */
+      call: TranscriptToolCall<T> | null;
+      events: T[];
+      items: TranscriptItem<T>[];
+      resultEvent?: T;
+    };
+
+export function getParentToolUseId(event: { payload: unknown }): string | null {
+  return isPlainRecord(event.payload) && typeof event.payload.parent_tool_use_id === 'string'
+    ? event.payload.parent_tool_use_id
+    : null;
+}
+
+export function groupCalls<T extends TranscriptEventLike>(
+  entries: TranscriptRunEntry<T>[],
+): TranscriptToolCall<T>[] {
+  const calls: TranscriptToolCall<T>[] = [];
+  for (const entry of entries) {
+    if (entry.kind === 'call') calls.push({ event: entry.event, chunk: entry.chunk });
+  }
+  return calls;
+}
+
+interface BuildOptions<T extends TranscriptEventLike> {
+  /** Events owned by an overlay (ask-user-question cards, hidden rows) render standalone. */
+  isSpecialEvent?: (event: T) => boolean;
+}
+
+/**
+ * Structures a flat event window for display: sidechain events (subagent
+ * activity, marked by payload.parent_tool_use_id) nest under the tool call
+ * that spawned them, and runs of consecutive tool calls (with their result
+ * rows) collapse into a group. The trailing call of each level stays out of
+ * its group while it is the most recent entry, so the "current" call reads
+ * normally until the next event lands. Sidechain events whose parent lies
+ * outside the loaded window surface as a parentless subagent item at the
+ * window top (they merge under the real call once older pages load).
+ */
+export function buildTranscriptItems<T extends TranscriptEventLike>(
+  events: T[],
+  options: BuildOptions<T> = {},
+): TranscriptItem<T>[] {
+  const byParent = new Map<string, T[]>();
+  const mainline: T[] = [];
+  for (const event of events) {
+    const parentId = getParentToolUseId(event);
+    if (parentId !== null) {
+      const group = byParent.get(parentId);
+      if (group) group.push(event);
+      else byParent.set(parentId, [event]);
+    } else {
+      mainline.push(event);
+    }
+  }
+
+  const attachedParents = new Set<string>();
+  const items = buildLevel(mainline, byParent, attachedParents, options);
+
+  const orphanItems: TranscriptItem<T>[] = [];
+  for (const [parentId, group] of byParent) {
+    if (attachedParents.has(parentId)) continue;
+    orphanItems.push({
+      type: 'subagent',
+      key: `orphan:${parentId}`,
+      call: null,
+      events: group,
+      items: buildLevel(group, byParent, attachedParents, options),
+    });
+  }
+  orphanItems.sort((a, b) => firstSeq(a) - firstSeq(b));
+  return [...orphanItems, ...items];
+}
+
+function firstSeq<T extends TranscriptEventLike>(item: TranscriptItem<T>): number {
+  return item.type === 'subagent' ? (item.events[0]?.seq ?? 0) : 0;
+}
+
+function resultAnswersSubagent<T extends TranscriptEventLike>(
+  event: T,
+  subagentKey: string,
+): boolean {
+  return getConversationEventChunks(event).some(
+    (c) => c.kind === 'tool_result' && c.toolUseId === subagentKey,
+  );
+}
+
+function buildLevel<T extends TranscriptEventLike>(
+  levelEvents: T[],
+  byParent: Map<string, T[]>,
+  attachedParents: Set<string>,
+  options: BuildOptions<T>,
+): TranscriptItem<T>[] {
+  const items: TranscriptItem<T>[] = [];
+  let run: TranscriptRunEntry<T>[] = [];
+
+  const flushRun = () => {
+    if (run.length === 0) return;
+    const calls = groupCalls(run);
+    if (calls.length >= 2) {
+      const first = calls[0];
+      items.push({
+        type: 'toolGroup',
+        key: `${first.event.seq}:${first.chunk.toolUseId ?? '?'}`,
+        entries: run,
+      });
+    } else {
+      for (const entry of run) items.push({ type: 'tool', entry });
+    }
+    run = [];
+  };
+
+  for (const event of levelEvents) {
+    if (options.isSpecialEvent?.(event)) {
+      flushRun();
+      items.push({ type: 'event', event });
+      continue;
+    }
+    if (event.kind === 'tool_result') {
+      if (run.length > 0) {
+        run.push({ kind: 'result', event });
+        continue;
+      }
+      const last = items[items.length - 1];
+      if (last?.type === 'subagent' && !last.resultEvent && resultAnswersSubagent(event, last.key)) {
+        last.resultEvent = event;
+        continue;
+      }
+      if (last?.type === 'tool') {
+        run.push(last.entry, { kind: 'result', event });
+        items.pop();
+        continue;
+      }
+      items.push({ type: 'event', event });
+      continue;
+    }
+    const chunks = getConversationEventChunks(event);
+    if (chunks.length === 0) continue;
+    const toolOnly = event.kind === 'assistant' && chunks.every((c) => c.kind === 'tool_use');
+    if (!toolOnly) {
+      flushRun();
+      items.push({ type: 'event', event });
+      continue;
+    }
+    for (const chunk of chunks) {
+      const spawned = chunk.toolUseId ? byParent.get(chunk.toolUseId) : undefined;
+      if (spawned && chunk.toolUseId) {
+        flushRun();
+        attachedParents.add(chunk.toolUseId);
+        items.push({
+          type: 'subagent',
+          key: chunk.toolUseId,
+          call: { event, chunk },
+          events: spawned,
+          items: buildLevel(spawned, byParent, attachedParents, options),
+        });
+      } else {
+        run.push({ kind: 'call', event, chunk });
+      }
+    }
+  }
+
+  // Tail rule: the level's final call (and its result) stays standalone
+  // until something follows it.
+  if (run.length > 0) {
+    let lastCallIdx = run.length - 1;
+    while (lastCallIdx >= 0 && run[lastCallIdx].kind !== 'call') lastCallIdx--;
+    const tail = lastCallIdx >= 0 ? run.splice(lastCallIdx) : run.splice(0);
+    flushRun();
+    for (const entry of tail) items.push({ type: 'tool', entry });
+  }
+  return items;
+}
+
+const TOOL_PHRASES: Record<string, [singular: string, plural: string]> = {
+  Bash: ['ran 1 shell command', 'ran # shell commands'],
+  Read: ['read 1 file', 'read # files'],
+  Grep: ['searched for 1 pattern', 'searched for # patterns'],
+  Glob: ['matched 1 glob', 'matched # globs'],
+  LS: ['listed 1 directory', 'listed # directories'],
+  Edit: ['made 1 edit', 'made # edits'],
+  MultiEdit: ['made 1 edit', 'made # edits'],
+  NotebookEdit: ['made 1 edit', 'made # edits'],
+  Write: ['wrote 1 file', 'wrote # files'],
+  WebFetch: ['fetched 1 page', 'fetched # pages'],
+  WebSearch: ['ran 1 web search', 'ran # web searches'],
+  TodoWrite: ['updated the plan 1 time', 'updated the plan # times'],
+};
+
+/**
+ * `Searched for 4 patterns, read 3 files, ran 2 shell commands` — phrases in
+ * first-appearance order, unknown tools as `ToolName ×N`.
+ */
+export function describeToolGroup<T extends TranscriptEventLike>(
+  calls: TranscriptToolCall<T>[],
+): string {
+  const counts = new Map<string, number>();
+  for (const call of calls) {
+    const name = call.chunk.toolName ?? 'Tool';
+    counts.set(name, (counts.get(name) ?? 0) + 1);
+  }
+  const phrases: string[] = [];
+  for (const [name, n] of counts) {
+    const phrase = TOOL_PHRASES[name];
+    if (!phrase) {
+      phrases.push(n === 1 ? name : `${name} ×${n}`);
+    } else {
+      phrases.push(n === 1 ? phrase[0] : phrase[1].replace('#', String(n)));
+    }
+  }
+  const joined = phrases.join(', ');
+  return joined.charAt(0).toUpperCase() + joined.slice(1);
+}

--- a/packages/lesswrong/unitTests/transcriptItems.tests.ts
+++ b/packages/lesswrong/unitTests/transcriptItems.tests.ts
@@ -1,0 +1,169 @@
+import { buildTranscriptItems, describeToolGroup, groupCalls } from '@/components/research/transcriptItems';
+
+let seqCounter = 0;
+function assistantEvent(blocks: unknown[], parent?: string) {
+  return {
+    seq: ++seqCounter,
+    kind: 'assistant',
+    payload: {
+      type: 'assistant',
+      parent_tool_use_id: parent ?? null,
+      message: { content: blocks },
+    },
+  };
+}
+function userEvent(text: string) {
+  return {
+    seq: ++seqCounter,
+    kind: 'user',
+    payload: { type: 'user', parent_tool_use_id: null, message: { content: text } },
+  };
+}
+function resultEvent(toolUseId: string, parent?: string, isError = false) {
+  return {
+    seq: ++seqCounter,
+    kind: 'tool_result',
+    payload: {
+      type: 'user',
+      parent_tool_use_id: parent ?? null,
+      message: {
+        content: [{ type: 'tool_result', tool_use_id: toolUseId, content: 'ok', is_error: isError }],
+      },
+    },
+  };
+}
+const tool = (id: string, name = 'Bash', input: unknown = { command: 'ls' }) => ({
+  type: 'tool_use',
+  id,
+  name,
+  input,
+});
+const text = (t: string) => ({ type: 'text', text: t });
+const emptyThinking = () => ({ type: 'thinking', thinking: '', signature: 'x' });
+
+describe('buildTranscriptItems', () => {
+  it('collapses a run of calls and their results, closed by a text event', () => {
+    seqCounter = 0;
+    const items = buildTranscriptItems([
+      userEvent('go'),
+      assistantEvent([tool('a')]),
+      resultEvent('a'),
+      assistantEvent([tool('b', 'Read', { file_path: '/x' })]),
+      resultEvent('b'),
+      assistantEvent([tool('c', 'Read', { file_path: '/y' })]),
+      resultEvent('c'),
+      assistantEvent([text('done')]),
+    ]);
+    expect(items.map((i) => i.type)).toEqual(['event', 'toolGroup', 'event']);
+    const group = items[1];
+    if (group.type !== 'toolGroup') throw new Error('expected group');
+    expect(groupCalls(group.entries)).toHaveLength(3);
+    expect(group.entries).toHaveLength(6);
+  });
+
+  it('keeps the trailing call and its result out of the group (tail rule)', () => {
+    seqCounter = 0;
+    const items = buildTranscriptItems([
+      assistantEvent([tool('a')]),
+      resultEvent('a'),
+      assistantEvent([tool('b')]),
+      resultEvent('b'),
+      assistantEvent([tool('c')]),
+      resultEvent('c'),
+    ]);
+    expect(items.map((i) => i.type)).toEqual(['toolGroup', 'tool', 'tool']);
+    const group = items[0];
+    if (group.type !== 'toolGroup') throw new Error('expected group');
+    expect(groupCalls(group.entries).map((c) => c.chunk.toolUseId)).toEqual(['a', 'b']);
+  });
+
+  it('ignores empty-thinking events inside a run', () => {
+    seqCounter = 0;
+    const items = buildTranscriptItems([
+      assistantEvent([tool('a')]),
+      assistantEvent([emptyThinking()]),
+      assistantEvent([tool('b')]),
+      assistantEvent([tool('c')]),
+      assistantEvent([text('done')]),
+    ]);
+    expect(items.map((i) => i.type)).toEqual(['toolGroup', 'event']);
+  });
+
+  it('nests sidechain events under the spawning tool call and attaches its result', () => {
+    seqCounter = 0;
+    const items = buildTranscriptItems([
+      userEvent('go'),
+      assistantEvent([tool('task1', 'Task', { subagent_type: 'Explore', description: 'map' })]),
+      assistantEvent([tool('sub-a')], 'task1'),
+      resultEvent('sub-a', 'task1'),
+      assistantEvent([text('sub summary')], 'task1'),
+      resultEvent('task1'),
+      assistantEvent([text('main done')]),
+    ]);
+    expect(items.map((i) => i.type)).toEqual(['event', 'subagent', 'event']);
+    const sub = items[1];
+    if (sub.type !== 'subagent') throw new Error('expected subagent');
+    expect(sub.key).toBe('task1');
+    expect(sub.call?.chunk.toolName).toBe('Task');
+    expect(sub.events).toHaveLength(3);
+    expect(sub.resultEvent?.seq).toBe(6);
+  });
+
+  it('surfaces orphaned sidechain events as a parentless subagent item first', () => {
+    seqCounter = 0;
+    const items = buildTranscriptItems([
+      assistantEvent([tool('sub-a')], 'missing-task'),
+      assistantEvent([text('sub text')], 'missing-task'),
+      userEvent('hello'),
+    ]);
+    expect(items.map((i) => i.type)).toEqual(['subagent', 'event']);
+    const sub = items[0];
+    if (sub.type !== 'subagent') throw new Error('expected subagent');
+    expect(sub.call).toBeNull();
+    expect(sub.key).toBe('orphan:missing-task');
+  });
+
+  it('treats overlay-special events as run breaks', () => {
+    seqCounter = 0;
+    const special = assistantEvent([tool('ask', 'AskUserQuestion', {})]);
+    const items = buildTranscriptItems(
+      [assistantEvent([tool('a')]), assistantEvent([tool('b')]), special, assistantEvent([tool('c')])],
+      { isSpecialEvent: (e) => e === special },
+    );
+    expect(items.map((i) => i.type)).toEqual(['toolGroup', 'event', 'tool']);
+  });
+
+  it('handles nested subagents recursively', () => {
+    seqCounter = 0;
+    const items = buildTranscriptItems([
+      assistantEvent([tool('outer', 'Task', {})]),
+      assistantEvent([tool('inner', 'Task', {})], 'outer'),
+      assistantEvent([text('deep')], 'inner'),
+      assistantEvent([text('done')]),
+    ]);
+    const sub = items[0];
+    if (sub.type !== 'subagent') throw new Error('expected subagent');
+    const inner = sub.items[0];
+    if (inner.type !== 'subagent') throw new Error('expected nested subagent');
+    expect(inner.key).toBe('inner');
+  });
+});
+
+describe('describeToolGroup', () => {
+  it('aggregates by tool with first-appearance order and pluralization', () => {
+    seqCounter = 0;
+    const items = buildTranscriptItems([
+      assistantEvent([tool('1', 'Grep', {})]),
+      assistantEvent([tool('2', 'Read', {})]),
+      assistantEvent([tool('3', 'Grep', {})]),
+      assistantEvent([tool('4', 'Bash', {})]),
+      assistantEvent([tool('5', 'Frobnicate', {})]),
+      assistantEvent([text('end')]),
+    ]);
+    const group = items[0];
+    if (group.type !== 'toolGroup') throw new Error('expected group');
+    expect(describeToolGroup(groupCalls(group.entries))).toBe(
+      'Searched for 2 patterns, read 1 file, ran 1 shell command, Frobnicate',
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- **Subagent events no longer spill into the top-level transcript.** Sidechain events (`payload.parent_tool_use_id`, persisted verbatim since day one but never read on the display side) nest under the tool call that spawned them as a collapsed, expandable subagent row — description from the spawn call's input, live latest-activity line while running, event count, and the final report attached once the parent's `tool_result` arrives. Recursive for nested subagents. Orphaned sidechain events (parent outside the loaded page window) render as a parentless "Subagent (earlier)" row at the window top and merge under the real call once older pages load.
- **Consecutive tool calls (with their result rows) collapse into one expandable aggregate row** ("Searched for 4 patterns, read 3 files, ran 2 shell commands"), failures counted in the header. The trailing call of each run stays a standalone row until the next event lands, so the current call reads normally while executing. Empty-thinking events yield no display items and don't break runs.

Pure display-layer change: grouping is computed at render time (`transcriptItems.ts`), consumed by `ConversationTranscript`; no schema or ingestion changes. Counterpart to LessWrong2/lightcone-commons#164 (same builder logic; the FM variant additionally absorbs standalone `tool_result` rows into runs, since FM renders results as their own rows rather than folding them).

## Test plan
- `yarn tsc` clean apart from the pre-existing `.next/types/routes` generated-file errors
- 8 unit tests (`yarn unit packages/lesswrong/unitTests/transcriptItems.tests.ts`): grouping with results, tail rule incl. trailing result, empty-thinking transparency, nesting + result attachment, recursion, orphans, overlay passthrough, aggregate wording
- The identical structural logic was E2E-verified in lightcone-commons against a real 166-sidechain-event conversation (subagent rows with descriptions/counts, orphan fallback triggering at the page-window edge, group aggregation, expansion); FM rendering uses the existing MetaLine idiom but wasn't exercised live here — worth a visual pass on a subagent-heavy research conversation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1217181839339512) by [Unito](https://www.unito.io)
