### PR TITLE
Move Copy Markdown above Summarize in post actions menu

### DIFF
--- a/packages/lesswrong/components/dropdowns/posts/PostActions.tsx
+++ b/packages/lesswrong/components/dropdowns/posts/PostActions.tsx
@@ -77,8 +77,8 @@ const PostActions = ({post, closeMenu, includeBookmark=true}: {
       <DislikeRecommendationDropdownItem post={post} />
       <ReportPostDropdownItem post={post}/>
       {currentUser && <EditTagsDropdownItem post={post} closeMenu={closeMenu} />}
-      <SummarizeDropdownItem post={post} closeMenu={closeMenu} />
       <CopyMarkdownDropdownItem path={`/api/post/${post._id}`} />
+      <SummarizeDropdownItem post={post} closeMenu={closeMenu} />
       {currentUser && <MarkAsReadDropdownItem post={post} />}
       {hasCuratedPostsSetting.get() && <SuggestCuratedDropdownItem post={post} />}
       <MoveToDraftDropdownItem post={post} />


### PR DESCRIPTION
Reorders the post actions dropdown so the "Copy Markdown" item appears above "Summarize", by swapping the two items in `PostActions.tsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xs3G3z6utQNnYLFXx9WSXL

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xs3G3z6utQNnYLFXx9WSXL)_

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1217319097469476) by [Unito](https://www.unito.io)
