### PR TITLE
Add per-group "+" button to the supermod template list

### DIFF
--- a/packages/lesswrong/components/moderationTemplates/ModerationTemplateForm.tsx
+++ b/packages/lesswrong/components/moderationTemplates/ModerationTemplateForm.tsx
@@ -47,12 +47,21 @@ const formStyles = defineStyles('ModerationTemplatesForm', (theme: ThemeType) =>
 export const ModerationTemplatesForm = ({
   initialData,
   initialCollectionName,
+  initialGroupLabel,
+  hideMetadataFields,
   onSuccess,
   onCancel,
   refetchQueries,
 }: {
   initialData?: UpdateModerationTemplateDataInput & { _id: string; collectionName: TemplateType };
   initialCollectionName?: TemplateType;
+  initialGroupLabel?: string;
+  /**
+   * Hide the collectionName/order/groupLabel fields, submitting their initial
+   * values as-is. Used when the surrounding UI already determines them, as in
+   * the grouped supermod template list.
+   */
+  hideMetadataFields?: boolean;
   onSuccess?: (doc: ModerationTemplateFragment) => void;
   onCancel?: () => void;
   refetchQueries?: MutationHookOptions['refetchQueries'];
@@ -91,7 +100,7 @@ export const ModerationTemplatesForm = ({
     ...defaultValues,
     collectionName: defaultValues.collectionName ?? initialCollectionName ?? 'Rejections',
     name: defaultValues.name ?? '',
-    groupLabel: defaultValues.groupLabel ?? undefined,
+    groupLabel: defaultValues.groupLabel ?? initialGroupLabel ?? undefined,
   };
 
   const form = useForm({
@@ -175,43 +184,45 @@ export const ModerationTemplatesForm = ({
         </form.Field>
       </div>
 
-      <div className={classes.fieldWrapper}>
-        <form.Field name="collectionName">
-          {(field) => (
-            <FormComponentSelect
-              field={field}
-              options={ALLOWABLE_COLLECTIONS.map((collectionName) => ({
-                label: collectionName,
-                value: collectionName,
-              }))}
-              label="Collection name"
-            />
-          )}
-        </form.Field>
-      </div>
+      {!hideMetadataFields && <>
+        <div className={classes.fieldWrapper}>
+          <form.Field name="collectionName">
+            {(field) => (
+              <FormComponentSelect
+                field={field}
+                options={ALLOWABLE_COLLECTIONS.map((collectionName) => ({
+                  label: collectionName,
+                  value: collectionName,
+                }))}
+                label="Collection name"
+              />
+            )}
+          </form.Field>
+        </div>
 
-      <div className={classes.fieldWrapper}>
-        <form.Field name="order">
-          {(field) => (
-            <MuiTextField
-              field={field}
-              type="number"
-              label="Order"
-            />
-          )}
-        </form.Field>
-      </div>
+        <div className={classes.fieldWrapper}>
+          <form.Field name="order">
+            {(field) => (
+              <MuiTextField
+                field={field}
+                type="number"
+                label="Order"
+              />
+            )}
+          </form.Field>
+        </div>
 
-      <div className={classes.fieldWrapper}>
-        <form.Field name="groupLabel">
-          {(field) => (
-            <MuiTextField
-              field={field}
-              label="Group label"
-            />
-          )}
-        </form.Field>
-      </div>
+        <div className={classes.fieldWrapper}>
+          <form.Field name="groupLabel">
+            {(field) => (
+              <MuiTextField
+                field={field}
+                label="Group label"
+              />
+            )}
+          </form.Field>
+        </div>
+      </>}
 
       {formType === 'edit' && (
         <div className={classes.fieldWrapper}>

--- a/packages/lesswrong/components/moderationTemplates/ModerationTemplateForm.tsx
+++ b/packages/lesswrong/components/moderationTemplates/ModerationTemplateForm.tsx
@@ -56,11 +56,6 @@ export const ModerationTemplatesForm = ({
   initialData?: UpdateModerationTemplateDataInput & { _id: string; collectionName: TemplateType };
   initialCollectionName?: TemplateType;
   initialGroupLabel?: string;
-  /**
-   * Hide the collectionName/order/groupLabel fields, submitting their initial
-   * values as-is. Used when the surrounding UI already determines them, as in
-   * the grouped supermod template list.
-   */
   hideMetadataFields?: boolean;
   onSuccess?: (doc: ModerationTemplateFragment) => void;
   onCancel?: () => void;

--- a/packages/lesswrong/components/sunshineDashboard/GroupedModerationTemplateList.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/GroupedModerationTemplateList.tsx
@@ -236,17 +236,23 @@ const styles = defineStyles('GroupedModerationTemplateList', (theme: ThemeType) 
     zIndex: 2,
     opacity: 0.7,
   },
-  newTemplateButton: {
+  addTemplateButton: {
+    marginLeft: 'auto',
     flexShrink: 0,
-    cursor: 'pointer',
-    fontSize: 12,
-    fontWeight: 600,
-    textTransform: 'uppercase',
+    display: 'flex',
+    alignItems: 'center',
+  },
+  addTemplateIcon: {
+    height: 14,
+    width: 14,
     color: theme.palette.grey[600],
-    letterSpacing: '0.5px',
+    '&:hover': {
+      color: theme.palette.grey[900],
+    },
   },
   newTemplateForm: {
-    marginTop: 16,
+    marginTop: 4,
+    marginBottom: 8,
     paddingLeft: 12,
     paddingRight: 0,
     marginLeft: -6,
@@ -339,7 +345,7 @@ const DraggableTemplateItem = ({template, onTemplateClick, highlighted, onHideTe
   );
 };
 
-const TemplateGroup = ({group, templatesInGroup, expanded, onToggleExpanded, onTemplateClick, onRenameGroup, onHideTemplate, highlightedTemplateNames}: {
+const TemplateGroup = ({group, templatesInGroup, expanded, onToggleExpanded, onTemplateClick, onRenameGroup, onHideTemplate, onAddTemplate, newTemplateForm, highlightedTemplateNames}: {
   group: string,
   templatesInGroup: ModerationTemplateFragment[],
   expanded: boolean,
@@ -347,6 +353,8 @@ const TemplateGroup = ({group, templatesInGroup, expanded, onToggleExpanded, onT
   onTemplateClick: (template: ModerationTemplateFragment) => void,
   onRenameGroup: (group: string, newGroup: string) => void,
   onHideTemplate: (template: ModerationTemplateFragment) => void,
+  onAddTemplate: (group: string) => void,
+  newTemplateForm: React.ReactNode,
   highlightedTemplateNames?: Set<string>,
 }) => {
   const classes = useStyles(styles);
@@ -393,7 +401,18 @@ const TemplateGroup = ({group, templatesInGroup, expanded, onToggleExpanded, onT
               }}
             />
           : <span className={classes.templateGroupLabel} onDoubleClick={() => setDraftName(group)}>{group}</span>}
+        <LWTooltip title="New template in this group" placement="left" className={classes.addTemplateButton}>
+          <ForumIcon
+            icon="Plus"
+            className={classes.addTemplateIcon}
+            onClick={(e) => {
+              e.stopPropagation();
+              onAddTemplate(group);
+            }}
+          />
+        </LWTooltip>
       </div>
+      {newTemplateForm}
       {expanded && templatesInGroup.map(template => (
         <DraggableTemplateItem
           key={template._id}
@@ -447,7 +466,7 @@ const GroupedModerationTemplateList = ({ collectionName, onTemplateClick, highli
 }) => {
   const classes = useStyles(styles);
   const currentUser = useCurrentUser();
-  const [showNewTemplateForm, setShowNewTemplateForm] = useState(false);
+  const [newTemplateGroup, setNewTemplateGroup] = useState<string | null>(null);
   const [groupExpandedOverrides, setGroupExpandedOverrides] = useState<Record<string, boolean>>({});
   const [searchOpen, setSearchOpen] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
@@ -486,6 +505,12 @@ const GroupedModerationTemplateList = ({ collectionName, onTemplateClick, highli
 
   const handleHideTemplate = (template: ModerationTemplateFragment) => setTemplateHidden(template, true);
   const handleUnhideTemplate = (template: ModerationTemplateFragment) => setTemplateHidden(template, false);
+
+  // Expand the group so the form (and, after submitting, the new template) is visible
+  const handleAddTemplate = (group: string) => {
+    setGroupExpandedOverrides(prev => ({...prev, [group]: true}));
+    setNewTemplateGroup(group);
+  };
 
   // Dropping manual toggles on a query change reopens anything the moderator collapsed, so matches stay visible
   const handleSearchQueryChange = (query: string) => {
@@ -532,6 +557,11 @@ const GroupedModerationTemplateList = ({ collectionName, onTemplateClick, highli
   // Groups are only created when non-empty, so all-hidden ones vanish
   const visibleGroups = groupTemplatesByLabel(matchingTemplates.filter(template => !hiddenTemplateIds.has(template._id)));
   const hiddenTemplates = matchingTemplates.filter(template => hiddenTemplateIds.has(template._id));
+  // Outside of a search, always show "Other" (even when empty) so its "+" button
+  // is the standing affordance for creating an ungrouped template
+  if (!lowercaseQuery && !visibleGroups.some(([group]) => group === UNGROUPED_TEMPLATES_LABEL)) {
+    visibleGroups.push([UNGROUPED_TEMPLATES_LABEL, []]);
+  }
 
   // DndContext gets an explicit id because the ids dnd-kit puts in aria-describedby
   // otherwise come from a module-level counter, which drifts between the server and
@@ -543,7 +573,7 @@ const GroupedModerationTemplateList = ({ collectionName, onTemplateClick, highli
     onDragEnd={handleTemplateDragEnd}
   >
     <div className={classes.root}>
-      {templates.length > 0 && <>
+      {templates.length > 0 && (
         <TemplateSearchBar
           searchOpen={searchOpen}
           searchQuery={searchQuery}
@@ -551,44 +581,44 @@ const GroupedModerationTemplateList = ({ collectionName, onTemplateClick, highli
           onClose={handleCloseSearch}
           onQueryChange={handleSearchQueryChange}
         />
-        {visibleGroups.map(([group, templatesInGroup]) => (
-          <TemplateGroup
-            key={group}
-            group={group}
-            templatesInGroup={templatesInGroup}
-            expanded={groupExpandedOverrides[group] ?? true}
-            onToggleExpanded={handleToggleGroupExpanded}
-            onTemplateClick={onTemplateClick}
-            onRenameGroup={handleRenameGroup}
-            onHideTemplate={handleHideTemplate}
-            highlightedTemplateNames={highlightedTemplateNames}
-          />
-        ))}
-        {hiddenTemplates.length > 0 && (
-          <HiddenTemplatesSection
-            hiddenTemplates={hiddenTemplates}
-            expanded={hiddenSectionExpanded}
-            onToggleExpanded={setHiddenSectionExpanded}
-            onTemplateClick={onTemplateClick}
-            onUnhideTemplate={handleUnhideTemplate}
-          />
-        )}
-        {lowercaseQuery && visibleGroups.length === 0 && hiddenTemplates.length === 0 && (
-          <div className={classes.noSearchResults}>No templates match “{searchQuery.trim()}”</div>
-        )}
-      </>}
-      <div className={classes.newTemplateButton} onClick={() => setShowNewTemplateForm(true)}>
-        New {collectionName === "Rejections" ? "Rejection Reason" : "Mod Template"}
-      </div>
-      {showNewTemplateForm && (
-        <div className={classes.newTemplateForm}>
-          <ModerationTemplatesForm
-            initialCollectionName={collectionName}
-            onSuccess={() => setShowNewTemplateForm(false)}
-            onCancel={() => setShowNewTemplateForm(false)}
-            refetchQueries={[{ query: ModerationTemplatesListQuery, variables: queryVariables }]}
-          />
-        </div>
+      )}
+      {visibleGroups.map(([group, templatesInGroup]) => (
+        <TemplateGroup
+          key={group}
+          group={group}
+          templatesInGroup={templatesInGroup}
+          expanded={groupExpandedOverrides[group] ?? true}
+          onToggleExpanded={handleToggleGroupExpanded}
+          onTemplateClick={onTemplateClick}
+          onRenameGroup={handleRenameGroup}
+          onHideTemplate={handleHideTemplate}
+          onAddTemplate={handleAddTemplate}
+          newTemplateForm={newTemplateGroup === group && (
+            <div className={classes.newTemplateForm}>
+              <ModerationTemplatesForm
+                initialCollectionName={collectionName}
+                initialGroupLabel={group === UNGROUPED_TEMPLATES_LABEL ? undefined : group}
+                hideMetadataFields
+                onSuccess={() => setNewTemplateGroup(null)}
+                onCancel={() => setNewTemplateGroup(null)}
+                refetchQueries={[{ query: ModerationTemplatesListQuery, variables: queryVariables }]}
+              />
+            </div>
+          )}
+          highlightedTemplateNames={highlightedTemplateNames}
+        />
+      ))}
+      {hiddenTemplates.length > 0 && (
+        <HiddenTemplatesSection
+          hiddenTemplates={hiddenTemplates}
+          expanded={hiddenSectionExpanded}
+          onToggleExpanded={setHiddenSectionExpanded}
+          onTemplateClick={onTemplateClick}
+          onUnhideTemplate={handleUnhideTemplate}
+        />
+      )}
+      {lowercaseQuery && visibleGroups.length === 0 && hiddenTemplates.length === 0 && (
+        <div className={classes.noSearchResults}>No templates match “{searchQuery.trim()}”</div>
       )}
     </div>
   </DndContext>;


### PR DESCRIPTION
Each subsection header in the grouped moderation template list now has a right-aligned `+` that opens a new-template form directly underneath that section title.

The form shows only **Name** and the content editor. `collectionName`, `order`, and `groupLabel` are all determined by the surrounding UI rather than typed in:

| field | where it comes from |
|---|---|
| `collectionName` | the list the moderator is in — the same value it already filters by |
| `groupLabel` | the group whose `+` was clicked; **Other** means no group name (`null`) |
| `order` | `10`, the form's existing default for new records |

The **New Rejection Reason** / **New Mod Template** button at the bottom of the list is removed, since the **Other** group's `+` now covers it. So that creating an ungrouped template stays possible, **Other** is always rendered outside of a search — even when it holds no templates. During a search it is suppressed as before, so the "No templates match" empty state is unchanged.

`hideMetadataFields` on `ModerationTemplatesForm` is opt-in, so the admin `/moderationTemplates` page and the per-template edit forms are untouched and still show every field.

## Testing

Verified in the supermod moderation inbox against the dev database:

- `+` renders on every group header, right-aligned, and opens the form beneath that header
- the form shows Name + editor only — no collectionName, order, or groupLabel inputs
- a real submit into **Offboarding** created `{collectionName: "Messages", groupLabel: "Offboarding", order: 10}`
- the new template appears in its section immediately, without a reload
- the bottom new-template button is gone

`yarn tsc` reports no errors in the changed files (the 10 that remain are pre-existing, in `fly/` and one lexical plugin).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1217211729106244) by [Unito](https://www.unito.io)
