### PR TITLE
Fix Cmd+Enter being swallowed by template toggle in supermod rejection panel

### DIFF
--- a/packages/lesswrong/components/sunshineDashboard/GroupedModerationTemplateList.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/GroupedModerationTemplateList.tsx
@@ -665,6 +665,10 @@ const GroupedModerationTemplateList = ({ collectionName, onTemplateClick, highli
         setSelectedIndex(prev => prev - 1);
         break;
       case 'Enter':
+        // Cmd/Ctrl+Enter submits the composer above the list (e.g. rejecting
+        // the content), handled by its own document-level listener; only a
+        // plain Enter toggles the selected template
+        if (event.metaKey || event.ctrlKey) return;
         event.preventDefault();
         if (selectedTemplate) {
           onTemplateClick(selectedTemplate);

--- a/packages/lesswrong/components/sunshineDashboard/GroupedModerationTemplateList.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/GroupedModerationTemplateList.tsx
@@ -666,8 +666,6 @@ const GroupedModerationTemplateList = ({ collectionName, onTemplateClick, highli
         break;
       case 'Enter':
         // Cmd/Ctrl+Enter submits the composer above the list (e.g. rejecting
-        // the content), handled by its own document-level listener; only a
-        // plain Enter toggles the selected template
         if (event.metaKey || event.ctrlKey) return;
         event.preventDefault();
         if (selectedTemplate) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

In the supermod rejection panel, pressing Cmd/Ctrl+Enter while the template search was focused with a rejection template selected would toggle (remove) that template from the draft instead of submitting the rejection. The plain-Enter template-toggle handler in `GroupedModerationTemplateList` fired on any Enter keypress, modifiers included, and called `preventDefault` + `onTemplateClick` before the panel's document-level Cmd+Enter reject handler could act on the event.

The fix makes the search input's `Enter` case ignore presses with Cmd/Ctrl held, so the event propagates to `RejectContentPanel`'s document-level listener, which submits the rejection. This matches the convention already used in `RejectContentDialog`, where the `Enter` case explicitly branches on `e.ctrlKey || e.metaKey`.

## Testing

Tested manually against a local dev server seeded with a flagged user, an unreviewed post, and rejection templates:

- ArrowDown in the template search highlights a template; plain Enter still toggles it into the draft (bold lead appears in the message preview).
- With the template still selected and focus in the search input, Ctrl+Enter now submits the rejection: the draft clears, the post shows "Rejected by moderator", and the `rejectedReason` in the database contains the template's html.

[supermod_ctrl_enter_rejects_post_with_selected_template.mp4](https://cursor.com/agents/bc-4e0731a2-f41d-47eb-bc0e-89d06d659c4c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsupermod_ctrl_enter_rejects_post_with_selected_template.mp4)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4e0731a2-f41d-47eb-bc0e-89d06d659c4c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4e0731a2-f41d-47eb-bc0e-89d06d659c4c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1217396341251395) by [Unito](https://www.unito.io)
