### PR TITLE
Return SSR GraphQL errors as values so error pages can set real status codes

### DIFF
--- a/app/[...not-found]/page.tsx
+++ b/app/[...not-found]/page.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { notFound } from 'next/navigation';
+import Error404 from '@/components/common/Error404';
+import RouteRoot from '@/components/layout/RouteRoot';
 import { assertRouteAttributes } from "@/lib/routeChecks/assertRouteAttributes";
 
 assertRouteAttributes("/[...not-found]", {
@@ -10,6 +11,12 @@ assertRouteAttributes("/[...not-found]", {
   hasMarkdownVersion: false,
 });
 
+// Render the not-found UI directly rather than calling notFound(): a
+// notFound() thrown mid-stream can't affect the HTTP status, whereas
+// rendering Error404 emits the StatusCodeSetter marker that the middleware
+// turns into a real 404 (or a redirect, for miscapitalized routes).
 export default function NotFound() {
-  notFound();
+  return <RouteRoot delayedStatusCode>
+    <Error404/>
+  </RouteRoot>;
 }

--- a/app/groups/[groupId]/page.tsx
+++ b/app/groups/[groupId]/page.tsx
@@ -6,7 +6,6 @@ import { getDefaultMetadata, getMetadataDescriptionFields, getMetadataImagesFiel
 import merge from "lodash/merge";
 import { cloudinaryCloudNameSetting, taglineSetting } from "@/lib/instanceSettings";
 import RouteRoot from "@/components/layout/RouteRoot";
-import { notFound } from "next/navigation";
 import { runQuery } from "@/server/vulcan-lib/query";
 import { assertRouteAttributes } from "@/lib/routeChecks/assertRouteAttributes";
 
@@ -46,7 +45,7 @@ export async function generateMetadata({ params, searchParams }: { params: Promi
   
     const localgroup = data?.localgroup?.result;
   
-    if (!localgroup) return notFound();
+    if (!localgroup) return defaultMetadata;
   
     const description = localgroup.contents?.plaintextDescription ?? taglineSetting.get();
     const descriptionFields = getMetadataDescriptionFields(description);

--- a/app/users/[slug]/page.tsx
+++ b/app/users/[slug]/page.tsx
@@ -18,7 +18,7 @@ export default async function Page({ params }: {
   params: Promise<{ slug: string }>
 }) {
   const { slug } = await params;
-  return <RouteRoot>
+  return <RouteRoot delayedStatusCode>
     <UsersSingle slug={slug}/>
   </RouteRoot>;
 }

--- a/packages/lesswrong/lib/crud/useQuery.ts
+++ b/packages/lesswrong/lib/crud/useQuery.ts
@@ -291,9 +291,16 @@ export const useQuery: typeof useQueryApollo = ((query: any, options?: UseQueryO
     const injectedStore = injectedStoreAfterWait ?? injectedStoreBeforeWait;
 
     const injectedErrors = injected?.errors;
+    // Injected errors exist to make the hydration render agree with the SSR'd
+    // error UI, so they're only adopted by instances whose first render is a
+    // hydration render. Post-hydration mounts (eg client-side navigation back
+    // to the page) ignore them and get apollo's normal lifecycle, which
+    // re-executes the query rather than reusing a possibly-stale error.
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const isHydrationRender = useIsHydrationWithNoRerender();
     // eslint-disable-next-line react-hooks/rules-of-hooks
     const injectedErrorRef = useRef<{ key: string, error: CombinedGraphQLErrors } | null>(null);
-    if (firstRender.current && injectedErrors?.length) {
+    if (firstRender.current && isHydrationRender && injectedErrors?.length) {
       injectedErrorRef.current = { key: injectedKey, error: new CombinedGraphQLErrors({ errors: injectedErrors }) };
     }
     const injectedError = injectedErrorRef.current?.key === injectedKey ? injectedErrorRef.current.error : undefined;

--- a/packages/lesswrong/lib/crud/useQuery.ts
+++ b/packages/lesswrong/lib/crud/useQuery.ts
@@ -3,8 +3,9 @@
 import React, { createContext, use, useContext, useMemo, useRef, useState, useSyncExternalStore } from "react";
 // eslint-disable-next-line no-restricted-imports
 import { useQuery as useQueryApollo, useSuspenseQuery as useSuspenseQueryApollo, useReadQuery as useReadQueryApollo, useBackgroundQuery as useBackgroundQueryApollo, useApolloClient, type SuspenseQueryHookFetchPolicy } from "@apollo/client/react";
+import { CombinedGraphQLErrors, NetworkStatus } from "@apollo/client";
 import { debugSuspenseBoundaries, NamedSuspenseBoundary } from "@/components/common/SuspenseWrapper";
-import type { DocumentNode, OperationDefinitionNode } from 'graphql';
+import type { DocumentNode, GraphQLFormattedError, OperationDefinitionNode } from 'graphql';
 import { print } from "graphql";
 import type { TypedDocumentNode } from "@graphql-typed-document-node/core";
 import jsonStringifyDeterministic from "json-stringify-deterministic";
@@ -27,7 +28,7 @@ export type UseQueryOptions = {
 
 declare global {
   interface Window {
-    __LW_SSR_GQL__?: Record<string, { data: any }>;
+    __LW_SSR_GQL__?: Record<string, { data: any, errors?: GraphQLFormattedError[] }>;
     __LW_SSR_GQL_STORE_MAP__?: Map<string, JsonObject>;
     __lwSsrGql?: {
       get: (key: string) => unknown;
@@ -156,6 +157,64 @@ function normalizeQueryResult(result: any): any {
 }
 
 /**
+ * Serialize GraphQL errors for inclusion in an injected SSR payload. Only the
+ * message and path are kept: they're all that downstream error classification
+ * (eg isMissingDocumentError) needs, and other fields such as
+ * extensions.stacktrace must not leak into the HTML.
+ */
+function serializeGraphQLErrors(errors: readonly GraphQLFormattedError[]): GraphQLFormattedError[] {
+  return errors.map(({ message, path }) => ({ message, ...(path ? { path } : {}) }));
+}
+
+/**
+ * Get the cached promise for an SSR query, creating and caching it if this is
+ * the first hook to ask for this query+variables combination. The promise
+ * never rejects on GraphQL errors: to match the client-side useQuery contract
+ * (apollo's errorPolicy "none"), it resolves to `{data: undefined, error}` so
+ * that components can render their error states during SSR.
+ */
+function getOrCreateSsrQueryPromise(
+  ssrCache: SsrQueryCache,
+  injectedKey: string,
+  query: any,
+  variables: any,
+  resolverContext: ResolverContext,
+  injectHTML: (html: string) => void,
+): Promise<any> {
+  const existingPromise = ssrCache.queryPromises.get(injectedKey);
+  if (existingPromise) {
+    return existingPromise;
+  }
+  const queryPromise = (async () => {
+    const { runQueryNonThrowing } = await import("@/server/vulcan-lib/query");
+    // Modify selection sets to add __typename. Because apollo-client will
+    // do this transform when the same query is given to useQuery, we need
+    // to do it for the injected version, or else there would be a mismatch in
+    // whether the __typename field is present on some objects, which causes
+    // apollo-client to look for fields in the wrong place and return
+    //  incorrect empty objects.
+    const transformedQuery = addTypenameToDocument(query);
+    const result = await runQueryNonThrowing(transformedQuery, variables, resolverContext);
+
+    if (result.errors?.length) {
+      const serializedErrors = serializeGraphQLErrors(result.errors);
+      injectQueryResult(injectHTML, injectedKey, null, ssrCache, serializedErrors);
+      return {
+        data: undefined,
+        error: new CombinedGraphQLErrors({ errors: serializedErrors }),
+        networkStatus: NetworkStatus.error,
+      };
+    }
+
+    const payloadData = ((result as any)?.data ?? null) as JsonValue;
+    injectQueryResult(injectHTML, injectedKey, payloadData, ssrCache);
+    return normalizeQueryResult(result);
+  })();
+  ssrCache.queryPromises.set(injectedKey, queryPromise);
+  return queryPromise;
+}
+
+/**
  * Wrapper around apollo-client's useQuery, which uses Suspense
  * (useSuspenseQuery) for SSR, then switches to to regular useQuery afterwards.
  * We do this because handling non-first-time loading states (ie Load More
@@ -197,25 +256,7 @@ export const useQuery: typeof useQueryApollo = ((query: any, options?: UseQueryO
       } as any;
     }
 
-    const existingPromise = ssrCache.queryPromises.get(injectedKey);
-    const queryPromise = existingPromise ?? (async () => {
-      const { runQuery } = await import("@/server/vulcan-lib/query");
-      // Modify selection sets to add __typename. Because apollo-client will
-      // do this transform when the same query is given to useQuery, we need
-      // to do it for the injected version, or else there would be a mismatch in
-      // whether the __typename field is present on some objects, which causes
-      // apollo-client to look for fields in the wrong place and return
-      //  incorrect empty objects.
-      const transformedQuery = addTypenameToDocument(query);
-      const result = await runQuery(transformedQuery, variables, resolverContext);
-
-      const payloadData = ((result as any)?.data ?? null) as JsonValue;
-      injectQueryResult(injectHTML, injectedKey, payloadData, ssrCache);
-      return normalizeQueryResult(result);
-    })();
-    if (!existingPromise) {
-      ssrCache.queryPromises.set(injectedKey, queryPromise);
-    }
+    const queryPromise = getOrCreateSsrQueryPromise(ssrCache, injectedKey, query, variables, resolverContext, injectHTML);
 
     const result = use(queryPromise);
 
@@ -249,7 +290,15 @@ export const useQuery: typeof useQueryApollo = ((query: any, options?: UseQueryO
     const injected = injectedAfterWait ?? injectedBeforeWait;
     const injectedStore = injectedStoreAfterWait ?? injectedStoreBeforeWait;
 
-    const shouldUseInjected = !!injected && firstRender.current;
+    const injectedErrors = injected?.errors;
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const injectedErrorRef = useRef<{ key: string, error: CombinedGraphQLErrors } | null>(null);
+    if (firstRender.current && injectedErrors?.length) {
+      injectedErrorRef.current = { key: injectedKey, error: new CombinedGraphQLErrors({ errors: injectedErrors }) };
+    }
+    const injectedError = injectedErrorRef.current?.key === injectedKey ? injectedErrorRef.current.error : undefined;
+
+    const shouldUseInjected = !!injected && !injectedErrors?.length && firstRender.current;
     firstRender.current = false;
 
     const hydratedInjectedData = shouldUseInjected
@@ -281,10 +330,22 @@ export const useQuery: typeof useQueryApollo = ((query: any, options?: UseQueryO
       }
     }
 
+    // While this instance holds an SSR-injected error, skip apollo's own
+    // query: unlike injected data (which primes the apollo cache), an error
+    // can't be written to the cache, so without skip apollo would refetch and
+    // transiently flash a loading state on the way to the same error.
     // eslint-disable-next-line react-hooks/rules-of-hooks
-    const result = useQueryApollo(query, options);
+    const result = useQueryApollo(query, injectedError ? { ...options, skip: true } : options);
 
-    if (shouldUseInjected) {
+    if (injectedError) {
+      return {
+        ...result,
+        data: undefined,
+        error: injectedError,
+        loading: false,
+        networkStatus: NetworkStatus.error,
+      } as any;
+    } else if (shouldUseInjected) {
       return {
         ...result,
         data: hydratedInjectedData,
@@ -303,9 +364,14 @@ export const useSuspenseQuery: typeof useSuspenseQueryApollo = ((query: any, opt
   // eslint-disable-next-line react-hooks/rules-of-hooks
   if (bundleIsServer) {
     // On the server, `useQuery` already suspends (via `use(queryPromise)`), so
-    // this is equivalent.
+    // this is equivalent, except that useQuery returns GraphQL errors as
+    // values while apollo's useSuspenseQuery (errorPolicy "none") throws them.
     // eslint-disable-next-line react-hooks/rules-of-hooks
-    return useQuery(query, options) as any;
+    const result = useQuery(query, options) as any;
+    if (result?.error) {
+      throw result.error;
+    }
+    return result;
   }
 
   const apolloClient = useApolloClient();
@@ -326,7 +392,9 @@ export const useSuspenseQuery: typeof useSuspenseQueryApollo = ((query: any, opt
   const injectedAfterWait = injectedStoreAfterWait?.[injectedKey];
   const injected = injectedAfterWait ?? injectedBeforeWait;
   const injectedStore = injectedStoreAfterWait ?? injectedStoreBeforeWait;
-  const shouldUseInjected = !!injected && firstRender.current;
+  // Error payloads can't prime the apollo cache; let apollo run the query
+  // itself, which will throw the error to the nearest boundary as usual.
+  const shouldUseInjected = !!injected && !injected.errors?.length && firstRender.current;
   firstRender.current = false;
 
   const hydratedInjectedData = shouldUseInjected
@@ -366,9 +434,9 @@ type LwClientBackgroundQueryRef = {
   __lwInjectedKey: string;
 };
 
-function injectQueryResult(injectHTML: (html: string) => void, injectedKey: string, payloadData: JsonValue, ssrCache: SsrQueryCache) {
+function injectQueryResult(injectHTML: (html: string) => void, injectedKey: string, payloadData: JsonValue, ssrCache: SsrQueryCache, serializedErrors?: GraphQLFormattedError[]) {
   const { substituted, delta } = extractToObjectStoreAndSubstitute(payloadData, ssrCache.deduplicatedObjectStore);
-  const payload = { data: substituted };
+  const payload = serializedErrors?.length ? { data: substituted, errors: serializedErrors } : { data: substituted };
   const keyJson = escapeInlineScriptJson(JSON.stringify(injectedKey));
   const payloadJson = escapeInlineScriptJson(JSON.stringify(payload));
   const deltaJson = Object.keys(delta).length
@@ -396,19 +464,9 @@ export const useBackgroundQuery: typeof useBackgroundQueryApollo = ((query: any,
     }, [injectedKey, isSkipped]);
 
     if (!isSkipped) {
-      const existingPromise = ssrCache.queryPromises.get(injectedKey);
-      const queryPromise = existingPromise ?? (async () => {
-        const { runQuery } = await import("@/server/vulcan-lib/query");
-        const transformedQuery = addTypenameToDocument(query);
-        const result = await runQuery(transformedQuery, variables, resolverContext);
-
-        const payloadData = ((result as any)?.data ?? null) as JsonValue;
-        injectQueryResult(injectHTML, injectedKey, payloadData, ssrCache);
-        return normalizeQueryResult(result);
-      })();
-      if (!existingPromise) {
-        ssrCache.queryPromises.set(injectedKey, queryPromise);
-      }
+      // The promise is cached in ssrCache and consumed by useReadQuery.
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
+      getOrCreateSsrQueryPromise(ssrCache, injectedKey, query, variables, resolverContext, injectHTML);
     }
 
     return [
@@ -438,7 +496,9 @@ export const useBackgroundQuery: typeof useBackgroundQueryApollo = ((query: any,
     const injectedAfterWait = injectedStoreAfterWait?.[injectedKey];
     const injected = injectedAfterWait ?? injectedBeforeWait;
     const injectedStore = injectedStoreAfterWait ?? injectedStoreBeforeWait;
-    const shouldUseInjected = !!injected && firstRender.current;
+    // Error payloads can't prime the apollo cache; let apollo run the query
+    // itself, which will surface the error through the QueryRef as usual.
+    const shouldUseInjected = !!injected && !injected.errors?.length && firstRender.current;
     firstRender.current = false;
 
     const hydratedInjectedData = shouldUseInjected
@@ -497,6 +557,11 @@ export const useReadQuery: typeof useReadQueryApollo = ((queryRef: any) => {
     }
 
     const result = use(promise);
+    // Apollo's useReadQuery (errorPolicy "none") throws GraphQL errors rather
+    // than returning them.
+    if ((result as any)?.error) {
+      throw (result as any).error;
+    }
     return {
       ...(result as any),
       loading: false,

--- a/packages/lesswrong/server/pageMetadata/postPageMetadata.ts
+++ b/packages/lesswrong/server/pageMetadata/postPageMetadata.ts
@@ -5,7 +5,6 @@ import merge from "lodash/merge";
 import { CommentPermalinkMetadataQuery, getCommentDescription, getDefaultMetadata, getMetadataDescriptionFields, getMetadataImagesFields, getPageTitleFields, getResolverContextForGenerateMetadata, handleMetadataError, noIndexMetadata } from "./sharedMetadata";
 import { postGetPageUrl } from "@/lib/collections/posts/helpers";
 import { getPostDescription } from "@/components/posts/PostsPage/structuredData";
-import { notFound } from "next/navigation";
 import { filterNonnull } from "@/lib/utils/typeGuardUtils";
 import { runQuery } from "../vulcan-lib/query";
 
@@ -106,7 +105,7 @@ export function getPostPageMetadataFunction<Params>(paramsToPostIdConverter: (pa
       const post = postData?.post?.result;
       const comment = commentData?.comment?.result;
   
-      if (!post) return notFound();
+      if (!post) return defaultMetadata;
   
       const description = comment
         ? getCommentDescription(comment)

--- a/packages/lesswrong/server/pageMetadata/sequencePageMetadata.ts
+++ b/packages/lesswrong/server/pageMetadata/sequencePageMetadata.ts
@@ -4,7 +4,6 @@ import type { Metadata } from "next";
 import merge from "lodash/merge";
 import { combineUrls, getSiteUrl } from "@/lib/vulcan-lib/utils";
 import { sequenceGetPageUrl } from "@/lib/collections/sequences/helpers";
-import { notFound } from "next/navigation";
 import { makeCloudinaryImageUrl } from "@/components/common/cloudinaryHelpers";
 import { runQuery } from "@/server/vulcan-lib/query";
 
@@ -41,7 +40,7 @@ export async function generateSequencePageMetadata({ params, searchParams }: {
 
     const sequence = data?.sequence?.result;
 
-    if (!sequence) return notFound();
+    if (!sequence) return await getDefaultMetadata();
 
     const titleFields = getPageTitleFields(sequence.title);
 

--- a/packages/lesswrong/server/pageMetadata/sharedMetadata.ts
+++ b/packages/lesswrong/server/pageMetadata/sharedMetadata.ts
@@ -5,7 +5,6 @@ import { CombinedGraphQLErrors } from '@apollo/client';
 import { captureException } from '@/lib/sentryWrapper';
 import type { Metadata } from "next";
 import { headers } from "next/headers";
-import { notFound } from 'next/navigation';
 import { getRequestIdForServerComponentOrGenerateMetadata } from '../rendering/requestId';
 import { getResolverContextForSSR } from '@/server/rendering/ssrApolloClient';
 
@@ -132,17 +131,23 @@ function shouldIgnoreError(error: unknown) {
   return false;
 }
 
-export function handleMetadataError(prefix: string, error: unknown) {
-  // Don't log on noisy permission/not found errors; we have a lot of scrapers which 
+/**
+ * Handle an error thrown while generating page metadata by falling back to the
+ * site-default metadata. Deliberately not `notFound()`: that would put a 404
+ * digest in the RSC payload, which makes the client render the not-found page
+ * regardless of what the page's own SSR decided, while being unable to affect
+ * the HTTP status (metadata streams in after the status is committed). The
+ * page component owns the error UI and status code (via StatusCodeSetter).
+ */
+export function handleMetadataError(prefix: string, error: unknown): Promise<Metadata> {
+  // Don't log on noisy permission/not found errors; we have a lot of scrapers which
   // end up hitting posts that are now drafts, don't exist, etc.
-  if (shouldIgnoreError(error)) {
-    return notFound();
+  if (!shouldIgnoreError(error)) {
+    //eslint-disable-next-line no-console
+    console.error(`${prefix}:`, error);
+    captureException(error);
   }
-
-  //eslint-disable-next-line no-console
-  console.error(`${prefix}:`, error);
-  captureException(error);
-  return notFound();
+  return getDefaultMetadata();
 }
 
 /**

--- a/packages/lesswrong/server/pageMetadata/userPageMetadata.ts
+++ b/packages/lesswrong/server/pageMetadata/userPageMetadata.ts
@@ -4,8 +4,6 @@ import type { Metadata } from "next";
 import merge from "lodash/merge";
 import { cloudinaryCloudNameSetting, siteNameWithArticleSetting, taglineSetting } from "@/lib/instanceSettings";
 import { userGetDisplayName } from "@/lib/collections/users/helpers";
-import { captureException } from "@/lib/sentryWrapper";
-import { notFound } from "next/navigation";
 import { runQuery } from "@/server/vulcan-lib/query";
 
 const UserMetadataQuery = gql(`
@@ -42,7 +40,7 @@ export async function generateUserPageMetadata({ params, searchParams }: {
   
     const user = data?.users?.results?.[0];
   
-    if (!user) return notFound();
+    if (!user) return defaultMetadata;
   
     const displayName = userGetDisplayName(user);
     const description = `${displayName}'s profile on ${siteNameWithArticleSetting.get()} — ${taglineSetting.get()}`;

--- a/packages/lesswrong/server/vulcan-lib/query.ts
+++ b/packages/lesswrong/server/vulcan-lib/query.ts
@@ -27,7 +27,7 @@ export function setOnGraphQLError(fn: ((errors: readonly GraphQLError[]) => void
 }
 
 // note: if no context is passed, default to running requests with full admin privileges
-export const runQuery = async <TData extends Record<string, any>, TVariables extends OperationVariables>(query: string | TypedDocumentNode<TData, TVariables>, variables: TVariables = {} as TVariables, context?: Partial<ResolverContext>) => {
+export const runQueryNonThrowing = async <TData extends Record<string, any>, TVariables extends OperationVariables>(query: string | TypedDocumentNode<TData, TVariables>, variables: TVariables = {} as TVariables, context?: Partial<ResolverContext>) => {
   const { getExecutableSchema } = await import('./apollo-server/initGraphQL');
 
   const executableSchema = getExecutableSchema();
@@ -48,6 +48,16 @@ export const runQuery = async <TData extends Record<string, any>, TVariables ext
 
   if (result.errors) {
     onGraphQLError(result.errors);
+  }
+
+  return result;
+};
+
+// note: if no context is passed, default to running requests with full admin privileges
+export const runQuery = async <TData extends Record<string, any>, TVariables extends OperationVariables>(query: string | TypedDocumentNode<TData, TVariables>, variables: TVariables = {} as TVariables, context?: Partial<ResolverContext>) => {
+  const result = await runQueryNonThrowing(query, variables, context);
+
+  if (result.errors) {
     throw new Error(result.errors?.[0]?.message);
   }
 

--- a/packages/lesswrong/stubs/server/vulcan-lib/query.ts
+++ b/packages/lesswrong/stubs/server/vulcan-lib/query.ts
@@ -3,3 +3,7 @@ export const runQuery: any = () => {
   throw new Error("This function can only be run on the server");
 }
 
+export const runQueryNonThrowing: any = () => {
+  throw new Error("This function can only be run on the server");
+}
+


### PR DESCRIPTION
Written by Claude
-----

Previously, a GraphQL error during SSR (eg app.operation_not_allowed for a logged-out request to a draft post) rejected the useQuery suspense promise, crashing the Suspense boundary before the error UI could render. The StatusCodeSetter marker never reached the HTML stream, so the middleware passed through a 200 for pages that then rendered as errors client-side.

- Split runQuery into runQueryNonThrowing + a throwing wrapper (existing callers unchanged), and make the SSR branch of useQuery resolve to {data: undefined, error: CombinedGraphQLErrors} on GraphQL errors, matching client-side apollo errorPolicy "none" semantics. useSuspenseQuery/useReadQuery still throw, also matching apollo.
- Inject serialized errors (message + path only) into the SSR payload, and have the client useQuery return the injected error on hydration while skipping apollo's own query, so hydration matches the SSR'd error UI with no duplicate request or loading flash.
- Stop calling notFound() from generateMetadata error/missing-document paths (post, user, sequence, localgroup, handleMetadataError); return default metadata instead. The notFound() there could never affect the HTTP status (metadata streams after the status is committed) but its 404 digest forced the client to render the not-found page regardless of what the page's own SSR decided. Status codes and error UI are now solely owned by page components via StatusCodeSetter.
- Fix two routes the audit surfaced: /users/[slug] was missing delayedStatusCode (its early 200 marker beat the 404 marker for missing users), and the /[...not-found] catch-all threw notFound() instead of rendering Error404, so unmatched routes returned 200.

Verified against a local production build: draft post 401, missing post/user and unmatched routes 404, public pages unchanged at 200.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1217297503770924) by [Unito](https://www.unito.io)
