### PR TITLE
Optically center the transcript group/subagent glyph

### DIFF
--- a/packages/lesswrong/components/research/ConversationTranscriptItems.tsx
+++ b/packages/lesswrong/components/research/ConversationTranscriptItems.tsx
@@ -39,6 +39,9 @@ const styles = defineStyles('ConversationTranscriptItems', (theme: ThemeType) =>
     flex: 'none',
     userSelect: 'none',
     color: researchWarmAlpha(0.45),
+    // Optical correction: the triangle's ink sits on the baseline with no
+    // descender, reading visually low next to lowercase text.
+    transform: 'translateY(-1px)',
   },
   glyphTool: {
     color: theme.palette.primary.main,

--- a/packages/lesswrong/components/research/ConversationTranscriptItems.tsx
+++ b/packages/lesswrong/components/research/ConversationTranscriptItems.tsx
@@ -6,7 +6,6 @@ import { getConversationEventChunks, isPlainRecord } from './conversationEventFo
 import { ConversationEventRow, MetaLine } from './ConversationEventRow';
 import {
   describeToolGroup,
-  getParentToolUseId,
   groupCalls,
   type TranscriptItem,
   type TranscriptRunEntry,
@@ -39,8 +38,6 @@ const styles = defineStyles('ConversationTranscriptItems', (theme: ThemeType) =>
     flex: 'none',
     userSelect: 'none',
     color: researchWarmAlpha(0.45),
-    // Optical correction: the triangle's ink sits on the baseline with no
-    // descender, reading visually low next to lowercase text.
     transform: 'translateY(-1px)',
   },
   glyphTool: {


### PR DESCRIPTION
## Summary
- `translateY(-1px)` on `.ConversationTranscriptItems-glyph`: the `▸`/`▾` triangles' ink sits on the text baseline with no descender, so they read visually low next to the row's lowercase text. Paint-only nudge (no layout participation), value tuned in-browser.

## Test plan
- Style-only; `yarn tsc` clean apart from the pre-existing `.next/types/routes` generated-file errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1217183125896815) by [Unito](https://www.unito.io)
