### PR TITLE
Count comments in "Multiple LLM rejections" template highlight rule

### DIFF
--- a/packages/lesswrong/components/sunshineDashboard/supermod/templateHighlightRules.ts
+++ b/packages/lesswrong/components/sunshineDashboard/supermod/templateHighlightRules.ts
@@ -19,10 +19,11 @@ const TEMPLATE_HIGHLIGHT_RULES: Record<string, HighlightRule> = {
     const moderatorMessages = moderatorActions.filter(a => a.type === SENT_MODERATOR_MESSAGE);
     return moderatorMessages.length >= 2;
   },
-  "Multiple LLM rejections": ({ moderatorActions, posts }) => {
+  "Multiple LLM rejections": ({ moderatorActions, posts, comments }) => {
     const moderatorMessages = moderatorActions.filter(a => a.type === SENT_MODERATOR_MESSAGE);
-    const highLLMPosts = posts.filter(p => (p.automatedContentEvaluations?.pangramScore ?? 0) >= .2);
-    return highLLMPosts.length >= 2 && moderatorMessages.length >= 2;
+    const userContent = [...posts, ...comments];
+    const highLLMContent = userContent.filter(c => (c.automatedContentEvaluations?.pangramScore ?? 0) >= .2);
+    return highLLMContent.length >= 2 && moderatorMessages.length >= 2;
   },
   "Semi-automoderated quality warning (downvoted)": ({ moderatorActions }) =>
     moderatorActions.some(a => a.active && a.type === RECENTLY_DOWNVOTED_CONTENT_ALERT),


### PR DESCRIPTION
## Summary
- The "Multiple LLM rejections" moderation-template highlight rule only counted **posts** with a pangram score >= 0.2, so users whose LLM-flagged content was mostly comments (e.g. shortform) never triggered the suggestion, even with multiple autorejected comments.
- The rule now counts posts and comments together when checking for >= 2 high-LLM-score items. The `SunshineCommentsList` fragment already includes the same `automatedContentEvaluations` fields as posts, so no query changes were needed.

## Test plan
- [ ] On the supermod dashboard, open a user with >= 2 prior moderator messages and >= 2 high-pangram-score items where at least one is a comment; confirm "Multiple LLM rejections" is highlighted in the template list.

Made with [Cursor](https://cursor.com)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1217395016042909) by [Unito](https://www.unito.io)
