### PR TITLE
Hide metadata fields when editing templates in the supermod list

### DIFF
--- a/packages/lesswrong/components/sunshineDashboard/ModerationTemplateSunshineItem.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/ModerationTemplateSunshineItem.tsx
@@ -155,6 +155,7 @@ export const ModerationTemplateSunshineItem = ({template, onTemplateClick, highl
           <BasicFormStyles>
             <ModerationTemplatesForm
               initialData={template}
+              hideMetadataFields
               onSuccess={() => setEdit(false)}
               onCancel={() => setEdit(false)}
             />


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

When editing a moderation template from the template list on `/admin/supermod` (via `ModerationTemplateSunshineItem`), the edit form no longer shows the **Collection name**, **Order**, and **Group label** inputs.

The values are still preserved under the hood: they remain in the form's default values, and since `getUpdatedFieldValues` only sends dirty fields on update, the stored `collectionName`, `order`, and `groupLabel` are untouched when the moderator edits the name or contents.

This reuses the existing `hideMetadataFields` prop on `ModerationTemplatesForm`, which the same list already uses for its new-template form. The full-featured admin page at `/admin/moderationTemplates` still shows all fields.

## Screenshots

Before — editing a template in the supermod list showed Collection name, Order, and Group label:

[Edit form before, with Collection name, Order, and Group label fields](https://cursor.com/agents/bc-d8957ec8-3c12-4423-9db9-5188337b2eae/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fedit_form_before_with_metadata_fields.webp)

After — the same edit form shows only Name, contents, and Deleted:

[Edit form after, without metadata fields](https://cursor.com/agents/bc-d8957ec8-3c12-4423-9db9-5188337b2eae/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fedit_form_after_metadata_fields_hidden.webp)

Values preserved: after renaming "Be nicer" to "Be nicer please" through the reduced form and submitting, the template stays under its WARNINGS group (and the DB row keeps `collectionName=Messages`, `order=10`, `groupLabel=Warnings`):

[Template still grouped under WARNINGS after editing](https://cursor.com/agents/bc-d8957ec8-3c12-4423-9db9-5188337b2eae/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftemplate_still_under_warnings_after_edit.webp)

Demo video:

[supermod_template_edit_form_without_metadata_fields.mp4](https://cursor.com/agents/bc-d8957ec8-3c12-4423-9db9-5188337b2eae/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsupermod_template_edit_form_without_metadata_fields.mp4)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d8957ec8-3c12-4423-9db9-5188337b2eae?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d8957ec8-3c12-4423-9db9-5188337b2eae&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1217396153932158) by [Unito](https://www.unito.io)
