### PR TITLE
Add rejection-dialog-style hotkeys to the supermod moderation template list

### DIFF
--- a/packages/lesswrong/components/sunshineDashboard/GroupedModerationTemplateList.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/GroupedModerationTemplateList.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import classNames from 'classnames';
 import {
   DndContext,
@@ -21,6 +21,7 @@ import ForumIcon from '../common/ForumIcon';
 import LWTooltip from '../common/LWTooltip';
 import { useCurrentUser } from '../common/withUser';
 import { getBrowserLocalStorage } from '../editor/localStorageHandlers';
+import { useGlobalKeydown } from '../common/withGlobalKeydown';
 import type { TemplateType } from '@/lib/collections/moderationTemplates/constants';
 
 const ModerationTemplatesListQuery = gql(`
@@ -106,6 +107,11 @@ function groupTemplatesByLabel(templates: ModerationTemplateFragment[]): [string
 // Same matching as the rejection dialog's template search: case-insensitive substring of the name
 function templateMatchesQuery(template: ModerationTemplateFragment, lowercaseQuery: string) {
   return template.name.toLowerCase().includes(lowercaseQuery);
+}
+
+function isInTextInput(target: EventTarget | null) {
+  if (!(target instanceof HTMLElement)) return false;
+  return target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable;
 }
 
 function getGroupLabelUpdateOptions(template: ModerationTemplateFragment, newGroupLabel: string | null) {
@@ -266,12 +272,15 @@ const styles = defineStyles('GroupedModerationTemplateList', (theme: ThemeType) 
   },
 }));
 
-const TemplateSearchBar = ({searchOpen, searchQuery, onOpen, onClose, onQueryChange}: {
+const TemplateSearchBar = ({searchOpen, searchQuery, focusToken, onOpen, onClose, onQueryChange, onKeyDown}: {
   searchOpen: boolean,
   searchQuery: string,
+  // Bumped whenever the search hotkey is pressed, so it refocuses an already-open search
+  focusToken: number,
   onOpen: () => void,
   onClose: () => void,
   onQueryChange: (query: string) => void,
+  onKeyDown: (event: React.KeyboardEvent) => void,
 }) => {
   const classes = useStyles(styles);
   const inputRef = useRef<HTMLInputElement>(null);
@@ -280,12 +289,12 @@ const TemplateSearchBar = ({searchOpen, searchQuery, onOpen, onClose, onQueryCha
     if (searchOpen) {
       inputRef.current?.focus();
     }
-  }, [searchOpen]);
+  }, [searchOpen, focusToken]);
 
   if (!searchOpen) {
     return (
       <div className={classes.listHeader}>
-        <LWTooltip title="Search templates" placement="left">
+        <LWTooltip title="Search templates (/)" placement="left">
           <ForumIcon icon="Search" className={classes.searchIcon} onClick={onOpen} />
         </LWTooltip>
       </div>
@@ -301,36 +310,41 @@ const TemplateSearchBar = ({searchOpen, searchQuery, onOpen, onClose, onQueryCha
         placeholder="Search templates..."
         value={searchQuery}
         onChange={(e) => onQueryChange(e.target.value)}
-        onKeyDown={(e) => {
-          if (e.key === 'Escape') {
-            // The supermod shortcut handler listens on document and acts on Escape even
-            // from inside text inputs, so it would deselect the user out from under the
-            // search. React's own listener is on document too, so only
-            // stopImmediatePropagation keeps the event from reaching it.
-            e.nativeEvent.stopImmediatePropagation();
-            onClose();
-          }
-        }}
+        onKeyDown={onKeyDown}
       />
       <ForumIcon icon="Close" className={classes.searchIcon} onClick={onClose} />
     </div>
   );
 };
 
-const DraggableTemplateItem = ({template, onTemplateClick, highlighted, onHideTemplate}: {
+const DraggableTemplateItem = ({template, onTemplateClick, highlighted, selected, onHideTemplate}: {
   template: ModerationTemplateFragment,
   onTemplateClick: (template: ModerationTemplateFragment) => void,
   highlighted: boolean,
+  selected: boolean,
   onHideTemplate: (template: ModerationTemplateFragment) => void,
 }) => {
   const classes = useStyles(styles);
   const {attributes, listeners, setNodeRef, setActivatorNodeRef, transform, isDragging} = useDraggable({
     id: template._id,
   });
+  const rowRef = useRef<HTMLDivElement | null>(null);
+
+  // dnd-kit needs the same node, so the two refs are combined here
+  const setRefs = useCallback((node: HTMLDivElement | null) => {
+    rowRef.current = node;
+    setNodeRef(node);
+  }, [setNodeRef]);
+
+  useEffect(() => {
+    if (selected) {
+      rowRef.current?.scrollIntoView({block: 'nearest'});
+    }
+  }, [selected]);
 
   return (
     <div
-      ref={setNodeRef}
+      ref={setRefs}
       className={classNames({[classes.draggedTemplate]: isDragging})}
       style={{transform: CSS.Translate.toString(transform)}}
     >
@@ -338,6 +352,7 @@ const DraggableTemplateItem = ({template, onTemplateClick, highlighted, onHideTe
         template={template}
         onTemplateClick={onTemplateClick}
         highlighted={highlighted}
+        selected={selected}
         dragHandleProps={{ref: setActivatorNodeRef, attributes, listeners}}
         onHide={onHideTemplate}
       />
@@ -345,7 +360,7 @@ const DraggableTemplateItem = ({template, onTemplateClick, highlighted, onHideTe
   );
 };
 
-const TemplateGroup = ({group, templatesInGroup, expanded, onToggleExpanded, onTemplateClick, onRenameGroup, onHideTemplate, onAddTemplate, newTemplateForm, highlightedTemplateNames}: {
+const TemplateGroup = ({group, templatesInGroup, expanded, onToggleExpanded, onTemplateClick, onRenameGroup, onHideTemplate, onAddTemplate, newTemplateForm, highlightedTemplateNames, selectedTemplateId}: {
   group: string,
   templatesInGroup: ModerationTemplateFragment[],
   expanded: boolean,
@@ -356,6 +371,7 @@ const TemplateGroup = ({group, templatesInGroup, expanded, onToggleExpanded, onT
   onAddTemplate: (group: string) => void,
   newTemplateForm: React.ReactNode,
   highlightedTemplateNames?: Set<string>,
+  selectedTemplateId: string | null,
 }) => {
   const classes = useStyles(styles);
   const {setNodeRef, isOver} = useDroppable({id: group});
@@ -419,6 +435,7 @@ const TemplateGroup = ({group, templatesInGroup, expanded, onToggleExpanded, onT
           template={template}
           onTemplateClick={onTemplateClick}
           highlighted={!!highlightedTemplateNames?.has(template.name)}
+          selected={template._id === selectedTemplateId}
           onHideTemplate={onHideTemplate}
         />
       ))}
@@ -458,11 +475,16 @@ const HiddenTemplatesSection = ({hiddenTemplates, expanded, onToggleExpanded, on
  * grouped by `groupLabel`. Parameterized by collection so the same list can back
  * both message templates and rejection reasons; dragging a template onto another
  * group's header re-labels it, and double-clicking a group name renames the group.
+ *
+ * The search box drives the same keyboard flow as the rejection dialog: "/" opens and
+ * focuses it, up/down move the selection through the visible templates, Enter applies
+ * the selected one, Tab jumps to the composer, and Escape closes the search.
  */
-const GroupedModerationTemplateList = ({ collectionName, onTemplateClick, highlightedTemplateNames }: {
+const GroupedModerationTemplateList = ({ collectionName, onTemplateClick, highlightedTemplateNames, onFocusComposer }: {
   collectionName: TemplateType,
   onTemplateClick: (template: ModerationTemplateFragment) => void,
   highlightedTemplateNames?: Set<string>,
+  onFocusComposer?: () => void,
 }) => {
   const classes = useStyles(styles);
   const currentUser = useCurrentUser();
@@ -470,8 +492,21 @@ const GroupedModerationTemplateList = ({ collectionName, onTemplateClick, highli
   const [groupExpandedOverrides, setGroupExpandedOverrides] = useState<Record<string, boolean>>({});
   const [searchOpen, setSearchOpen] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
+  const [searchFocusToken, setSearchFocusToken] = useState(0);
+  const [selectedIndex, setSelectedIndex] = useState(0);
   const [hiddenTemplateIds, setHiddenTemplateIds] = useState<Set<string>>(new Set());
   const [hiddenSectionExpanded, setHiddenSectionExpanded] = useState(false);
+
+  // "/" is the way into the template list from the rest of the supermod keyboard flow,
+  // which is why this listens globally rather than on the list itself
+  useGlobalKeydown(useCallback((event: KeyboardEvent) => {
+    if (event.key !== '/' || event.metaKey || event.ctrlKey || event.altKey) return;
+    if (isInTextInput(event.target)) return;
+    event.preventDefault();
+    setSearchOpen(true);
+    setSelectedIndex(0);
+    setSearchFocusToken(token => token + 1);
+  }, []));
 
   // In an effect, not render: localStorage would break hydration
   useEffect(() => {
@@ -516,12 +551,14 @@ const GroupedModerationTemplateList = ({ collectionName, onTemplateClick, highli
   const handleSearchQueryChange = (query: string) => {
     setSearchQuery(query);
     setGroupExpandedOverrides({});
+    setSelectedIndex(0);
   };
 
   const handleCloseSearch = () => {
     setSearchOpen(false);
     setSearchQuery('');
     setGroupExpandedOverrides({});
+    setSelectedIndex(0);
   };
 
   const handleTemplateDragEnd = (event: DragEndEvent) => {
@@ -563,6 +600,50 @@ const GroupedModerationTemplateList = ({ collectionName, onTemplateClick, highli
     visibleGroups.push([UNGROUPED_TEMPLATES_LABEL, []]);
   }
 
+  const isGroupExpanded = (group: string) => groupExpandedOverrides[group] ?? true;
+
+  // What the arrow keys walk: everything on screen, in display order. Templates in
+  // collapsed groups and hidden templates aren't visible, so they aren't navigable.
+  const navigableTemplates = visibleGroups
+    .filter(([group]) => isGroupExpanded(group))
+    .flatMap(([, templatesInGroup]) => templatesInGroup);
+
+  // Collapsing a group can leave the index past the end of the list
+  const selectedTemplate = navigableTemplates[selectedIndex];
+
+  const handleSearchKeyDown = (event: React.KeyboardEvent) => {
+    switch (event.key) {
+      case 'ArrowDown':
+        event.preventDefault();
+        if (navigableTemplates.length === 0) return;
+        setSelectedIndex(prev => prev >= navigableTemplates.length - 1 ? 0 : prev + 1);
+        break;
+      case 'ArrowUp':
+        event.preventDefault();
+        if (navigableTemplates.length === 0) return;
+        setSelectedIndex(prev => prev <= 0 ? navigableTemplates.length - 1 : prev - 1);
+        break;
+      case 'Enter':
+        event.preventDefault();
+        if (selectedTemplate) {
+          onTemplateClick(selectedTemplate);
+        }
+        break;
+      case 'Tab':
+        event.preventDefault();
+        onFocusComposer?.();
+        break;
+      case 'Escape':
+        // The supermod shortcut handler listens on document and acts on Escape even
+        // from inside text inputs, so it would deselect the user out from under the
+        // search. React's own listener is on document too, so only
+        // stopImmediatePropagation keeps the event from reaching it.
+        event.nativeEvent.stopImmediatePropagation();
+        handleCloseSearch();
+        break;
+    }
+  };
+
   // DndContext gets an explicit id because the ids dnd-kit puts in aria-describedby
   // otherwise come from a module-level counter, which drifts between the server and
   // the client and trips a hydration mismatch
@@ -577,9 +658,11 @@ const GroupedModerationTemplateList = ({ collectionName, onTemplateClick, highli
         <TemplateSearchBar
           searchOpen={searchOpen}
           searchQuery={searchQuery}
+          focusToken={searchFocusToken}
           onOpen={() => setSearchOpen(true)}
           onClose={handleCloseSearch}
           onQueryChange={handleSearchQueryChange}
+          onKeyDown={handleSearchKeyDown}
         />
       )}
       {visibleGroups.map(([group, templatesInGroup]) => (
@@ -587,7 +670,7 @@ const GroupedModerationTemplateList = ({ collectionName, onTemplateClick, highli
           key={group}
           group={group}
           templatesInGroup={templatesInGroup}
-          expanded={groupExpandedOverrides[group] ?? true}
+          expanded={isGroupExpanded(group)}
           onToggleExpanded={handleToggleGroupExpanded}
           onTemplateClick={onTemplateClick}
           onRenameGroup={handleRenameGroup}
@@ -606,6 +689,7 @@ const GroupedModerationTemplateList = ({ collectionName, onTemplateClick, highli
             </div>
           )}
           highlightedTemplateNames={highlightedTemplateNames}
+          selectedTemplateId={searchOpen ? (selectedTemplate?._id ?? null) : null}
         />
       ))}
       {hiddenTemplates.length > 0 && (

--- a/packages/lesswrong/components/sunshineDashboard/ModerationTemplateSunshineItem.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/ModerationTemplateSunshineItem.tsx
@@ -82,6 +82,12 @@ const styles = defineStyles('ModerationTemplateSunshineItem', (theme: ThemeType)
   highlighted: {
     border: theme.palette.border.intense
   },
+  // Defined before `suggested` so a selected-and-suggested row keeps the suggested
+  // background and only picks up the outline
+  selected: {
+    outline: theme.palette.greyBorder("1px", 0.3),
+    backgroundColor: theme.palette.greyAlpha(0.1),
+  },
   suggested: {
     backgroundColor: theme.palette.grey[900],
     color: theme.palette.grey[100],
@@ -112,10 +118,11 @@ const styles = defineStyles('ModerationTemplateSunshineItem', (theme: ThemeType)
   },
 }));
 
-export const ModerationTemplateSunshineItem = ({template, onTemplateClick, highlighted, dragHandleProps, onHide, onUnhide}: {
+export const ModerationTemplateSunshineItem = ({template, onTemplateClick, highlighted, selected, dragHandleProps, onHide, onUnhide}: {
   template: ModerationTemplateFragment,
   onTemplateClick: (template: ModerationTemplateFragment) => void,
   highlighted?: boolean,
+  selected?: boolean,
   dragHandleProps?: DragHandleProps,
   onHide?: (template: ModerationTemplateFragment) => void,
   onUnhide?: (template: ModerationTemplateFragment) => void,
@@ -157,7 +164,7 @@ export const ModerationTemplateSunshineItem = ({template, onTemplateClick, highl
       }
     >
       <div
-        className={classNames(classes.templateItem, { [classes.suggested]: highlighted })}
+        className={classNames(classes.templateItem, { [classes.suggested]: highlighted, [classes.selected]: selected })}
         onClick={() => onTemplateClick(template)}
       >
         {dragHandleProps && (

--- a/packages/lesswrong/components/sunshineDashboard/SunshineUserMessages.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineUserMessages.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useMemo } from 'react';
+import React, { useState, useEffect, useMemo, useRef } from 'react';
 import { useTracking } from '../../lib/analyticsEvents';
 import { TemplateQueryStrings } from '../messaging/NewConversationButton';
 import EmailIcon from '@/lib/vendor/@material-ui/icons/src/Email';
@@ -19,6 +19,7 @@ import { useAppendToEditor, AppendToEditorProvider } from '../editor/AppendToEdi
 import { getHighlightedTemplateNames } from './supermod/templateHighlightRules';
 import FormatDate from '../common/FormatDate';
 import GroupedModerationTemplateList from './GroupedModerationTemplateList';
+import { focusLexicalEditor } from '../editor/focusLexicalEditor';
 
 const ConversationsListMultiQuery = gql(`
   query multiConversationSunshineUserMessagesQuery($selector: ConversationSelector, $limit: Int, $enableTotal: Boolean) {
@@ -119,6 +120,8 @@ const SunshineUserMessagesInner = ({user, currentUser, posts, comments, showExpa
   const [embeddedConversationId, setEmbeddedConversationId] = useState<string | undefined>();
   const [templateQueries, setTemplateQueries] = useState<TemplateQueryStrings | undefined>();
   const [expandedConversationId, setExpandedConversationId] = useState<string | undefined>();
+  const [pendingComposerFocus, setPendingComposerFocus] = useState(false);
+  const composerRef = useRef<HTMLDivElement>(null);
 
   const { captureEvent } = useTracking()
   const { conversation, initiateConversation } = useInitiateConversation({ includeModerators: true });
@@ -180,6 +183,24 @@ const SunshineUserMessagesInner = ({user, currentUser, posts, comments, showExpa
     }
   };
 
+  // Focusing from the template list's Tab shortcut; if there's no conversation yet the
+  // composer doesn't exist, so start one and focus it once it renders.
+  const handleFocusComposer = () => {
+    if (embeddedConversationId) {
+      focusLexicalEditor(composerRef.current);
+    } else {
+      handleStartConversation();
+      setPendingComposerFocus(true);
+    }
+  };
+
+  useEffect(() => {
+    if (pendingComposerFocus && embeddedConversationId) {
+      setPendingComposerFocus(false);
+      focusLexicalEditor(composerRef.current);
+    }
+  }, [pendingComposerFocus, embeddedConversationId]);
+
   return <div>
     {results?.map(conversation => {
       const isExpanded = expandedConversationId === conversation._id;
@@ -210,7 +231,7 @@ const SunshineUserMessagesInner = ({user, currentUser, posts, comments, showExpa
       );
     })}
     {embeddedConversationId ? (
-      <div className={classes.conversationForm}>
+      <div className={classes.conversationForm} ref={composerRef}>
         <MessagesNewForm 
           conversationId={embeddedConversationId} 
           templateQueries={templateQueries}
@@ -233,6 +254,7 @@ const SunshineUserMessagesInner = ({user, currentUser, posts, comments, showExpa
       collectionName="Messages"
       onTemplateClick={handleTemplateClick}
       highlightedTemplateNames={highlightedTemplateNames}
+      onFocusComposer={handleFocusComposer}
     />
   </div>;
 }


### PR DESCRIPTION
Makes the moderation template list in `/admin/supermod` keyboard-drivable, matching how the rejection dialog's template list already works.

## Hotkeys

All of these operate from the template search box, same as `RejectContentDialog`:

- **`/`** — opens and focuses the template search (ignored while typing in an input, textarea, or the editor). Pressing it again refocuses an already-open search.
- **↑ / ↓** — move a wrapping selection through the visible templates in display order. Templates in collapsed groups and hidden templates aren't on screen, so they aren't navigable. The selected row scrolls into view.
- **Enter** — applies the selected template (appends it to the composer, or starts a conversation prefilled with it).
- **Tab** — focuses the message composer. If no conversation exists yet, it starts one and focuses the editor once it renders.
- **Escape** — closes the search. Unchanged behavior, just moved into the shared handler.

## Changes

- `GroupedModerationTemplateList.tsx` — selection state and the key handler; the search bar now delegates all key handling to the parent and takes a focus token so the `/` hotkey can refocus it while open. New optional `onFocusComposer` prop.
- `ModerationTemplateSunshineItem.tsx` — new `selected` style (outline plus a faint background). It's declared before `suggested` so a row that's both keeps the suggested dark background and only picks up the outline.
- `SunshineUserMessages.tsx` — supplies `onFocusComposer`, focusing the Lexical composer via the existing `focusLexicalEditor` helper.

## Testing

Typechecked. Not exercised in a browser — the container this was written in has no dev server or database, so the hotkeys are worth a click-through on the preview deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GhxVV7FmvgeeBGNiXukzWH

---
_Generated by [Claude Code](https://claude.ai/code/session_01GhxVV7FmvgeeBGNiXukzWH)_

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1217212367959949) by [Unito](https://www.unito.io)
