### PR TITLE
Add "Copy Markdown" item to post and comment menus

### DIFF
--- a/packages/lesswrong/components/dropdowns/CopyMarkdownDropdownItem.tsx
+++ b/packages/lesswrong/components/dropdowns/CopyMarkdownDropdownItem.tsx
@@ -11,16 +11,25 @@ const CopyMarkdownDropdownItem = ({path}: {
 }) => {
   const { flash } = useMessages();
 
-  const copyMarkdown = async () => {
-    // window.open must happen before any await, or popup blockers will eat it
-    window.open(path, '_blank');
-    const response = await fetch(path);
-    if (!response.ok) {
-      flash("Failed to fetch markdown");
-      return;
-    }
-    await navigator.clipboard.writeText(await response.text());
-    flash("Markdown copied to clipboard");
+  const copyMarkdown = () => {
+    // Start the clipboard write synchronously, while this document still has
+    // focus and user activation - opening the new tab takes focus away, which
+    // would make a later writeText call fail. Passing a promise to
+    // ClipboardItem lets the fetch resolve after focus is gone.
+    const markdownBlob = fetch(path).then(async (response) => {
+      if (!response.ok) {
+        throw new Error(`Failed to fetch markdown: ${response.status}`);
+      }
+      return new Blob([await response.text()], {type: "text/plain"});
+    });
+    const clipboardWrite = navigator.clipboard.write([
+      new ClipboardItem({"text/plain": markdownBlob}),
+    ]);
+    window.open(path, "_blank");
+    clipboardWrite.then(
+      () => flash("Markdown copied to clipboard"),
+      () => flash("Failed to copy markdown"),
+    );
   };
 
   return (

--- a/packages/lesswrong/components/dropdowns/CopyMarkdownDropdownItem.tsx
+++ b/packages/lesswrong/components/dropdowns/CopyMarkdownDropdownItem.tsx
@@ -8,10 +8,7 @@ const CopyMarkdownDropdownItem = ({path}: {
   const { flash } = useMessages();
 
   const copyMarkdown = () => {
-    // Start the clipboard write synchronously, while this document still has
-    // focus and user activation - opening the new tab takes focus away, which
-    // would make a later writeText call fail. Passing a promise to
-    // ClipboardItem lets the fetch resolve after focus is gone.
+    // Start synchronously, while doc still has focus and user activation - opening new tab takes focus away
     const markdownBlob = fetch(path).then(async (response) => {
       if (!response.ok) {
         throw new Error(`Failed to fetch markdown: ${response.status}`);

--- a/packages/lesswrong/components/dropdowns/CopyMarkdownDropdownItem.tsx
+++ b/packages/lesswrong/components/dropdowns/CopyMarkdownDropdownItem.tsx
@@ -2,10 +2,6 @@ import React from 'react';
 import DropdownItem from './DropdownItem';
 import { useMessages } from '../common/withMessages';
 
-/**
- * Menu item that opens the markdown API page for a post or comment in a new
- * tab, and copies its markdown to the clipboard.
- */
 const CopyMarkdownDropdownItem = ({path}: {
   path: string,
 }) => {

--- a/packages/lesswrong/components/dropdowns/CopyMarkdownDropdownItem.tsx
+++ b/packages/lesswrong/components/dropdowns/CopyMarkdownDropdownItem.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import DropdownItem from './DropdownItem';
+import { useMessages } from '../common/withMessages';
+
+/**
+ * Menu item that opens the markdown API page for a post or comment in a new
+ * tab, and copies its markdown to the clipboard.
+ */
+const CopyMarkdownDropdownItem = ({path}: {
+  path: string,
+}) => {
+  const { flash } = useMessages();
+
+  const copyMarkdown = async () => {
+    // window.open must happen before any await, or popup blockers will eat it
+    window.open(path, '_blank');
+    const response = await fetch(path);
+    if (!response.ok) {
+      flash("Failed to fetch markdown");
+      return;
+    }
+    await navigator.clipboard.writeText(await response.text());
+    flash("Markdown copied to clipboard");
+  };
+
+  return (
+    <DropdownItem
+      title="Copy Markdown"
+      icon="ClipboardDocument"
+      onClick={copyMarkdown}
+    />
+  );
+};
+
+export default CopyMarkdownDropdownItem;

--- a/packages/lesswrong/components/dropdowns/comments/CommentActions.tsx
+++ b/packages/lesswrong/components/dropdowns/comments/CommentActions.tsx
@@ -15,6 +15,7 @@ import MoveToAnswersDropdownItem from "./MoveToAnswersDropdownItem";
 import ToggleIsModeratorCommentDropdownItem from "./ToggleIsModeratorCommentDropdownItem";
 import PinToProfileDropdownItem from "./PinToProfileDropdownItem";
 import DropdownMenu from "../DropdownMenu";
+import CopyMarkdownDropdownItem from "../CopyMarkdownDropdownItem";
 import ShortformFrontpageDropdownItem from "./ShortformFrontpageDropdownItem";
 import { CommentSubscriptionsDropdownItem } from "./CommentSubscriptionsDropdownItem";
 import BanUserFromPostDropdownItem from "./BanUserFromPostDropdownItem";
@@ -64,6 +65,7 @@ const CommentActions = ({comment, post, tag, showEdit}: {
       <CommentSubscriptionsDropdownItem comment={comment} post={post} />
       {!comment.draft && <BookmarkDropdownItem documentId={comment._id} collectionName="Comments" preventMenuClose />}
       <ReportCommentDropdownItem comment={comment} post={post} />
+      {comment.postId && <CopyMarkdownDropdownItem path={`/api/post/${comment.postId}/comments/${comment._id}`} />}
       <MoveToAlignmentCommentDropdownItem comment={comment} post={postDetails} />
       <SuggestAlignmentCommentDropdownItem comment={comment} post={postDetails} />
 

--- a/packages/lesswrong/components/dropdowns/posts/PostActions.tsx
+++ b/packages/lesswrong/components/dropdowns/posts/PostActions.tsx
@@ -15,6 +15,7 @@ import MoveToFrontpageDropdownItem from "./MoveToFrontpageDropdownItem";
 import MoveToAlignmentPostDropdownItem from "./MoveToAlignmentPostDropdownItem";
 import ShortformDropdownItem from "./ShortformDropdownItem";
 import DropdownMenu from "../DropdownMenu";
+import CopyMarkdownDropdownItem from "../CopyMarkdownDropdownItem";
 import EditTagsDropdownItem from "./EditTagsDropdownItem";
 import EditPostDropdownItem from "./EditPostDropdownItem";
 import DuplicateEventDropdownItem from "./DuplicateEventDropdownItem";
@@ -77,6 +78,7 @@ const PostActions = ({post, closeMenu, includeBookmark=true}: {
       <ReportPostDropdownItem post={post}/>
       {currentUser && <EditTagsDropdownItem post={post} closeMenu={closeMenu} />}
       <SummarizeDropdownItem post={post} closeMenu={closeMenu} />
+      <CopyMarkdownDropdownItem path={`/api/post/${post._id}`} />
       {currentUser && <MarkAsReadDropdownItem post={post} />}
       {hasCuratedPostsSetting.get() && <SuggestCuratedDropdownItem post={post} />}
       <MoveToDraftDropdownItem post={post} />


### PR DESCRIPTION
Adds a **Copy Markdown** item to the post and comment triple-dot menus. Clicking it:

- opens the markdown API page for that post (`/api/post/[id]`) or comment (`/api/post/[postId]/comments/[commentId]`) in a new tab
- fetches that same URL and copies the markdown to the clipboard, with a flash confirmation

Implementation is one small shared `CopyMarkdownDropdownItem` component (following the `SharePostActions` copy-link pattern) wired into `PostActions` and `CommentActions`. For comments it only renders when the comment has a `postId` (the markdown API has no route for tag comments).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1217221482417106) by [Unito](https://www.unito.io)
