### PR TITLE
Supermod: poll for queue and user-content updates in the background

### DIFF
--- a/packages/lesswrong/components/hooks/useModeratedUserContents.ts
+++ b/packages/lesswrong/components/hooks/useModeratedUserContents.ts
@@ -38,8 +38,7 @@ export function useModeratedUserContents(userId: string, contentLimit = 20, poll
   return {
     posts: posts ?? [],
     comments,
-    // True until both queries have returned data at least once; while this is
-    // set, the content list may be partial (eg comments without posts).
+    // True until both queries have returned once; until then the list may be partial.
     loading: posts === undefined || commentsData === undefined,
   };
 }

--- a/packages/lesswrong/components/hooks/useModeratedUserContents.ts
+++ b/packages/lesswrong/components/hooks/useModeratedUserContents.ts
@@ -3,6 +3,7 @@ import { usePublishedPosts } from "./usePublishedPosts";
 import { gql } from "@/lib/generated/gql-codegen";
 import { useMemo } from "react";
 import { useHydrateModerationPostCache } from "./useHydrateModerationPostCache";
+import { skipPollWhenHidden } from "./usePageVisibility";
 
 const SunshineCommentsListMultiQuery = gql(`
   query multiCommentModerationSidebarQuery($selector: CommentSelector, $limit: Int, $enableTotal: Boolean) {
@@ -15,8 +16,8 @@ const SunshineCommentsListMultiQuery = gql(`
   }
 `);
 
-export function useModeratedUserContents(userId: string, contentLimit = 20) {
-  const { posts = [] } = usePublishedPosts(userId, contentLimit, false);
+export function useModeratedUserContents(userId: string, contentLimit = 20, pollInterval?: number) {
+  const { posts } = usePublishedPosts(userId, contentLimit, false, pollInterval);
   const { data: commentsData } = useQuery(SunshineCommentsListMultiQuery, {
     variables: {
       selector: { sunshineNewUsersComments: { userId } },
@@ -24,16 +25,21 @@ export function useModeratedUserContents(userId: string, contentLimit = 20) {
       enableTotal: false,
     },
     ssr: false,
+    pollInterval: userId ? pollInterval : undefined,
+    skipPollAttempt: skipPollWhenHidden,
   });
 
   const comments = useMemo(() => [...(commentsData?.comments?.results ?? [])], [commentsData]);
 
   // In ModerationContentDetail, we embed a post page wrapper into the moderation detail view.
   // Hydrating the apollo cache here lets us avoid a loading spinner when going through a user's posts that way.
-  useHydrateModerationPostCache(posts);
+  useHydrateModerationPostCache(posts ?? []);
 
   return {
-    posts,
+    posts: posts ?? [],
     comments,
+    // True until both queries have returned data at least once; while this is
+    // set, the content list may be partial (eg comments without posts).
+    loading: posts === undefined || commentsData === undefined,
   };
 }

--- a/packages/lesswrong/components/hooks/usePageVisibility.ts
+++ b/packages/lesswrong/components/hooks/usePageVisibility.ts
@@ -25,11 +25,7 @@ export function usePageVisibility(onChange: (isVisible: boolean, visibilityState
   useEventListener('visibilitychange' as keyof WindowEventMap, handleVisibilityChange);
 }
 
-/**
- * For apollo useQuery's `skipPollAttempt` option: skips background poll
- * attempts while the tab is hidden, so backgrounded tabs don't keep hitting
- * the server. Polling resumes on the next attempt after the tab is visible.
- */
+/** For apollo's `skipPollAttempt` option: skip polls while the tab is hidden. */
 export function skipPollWhenHidden() {
   return !getPageVisibility().isVisible;
 }

--- a/packages/lesswrong/components/hooks/usePageVisibility.ts
+++ b/packages/lesswrong/components/hooks/usePageVisibility.ts
@@ -25,6 +25,15 @@ export function usePageVisibility(onChange: (isVisible: boolean, visibilityState
   useEventListener('visibilitychange' as keyof WindowEventMap, handleVisibilityChange);
 }
 
+/**
+ * For apollo useQuery's `skipPollAttempt` option: skips background poll
+ * attempts while the tab is hidden, so backgrounded tabs don't keep hitting
+ * the server. Polling resumes on the next attempt after the tab is visible.
+ */
+export function skipPollWhenHidden() {
+  return !getPageVisibility().isVisible;
+}
+
 export function getPageVisibility(): {
   isVisible: boolean,
   visibilityState: DocumentVisibilityState

--- a/packages/lesswrong/components/hooks/usePublishedPosts.ts
+++ b/packages/lesswrong/components/hooks/usePublishedPosts.ts
@@ -1,6 +1,7 @@
 import { useQuery } from "@/lib/crud/useQuery";
 import { gql } from "@/lib/generated/gql-codegen";
 import { useMemo } from "react";
+import { skipPollWhenHidden } from "./usePageVisibility";
 
 const SunshinePostsListMultiQuery = gql(`
   query multiPostusePublishedPostsQuery($selector: PostSelector, $limit: Int, $enableTotal: Boolean) {
@@ -18,7 +19,7 @@ const SunshinePostsListMultiQuery = gql(`
  * To preserve user privacy, don't return drafts which have never been published.
  * This used to be implemented with LWEvents, but now we're just using the `wasEverUndrafted` field.
  */
-export function usePublishedPosts(userId: string, contentLimit = 20, ssr = true) {
+export function usePublishedPosts(userId: string, contentLimit = 20, ssr = true, pollInterval?: number) {
   const { data, loading } = useQuery(SunshinePostsListMultiQuery, {
     variables: {
       selector: { sunshineNewUsersPosts: { userId } },
@@ -27,6 +28,8 @@ export function usePublishedPosts(userId: string, contentLimit = 20, ssr = true)
     },
     notifyOnNetworkStatusChange: true,
     ssr,
+    pollInterval: userId ? pollInterval : undefined,
+    skipPollAttempt: skipPollWhenHidden,
   });
 
   const posts = useMemo(() => [...(data?.posts?.results ?? [])], [data]);

--- a/packages/lesswrong/components/sunshineDashboard/supermod/ModerationInbox.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/supermod/ModerationInbox.tsx
@@ -285,11 +285,8 @@ const ModerationInboxInner = ({ users, posts, classifiedPosts, curationPosts, la
     }
   }, [state.openedUserId, query.user, location, navigate]);
 
-  // The outer component polls ModerationInboxDataQuery in the background, so
-  // these props update over time. Fold refreshed results into the reducer
-  // state (REFRESH_DATA merges rather than replaces, so in-progress moderation
-  // isn't disrupted). The first value is skipped because it already seeded the
-  // reducer's initial state.
+  // Folds background-poll updates to these props into the reducer state; the first
+  // value is skipped because it already seeded the reducer's initial state.
   const initialDataSeededRef = useRef(false);
   useEffect(() => {
     if (!initialDataSeededRef.current) {
@@ -406,11 +403,8 @@ const ModerationInboxInner = ({ users, posts, classifiedPosts, curationPosts, la
 
   const { posts: userPosts, comments: userComments, loading: userContentsLoading } = useModeratedUserContents(openedUser?._id ?? '', 20, BACKGROUND_POLL_INTERVAL);
 
-  // The detail view's content focus is index-based, into the merged
-  // newest-first list that ModerationUserDetailView renders (recomputed here
-  // with the same sort). When a background refresh inserts or removes items,
-  // re-anchor the index to the item that was focused so the focus doesn't
-  // silently jump to a different item.
+  // Content focus is an index into this list (same sort as ModerationUserDetailView);
+  // when a refresh changes the list, re-anchor the index to the item that was focused.
   const allUserContent = useMemo(() => [...userPosts, ...userComments].sort((a, b) =>
     new Date(b.postedAt).getTime() - new Date(a.postedAt).getTime()
   ), [userPosts, userComments]);
@@ -420,8 +414,7 @@ const ModerationInboxInner = ({ users, posts, classifiedPosts, curationPosts, la
   useEffect(() => {
     const contentChanged = prevUserContentRef.current !== allUserContent;
     prevUserContentRef.current = allUserContent;
-    // While the list may be partial (one of the two content queries hasn't
-    // returned yet), neither re-anchor nor move the anchor.
+    // While the list may be partial (a query hasn't returned), leave the anchor alone
     if (userContentsLoading) return;
     if (contentChanged && state.openedUserId && focusedContentIdRef.current) {
       const anchoredIndex = allUserContent.findIndex(item => item._id === focusedContentIdRef.current);
@@ -564,8 +557,7 @@ const ModerationInbox = () => {
       curationLimit: 200,
     },
     fetchPolicy: 'cache-and-network',
-    // Background refresh; ModerationInboxInner folds refreshed results into
-    // its reducer state without disrupting in-progress moderation.
+    // Background refresh; ModerationInboxInner merges results into its reducer state
     pollInterval: BACKGROUND_POLL_INTERVAL,
     skipPollAttempt: skipPollWhenHidden,
   });

--- a/packages/lesswrong/components/sunshineDashboard/supermod/ModerationInbox.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/supermod/ModerationInbox.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useCallback, useEffect, useMemo, useReducer } from 'react';
+import React, { useCallback, useEffect, useMemo, useReducer, useRef } from 'react';
 import { defineStyles, useStyles } from '@/components/hooks/useStyles';
 import { useCurrentUser } from '@/components/common/withUser';
 import { userIsAdminOrMod } from '@/lib/vulcan-users/permissions';
@@ -19,7 +19,8 @@ import { getUserReviewGroup, type TabId } from './groupings';
 import { REVIEW_GROUP_TO_PRIORITY } from '@/lib/collections/users/reviewGroups';
 import { getFilteredGroups, getVisibleTabsInOrder, InboxState, inboxStateReducer } from './inboxReducer';
 import ModerationTabs, { type TabInfo } from './ModerationTabs';
-import { UNDO_QUEUE_DURATION } from './constants';
+import { UNDO_QUEUE_DURATION, BACKGROUND_POLL_INTERVAL } from './constants';
+import { skipPollWhenHidden } from '@/components/hooks/usePageVisibility';
 import { useHydrateModerationPostCache } from '@/components/hooks/useHydrateModerationPostCache';
 import { useCoreTags } from '@/components/tagging/useCoreTags';
 import { CoreTagsKeyboardProvider } from '@/components/tagging/CoreTagsKeyboardContext';
@@ -135,7 +136,7 @@ const ModerationInboxInner = ({ users, posts, classifiedPosts, curationPosts, la
 
   const [state, dispatch] = useReducer(
     inboxStateReducer,
-    { users: [], posts: [], classifiedPosts: [], curationPosts: [], activeTab: 'all', focusedUserId: null, openedUserId: initialOpenedUserId, focusedPostId: null, focusedContentIndex: 0, sidebarTab: null, undoQueue: [], history: [], runningLlmCheckId: null },
+    { users: [], posts: [], classifiedPosts: [], curationPosts: [], activeTab: 'all', focusedUserId: null, openedUserId: initialOpenedUserId, focusedPostId: null, focusedContentIndex: 0, sidebarTab: null, undoQueue: [], history: [], runningLlmCheckId: null, removedPostIds: [] },
     (): InboxState => {
       const initialUsers = directUser ? [directUser, ...users] : users;
       if (initialUsers.length === 0 && posts.length === 0 && classifiedPosts.length === 0 && curationPosts.length === 0) {
@@ -153,6 +154,7 @@ const ModerationInboxInner = ({ users, posts, classifiedPosts, curationPosts, la
           undoQueue: [],
           history: [],
           runningLlmCheckId: null,
+          removedPostIds: [],
         };
       }
 
@@ -171,6 +173,7 @@ const ModerationInboxInner = ({ users, posts, classifiedPosts, curationPosts, la
           undoQueue: [],
           history: [],
           runningLlmCheckId: null,
+          removedPostIds: [],
         };
       }
 
@@ -200,6 +203,7 @@ const ModerationInboxInner = ({ users, posts, classifiedPosts, curationPosts, la
           undoQueue: [],
           history: [],
           runningLlmCheckId: null,
+          removedPostIds: [],
         };
       }
       
@@ -218,6 +222,7 @@ const ModerationInboxInner = ({ users, posts, classifiedPosts, curationPosts, la
           undoQueue: [],
           history: [],
           runningLlmCheckId: null,
+          removedPostIds: [],
         };
       }
 
@@ -236,6 +241,7 @@ const ModerationInboxInner = ({ users, posts, classifiedPosts, curationPosts, la
           undoQueue: [],
           history: [],
           runningLlmCheckId: null,
+          removedPostIds: [],
         };
       }
 
@@ -256,6 +262,7 @@ const ModerationInboxInner = ({ users, posts, classifiedPosts, curationPosts, la
         undoQueue: [],
         history: [],
         runningLlmCheckId: null,
+        removedPostIds: [],
       };
     }
   );
@@ -277,6 +284,20 @@ const ModerationInboxInner = ({ users, posts, classifiedPosts, curationPosts, la
       }, { replace: true, skipRouter: true });
     }
   }, [state.openedUserId, query.user, location, navigate]);
+
+  // The outer component polls ModerationInboxDataQuery in the background, so
+  // these props update over time. Fold refreshed results into the reducer
+  // state (REFRESH_DATA merges rather than replaces, so in-progress moderation
+  // isn't disrupted). The first value is skipped because it already seeded the
+  // reducer's initial state.
+  const initialDataSeededRef = useRef(false);
+  useEffect(() => {
+    if (!initialDataSeededRef.current) {
+      initialDataSeededRef.current = true;
+      return;
+    }
+    dispatch({ type: 'REFRESH_DATA', users, posts, classifiedPosts, curationPosts, directUserId: directUser?._id ?? null });
+  }, [users, posts, classifiedPosts, curationPosts, directUser]);
 
   const groupedUsers = useMemo(() => groupBy(state.users, user => getUserReviewGroup(user)), [state.users]);
 
@@ -383,7 +404,34 @@ const ModerationInboxInner = ({ users, posts, classifiedPosts, curationPosts, la
   const isCurationTab = state.activeTab === 'curation';
   const isPostLikeTab = isPostsTab || isCurationTab;
 
-  const { posts: userPosts, comments: userComments } = useModeratedUserContents(openedUser?._id ?? '');
+  const { posts: userPosts, comments: userComments, loading: userContentsLoading } = useModeratedUserContents(openedUser?._id ?? '', 20, BACKGROUND_POLL_INTERVAL);
+
+  // The detail view's content focus is index-based, into the merged
+  // newest-first list that ModerationUserDetailView renders (recomputed here
+  // with the same sort). When a background refresh inserts or removes items,
+  // re-anchor the index to the item that was focused so the focus doesn't
+  // silently jump to a different item.
+  const allUserContent = useMemo(() => [...userPosts, ...userComments].sort((a, b) =>
+    new Date(b.postedAt).getTime() - new Date(a.postedAt).getTime()
+  ), [userPosts, userComments]);
+
+  const focusedContentIdRef = useRef<string | null>(null);
+  const prevUserContentRef = useRef(allUserContent);
+  useEffect(() => {
+    const contentChanged = prevUserContentRef.current !== allUserContent;
+    prevUserContentRef.current = allUserContent;
+    // While the list may be partial (one of the two content queries hasn't
+    // returned yet), neither re-anchor nor move the anchor.
+    if (userContentsLoading) return;
+    if (contentChanged && state.openedUserId && focusedContentIdRef.current) {
+      const anchoredIndex = allUserContent.findIndex(item => item._id === focusedContentIdRef.current);
+      if (anchoredIndex >= 0 && anchoredIndex !== state.focusedContentIndex) {
+        dispatch({ type: 'SET_FOCUSED_CONTENT_INDEX', index: anchoredIndex });
+        return;
+      }
+    }
+    focusedContentIdRef.current = allUserContent[state.focusedContentIndex]?._id ?? null;
+  }, [allUserContent, userContentsLoading, state.openedUserId, state.focusedContentIndex]);
 
   return (
     <CoreTagsKeyboardProvider>
@@ -516,6 +564,10 @@ const ModerationInbox = () => {
       curationLimit: 200,
     },
     fetchPolicy: 'cache-and-network',
+    // Background refresh; ModerationInboxInner folds refreshed results into
+    // its reducer state without disrupting in-progress moderation.
+    pollInterval: BACKGROUND_POLL_INTERVAL,
+    skipPollAttempt: skipPollWhenHidden,
   });
 
   const initialOpenedUserId = query.user || null;

--- a/packages/lesswrong/components/sunshineDashboard/supermod/constants.ts
+++ b/packages/lesswrong/components/sunshineDashboard/supermod/constants.ts
@@ -1,3 +1,3 @@
 export const UNDO_QUEUE_DURATION = 15_000;
-/** How often supermod polls in the background for updates to the moderation queues and the opened user's content. */
+/** How often supermod polls in the background for queue and content updates. */
 export const BACKGROUND_POLL_INTERVAL = 60_000;

--- a/packages/lesswrong/components/sunshineDashboard/supermod/constants.ts
+++ b/packages/lesswrong/components/sunshineDashboard/supermod/constants.ts
@@ -1,1 +1,3 @@
 export const UNDO_QUEUE_DURATION = 15_000;
+/** How often supermod polls in the background for updates to the moderation queues and the opened user's content. */
+export const BACKGROUND_POLL_INTERVAL = 60_000;

--- a/packages/lesswrong/components/sunshineDashboard/supermod/inboxReducer.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/supermod/inboxReducer.tsx
@@ -4,6 +4,7 @@ import groupBy from 'lodash/groupBy';
 import sumBy from 'lodash/sumBy';
 import { getUserReviewGroup, getTabsInPriorityOrder, type TabId } from './groupings';
 import { REVIEW_GROUP_TO_PRIORITY } from '@/lib/collections/users/reviewGroups';
+import { filterNonnull } from '@/lib/utils/typeGuardUtils';
 import type { GroupEntry } from './ModerationInboxList';
 import type { TabInfo } from './ModerationTabs';
 import type { SelectedSidebarTab } from './sidebarTabs';
@@ -54,6 +55,10 @@ export type InboxState = {
   history: HistoryItem[];
   // Document ID for which an LLM detection check is currently running
   runningLlmCheckId: string | null;
+  // Post ids removed by local moderator actions. A background refresh must not
+  // re-add these: the removal is dispatched before the server mutation
+  // resolves, so refreshed data may briefly still include them.
+  removedPostIds: string[];
 };
 
 export type InboxAction =
@@ -78,7 +83,9 @@ export type InboxAction =
   | { type: 'ADD_TO_UNDO_QUEUE'; item: UndoHistoryItem; }
   | { type: 'UNDO_ACTION'; userId: string; }
   | { type: 'EXPIRE_UNDO_ITEM'; userId: string; }
-  | { type: 'SET_LLM_CHECK_RUNNING'; documentId: string | null; };
+  | { type: 'SET_LLM_CHECK_RUNNING'; documentId: string | null; }
+  | { type: 'SET_FOCUSED_CONTENT_INDEX'; index: number; }
+  | { type: 'REFRESH_DATA'; users: SunshineUsersList[]; posts: SunshinePostsList[]; classifiedPosts: SunshinePostsList[]; curationPosts: SunshineCurationPostsListItem[]; directUserId: string | null; };
 
 
 
@@ -115,6 +122,34 @@ export function getVisibleTabsInOrder(
   tabs.push({ group: 'classifiedPosts', count: totalClassifiedPosts });
   
   return tabs;
+}
+
+/**
+ * Merge a background-refreshed list into the local copy, without disrupting
+ * whatever the moderator is currently doing:
+ * - Items the moderator is working on (`protectedIds`) keep their local
+ *   version and are never removed, even if the refreshed data no longer
+ *   includes them.
+ * - Other existing items are updated in place with the refreshed data,
+ *   preserving their current position in the list.
+ * - Items that vanished from the refreshed data (eg handled by another
+ *   moderator) are removed.
+ * - Newly arrived items are appended at the end, except ones removed by a
+ *   local action that the server may not reflect yet (`locallyRemovedIds`).
+ */
+function mergeRefreshedItems<T extends { _id: string }>(
+  currentItems: T[],
+  refreshedItems: T[],
+  protectedIds: Set<string>,
+  locallyRemovedIds: Set<string>,
+): T[] {
+  const refreshedById = new Map(refreshedItems.map(item => [item._id, item]));
+  const currentIds = new Set(currentItems.map(item => item._id));
+  const keptItems = currentItems
+    .filter(item => protectedIds.has(item._id) || refreshedById.has(item._id))
+    .map(item => protectedIds.has(item._id) ? item : refreshedById.get(item._id) ?? item);
+  const addedItems = refreshedItems.filter(item => !currentIds.has(item._id) && !locallyRemovedIds.has(item._id));
+  return [...keptItems, ...addedItems];
 }
 
 /**
@@ -537,6 +572,7 @@ function reduceInboxAction(state: InboxState, action: InboxAction): InboxState {
           posts: newPosts,
           classifiedPosts: newClassifiedPosts,
           focusedPostId: null,
+          removedPostIds: [...state.removedPostIds, action.postId],
         };
       }
 
@@ -549,6 +585,7 @@ function reduceInboxAction(state: InboxState, action: InboxAction): InboxState {
         posts: newPosts,
         classifiedPosts: newClassifiedPosts,
         focusedPostId: nextPostId,
+        removedPostIds: [...state.removedPostIds, action.postId],
       };
     }
 
@@ -657,6 +694,35 @@ function reduceInboxAction(state: InboxState, action: InboxAction): InboxState {
       return {
         ...state,
         runningLlmCheckId: action.documentId,
+      };
+    }
+
+    // Repositions the content focus without any of OPEN_CONTENT's side
+    // effects (it doesn't touch the composer), used to keep the focus anchored
+    // to the same item when a background refresh reorders the content list.
+    case 'SET_FOCUSED_CONTENT_INDEX': {
+      return {
+        ...state,
+        focusedContentIndex: action.index,
+      };
+    }
+
+    // Background-refreshed data from polling. Merges instead of replacing so
+    // that in-progress moderation (focused/opened items, the undo queue, and
+    // optimistic local updates on the item being acted on) is not disrupted.
+    case 'REFRESH_DATA': {
+      const protectedIds = new Set(filterNonnull([state.openedUserId, state.focusedUserId, state.focusedPostId, action.directUserId]));
+      const locallyRemovedUserIds = new Set([
+        ...state.undoQueue.map(item => item.user._id),
+        ...state.history.map(item => item.user._id),
+      ]);
+      const locallyRemovedPostIds = new Set(state.removedPostIds);
+      return {
+        ...state,
+        users: mergeRefreshedItems(state.users, action.users, protectedIds, locallyRemovedUserIds),
+        posts: mergeRefreshedItems(state.posts, action.posts, protectedIds, locallyRemovedPostIds),
+        classifiedPosts: mergeRefreshedItems(state.classifiedPosts, action.classifiedPosts, protectedIds, locallyRemovedPostIds),
+        curationPosts: mergeRefreshedItems(state.curationPosts, action.curationPosts, protectedIds, new Set()),
       };
     }
 

--- a/packages/lesswrong/components/sunshineDashboard/supermod/inboxReducer.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/supermod/inboxReducer.tsx
@@ -55,9 +55,7 @@ export type InboxState = {
   history: HistoryItem[];
   // Document ID for which an LLM detection check is currently running
   runningLlmCheckId: string | null;
-  // Post ids removed by local moderator actions. A background refresh must not
-  // re-add these: the removal is dispatched before the server mutation
-  // resolves, so refreshed data may briefly still include them.
+  // Posts removed locally; refreshes must not re-add them (mutation may be in flight)
   removedPostIds: string[];
 };
 
@@ -125,17 +123,10 @@ export function getVisibleTabsInOrder(
 }
 
 /**
- * Merge a background-refreshed list into the local copy, without disrupting
- * whatever the moderator is currently doing:
- * - Items the moderator is working on (`protectedIds`) keep their local
- *   version and are never removed, even if the refreshed data no longer
- *   includes them.
- * - Other existing items are updated in place with the refreshed data,
- *   preserving their current position in the list.
- * - Items that vanished from the refreshed data (eg handled by another
- *   moderator) are removed.
- * - Newly arrived items are appended at the end, except ones removed by a
- *   local action that the server may not reflect yet (`locallyRemovedIds`).
+ * Merge a background-refreshed list into the local copy without disrupting the
+ * moderator: `protectedIds` items keep their local version and are never removed,
+ * other existing items are updated in place, vanished items are removed, and new
+ * items are appended (except `locallyRemovedIds`, which the server may still return).
  */
 function mergeRefreshedItems<T extends { _id: string }>(
   currentItems: T[],
@@ -697,9 +688,7 @@ function reduceInboxAction(state: InboxState, action: InboxAction): InboxState {
       };
     }
 
-    // Repositions the content focus without any of OPEN_CONTENT's side
-    // effects (it doesn't touch the composer), used to keep the focus anchored
-    // to the same item when a background refresh reorders the content list.
+    // Moves the content focus without closing the composer (unlike OPEN_CONTENT)
     case 'SET_FOCUSED_CONTENT_INDEX': {
       return {
         ...state,
@@ -707,9 +696,7 @@ function reduceInboxAction(state: InboxState, action: InboxAction): InboxState {
       };
     }
 
-    // Background-refreshed data from polling. Merges instead of replacing so
-    // that in-progress moderation (focused/opened items, the undo queue, and
-    // optimistic local updates on the item being acted on) is not disrupted.
+    // Background poll results; merged so in-progress moderation isn't disrupted
     case 'REFRESH_DATA': {
       const protectedIds = new Set(filterNonnull([state.openedUserId, state.focusedUserId, state.focusedPostId, action.directUserId]));
       const locallyRemovedUserIds = new Set([

--- a/packages/lesswrong/unitTests/moderationInboxReducer.tests.ts
+++ b/packages/lesswrong/unitTests/moderationInboxReducer.tests.ts
@@ -1,4 +1,4 @@
-import { inboxStateReducer, type InboxState, type UndoHistoryItem } from '@/components/sunshineDashboard/supermod/inboxReducer';
+import { inboxStateReducer, type InboxAction, type InboxState, type UndoHistoryItem } from '@/components/sunshineDashboard/supermod/inboxReducer';
 import {
   UNREVIEWED_FIRST_POST,
   MANUAL_FLAG_ALERT,
@@ -60,6 +60,17 @@ function createMockUser(
   } as SunshineUsersList;
 }
 
+function createMockPost(id: string, partialPost?: Partial<SunshinePostsList>): SunshinePostsList {
+  return {
+    __typename: 'Post' as const,
+    _id: id,
+    title: `Post ${id}`,
+    postedAt: new Date().toISOString(),
+    reviewedByUserId: null,
+    ...partialPost,
+  } as SunshinePostsList;
+}
+
 function createUndoItem(
   user: SunshineUsersList,
   overrides?: Partial<UndoHistoryItem>
@@ -100,6 +111,7 @@ describe('Moderation Inbox Reducer', () => {
         undoQueue: [],
         history: [],
         runningLlmCheckId: null,
+        removedPostIds: [],
       };
 
       const newState = inboxStateReducer(state, { type: 'CLOSE_DETAIL' });
@@ -132,6 +144,7 @@ describe('Moderation Inbox Reducer', () => {
         undoQueue: [],
         history: [],
         runningLlmCheckId: null,
+        removedPostIds: [],
       };
 
       // Next from last user should wrap to first
@@ -160,6 +173,7 @@ describe('Moderation Inbox Reducer', () => {
         undoQueue: [],
         history: [],
         runningLlmCheckId: null,
+        removedPostIds: [],
       };
 
       // Prev from first user should wrap to last
@@ -190,6 +204,7 @@ describe('Moderation Inbox Reducer', () => {
         undoQueue: [],
         history: [],
         runningLlmCheckId: null,
+        removedPostIds: [],
       };
 
       // Start at newContent (highest priority)
@@ -232,6 +247,7 @@ describe('Moderation Inbox Reducer', () => {
         undoQueue: [],
         history: [],
         runningLlmCheckId: null,
+        removedPostIds: [],
       };
 
       // Start at newContent (highest priority)
@@ -270,6 +286,7 @@ describe('Moderation Inbox Reducer', () => {
         undoQueue: [],
         history: [],
         runningLlmCheckId: null,
+        removedPostIds: [],
       };
 
       state = inboxStateReducer(state, { type: 'REMOVE_USER', userId: 'user2' });
@@ -301,6 +318,7 @@ describe('Moderation Inbox Reducer', () => {
         undoQueue: [],
         history: [],
         runningLlmCheckId: null,
+        removedPostIds: [],
       };
 
       state = inboxStateReducer(state, { type: 'REMOVE_USER', userId: 'user1' });
@@ -330,6 +348,7 @@ describe('Moderation Inbox Reducer', () => {
         undoQueue: [],
         history: [],
         runningLlmCheckId: null,
+        removedPostIds: [],
       };
 
       state = inboxStateReducer(state, { type: 'REMOVE_USER', userId: 'user1' });
@@ -363,6 +382,7 @@ describe('Moderation Inbox Reducer', () => {
         undoQueue: [],
         history: [],
         runningLlmCheckId: null,
+        removedPostIds: [],
       };
 
       state = inboxStateReducer(state, { type: 'REMOVE_USER', userId: 'user2' });
@@ -394,6 +414,7 @@ describe('Moderation Inbox Reducer', () => {
         undoQueue: [],
         history: [],
         runningLlmCheckId: null,
+        removedPostIds: [],
       };
 
       state = inboxStateReducer(state, { type: 'REMOVE_USER', userId: 'user1' });
@@ -424,6 +445,7 @@ describe('Moderation Inbox Reducer', () => {
         undoQueue: [],
         history: [],
         runningLlmCheckId: null,
+        removedPostIds: [],
       };
 
       state = inboxStateReducer(state, { type: 'REMOVE_USER', userId: 'user1' });
@@ -457,6 +479,7 @@ describe('Moderation Inbox Reducer', () => {
         undoQueue: [createUndoItem(undoneUser, { sourceTab: 'newContent', wasDetailView: true })],
         history: [],
         runningLlmCheckId: null,
+        removedPostIds: [],
       };
 
       const newState = inboxStateReducer(state, { type: 'UNDO_ACTION', userId: 'user1' });
@@ -490,6 +513,7 @@ describe('Moderation Inbox Reducer', () => {
         undoQueue: [createUndoItem(undoneUser, { sourceTab: 'newContent', wasDetailView: false })],
         history: [],
         runningLlmCheckId: null,
+        removedPostIds: [],
       };
 
       const newState = inboxStateReducer(state, { type: 'UNDO_ACTION', userId: 'user1' });
@@ -516,6 +540,7 @@ describe('Moderation Inbox Reducer', () => {
         undoQueue: [],
         history: [],
         runningLlmCheckId: null,
+        removedPostIds: [],
       };
 
       const newState = inboxStateReducer(state, { type: 'UNDO_ACTION', userId: 'user1' });
@@ -545,6 +570,7 @@ describe('Moderation Inbox Reducer', () => {
         undoQueue: [],
         history: [],
         runningLlmCheckId: null,
+        removedPostIds: [],
       };
 
       // Try to change tabs
@@ -571,6 +597,7 @@ describe('Moderation Inbox Reducer', () => {
         undoQueue: [],
         history: [],
         runningLlmCheckId: null,
+        removedPostIds: [],
       };
     }
 
@@ -612,6 +639,248 @@ describe('Moderation Inbox Reducer', () => {
         documentId: 'post1',
       });
       expect(state.sidebarTab).toBe('reject');
+    });
+  });
+
+  describe('REMOVE_POST', () => {
+    test('records the removed post id so a background refresh cannot re-add it', () => {
+      const state: InboxState = {
+        users: [],
+        posts: [createMockPost('postA'), createMockPost('postB')],
+        classifiedPosts: [],
+        curationPosts: [],
+        activeTab: 'posts',
+        focusedUserId: null,
+        openedUserId: null,
+        focusedPostId: 'postA',
+        focusedContentIndex: 0,
+        sidebarTab: null,
+        undoQueue: [],
+        history: [],
+        runningLlmCheckId: null,
+        removedPostIds: [],
+      };
+
+      const newState = inboxStateReducer(state, { type: 'REMOVE_POST', postId: 'postA' });
+
+      expect(newState.posts.map(p => p._id)).toEqual(['postB']);
+      expect(newState.removedPostIds).toEqual(['postA']);
+    });
+  });
+
+  describe('SET_FOCUSED_CONTENT_INDEX', () => {
+    test('moves the content focus without closing the open composer', () => {
+      const state: InboxState = {
+        users: [createMockUser('user1', 'newContent')],
+        posts: [],
+        classifiedPosts: [],
+        curationPosts: [],
+        activeTab: 'newContent',
+        focusedUserId: null,
+        openedUserId: 'user1',
+        focusedPostId: null,
+        focusedContentIndex: 0,
+        sidebarTab: 'reject',
+        undoQueue: [],
+        history: [],
+        runningLlmCheckId: null,
+        removedPostIds: [],
+      };
+
+      const newState = inboxStateReducer(state, { type: 'SET_FOCUSED_CONTENT_INDEX', index: 2 });
+
+      expect(newState.focusedContentIndex).toBe(2);
+      expect(newState.sidebarTab).toBe('reject');
+    });
+  });
+
+  describe('REFRESH_DATA', () => {
+    function refreshAction(overrides?: Partial<Extract<InboxAction, { type: 'REFRESH_DATA' }>>) {
+      return {
+        type: 'REFRESH_DATA' as const,
+        users: [],
+        posts: [],
+        classifiedPosts: [],
+        curationPosts: [],
+        directUserId: null,
+        ...overrides,
+      };
+    }
+
+    test('appends newly arrived users and posts, and drops ones handled elsewhere', () => {
+      const state: InboxState = {
+        users: [createMockUser('user1', 'newContent'), createMockUser('user2', 'newContent')],
+        posts: [createMockPost('postA')],
+        classifiedPosts: [],
+        curationPosts: [],
+        activeTab: 'newContent',
+        focusedUserId: 'user1',
+        openedUserId: null,
+        focusedPostId: null,
+        focusedContentIndex: 0,
+        sidebarTab: null,
+        undoQueue: [],
+        history: [],
+        runningLlmCheckId: null,
+        removedPostIds: [],
+      };
+
+      // user2 and postA vanished server-side; user3 and postB are new
+      const newState = inboxStateReducer(state, refreshAction({
+        users: [createMockUser('user1', 'newContent'), createMockUser('user3', 'highContext')],
+        posts: [createMockPost('postB')],
+      }));
+
+      expect(newState.users.map(u => u._id)).toEqual(['user1', 'user3']);
+      expect(newState.posts.map(p => p._id)).toEqual(['postB']);
+    });
+
+    test('updates fields of existing users, but keeps the local version of the focused user', () => {
+      const state: InboxState = {
+        users: [
+          createMockUser('user1', 'newContent', { karma: 1 }),
+          createMockUser('user2', 'newContent', { karma: 2 }),
+        ],
+        posts: [],
+        classifiedPosts: [],
+        curationPosts: [],
+        activeTab: 'newContent',
+        focusedUserId: 'user1',
+        openedUserId: null,
+        focusedPostId: null,
+        focusedContentIndex: 0,
+        sidebarTab: null,
+        undoQueue: [],
+        history: [],
+        runningLlmCheckId: null,
+        removedPostIds: [],
+      };
+
+      const newState = inboxStateReducer(state, refreshAction({
+        users: [
+          createMockUser('user1', 'newContent', { karma: 100 }),
+          createMockUser('user2', 'newContent', { karma: 200 }),
+        ],
+      }));
+
+      // user1 is focused (possibly mid-action with optimistic local updates), so keeps the local copy
+      expect(newState.users.find(u => u._id === 'user1')?.karma).toBe(1);
+      expect(newState.users.find(u => u._id === 'user2')?.karma).toBe(200);
+    });
+
+    test('never removes the opened, focused, or deep-linked user', () => {
+      const state: InboxState = {
+        users: [
+          createMockUser('user1', 'newContent'),
+          createMockUser('user2', 'newContent'),
+          createMockUser('user3', 'newContent'),
+        ],
+        posts: [],
+        classifiedPosts: [],
+        curationPosts: [],
+        activeTab: 'newContent',
+        focusedUserId: 'user1',
+        openedUserId: 'user2',
+        focusedPostId: null,
+        focusedContentIndex: 0,
+        sidebarTab: null,
+        undoQueue: [],
+        history: [],
+        runningLlmCheckId: null,
+        removedPostIds: [],
+      };
+
+      const newState = inboxStateReducer(state, refreshAction({
+        users: [],
+        directUserId: 'user3',
+      }));
+
+      expect(newState.users.map(u => u._id)).toEqual(['user1', 'user2', 'user3']);
+    });
+
+    test('does not re-add users that are in the undo queue or history', () => {
+      const undoUser = createMockUser('user2', 'newContent');
+      const historyUser = createMockUser('user3', 'newContent');
+      const state: InboxState = {
+        users: [createMockUser('user1', 'newContent')],
+        posts: [],
+        classifiedPosts: [],
+        curationPosts: [],
+        activeTab: 'newContent',
+        focusedUserId: 'user1',
+        openedUserId: null,
+        focusedPostId: null,
+        focusedContentIndex: 0,
+        sidebarTab: null,
+        undoQueue: [createUndoItem(undoUser)],
+        history: [{ user: historyUser, actionLabel: 'Approved', timestamp: 0 }],
+        runningLlmCheckId: null,
+        removedPostIds: [],
+      };
+
+      // The server hasn't processed those reviews yet, so it still returns both users
+      const newState = inboxStateReducer(state, refreshAction({
+        users: [createMockUser('user1', 'newContent'), undoUser, historyUser],
+      }));
+
+      expect(newState.users.map(u => u._id)).toEqual(['user1']);
+    });
+
+    test('does not re-add locally removed posts, and keeps the focused post', () => {
+      const state: InboxState = {
+        users: [],
+        posts: [createMockPost('postA')],
+        classifiedPosts: [createMockPost('postC')],
+        curationPosts: [],
+        activeTab: 'posts',
+        focusedUserId: null,
+        openedUserId: null,
+        focusedPostId: 'postA',
+        focusedContentIndex: 0,
+        sidebarTab: null,
+        undoQueue: [],
+        history: [],
+        runningLlmCheckId: null,
+        removedPostIds: ['postB'],
+      };
+
+      // postB was just reviewed locally but the refreshed data still includes
+      // it; postA is focused and absent from the refreshed data
+      const newState = inboxStateReducer(state, refreshAction({
+        posts: [createMockPost('postB')],
+        classifiedPosts: [createMockPost('postC'), createMockPost('postB')],
+      }));
+
+      expect(newState.posts.map(p => p._id)).toEqual(['postA']);
+      expect(newState.classifiedPosts.map(p => p._id)).toEqual(['postC']);
+    });
+
+    test('leaves focus, tab, and composer state untouched', () => {
+      const state: InboxState = {
+        users: [createMockUser('user1', 'newContent')],
+        posts: [],
+        classifiedPosts: [],
+        curationPosts: [],
+        activeTab: 'newContent',
+        focusedUserId: null,
+        openedUserId: 'user1',
+        focusedPostId: null,
+        focusedContentIndex: 3,
+        sidebarTab: 'dm',
+        undoQueue: [],
+        history: [],
+        runningLlmCheckId: null,
+        removedPostIds: [],
+      };
+
+      const newState = inboxStateReducer(state, refreshAction({
+        users: [createMockUser('user1', 'newContent'), createMockUser('user2', 'automod')],
+      }));
+
+      expect(newState.activeTab).toBe('newContent');
+      expect(newState.openedUserId).toBe('user1');
+      expect(newState.focusedContentIndex).toBe(3);
+      expect(newState.sidebarTab).toBe('dm');
     });
   });
 });

--- a/packages/lesswrong/unitTests/moderationInboxReducer.tests.ts
+++ b/packages/lesswrong/unitTests/moderationInboxReducer.tests.ts
@@ -763,7 +763,7 @@ describe('Moderation Inbox Reducer', () => {
         ],
       }));
 
-      // user1 is focused (possibly mid-action with optimistic local updates), so keeps the local copy
+      // user1 is focused (possibly mid-action), so it keeps the local copy
       expect(newState.users.find(u => u._id === 'user1')?.karma).toBe(1);
       expect(newState.users.find(u => u._id === 'user2')?.karma).toBe(200);
     });
@@ -844,8 +844,7 @@ describe('Moderation Inbox Reducer', () => {
         removedPostIds: ['postB'],
       };
 
-      // postB was just reviewed locally but the refreshed data still includes
-      // it; postA is focused and absent from the refreshed data
+      // postB was reviewed locally but still returned; postA is focused and absent
       const newState = inboxStateReducer(state, refreshAction({
         posts: [createMockPost('postB')],
         classifiedPosts: [createMockPost('postC'), createMockPost('postB')],


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Supermod (`/admin/supermod`) previously fetched its data once on load; nothing refreshed until a full page reload. This adds background polling for the moderation queues (users, posts, auto-classified posts, curation candidates) and for the opened user's posts/comments, folding refreshed data in without disrupting whatever the moderator is doing.

## How it works

**Polling** (`BACKGROUND_POLL_INTERVAL` = 60s, skipped while the tab is hidden via apollo's `skipPollAttempt` and a new `skipPollWhenHidden` helper):
- `ModerationInboxDataQuery` (users / posts / classifiedPosts / curation candidates) polls in the outer `ModerationInbox` component.
- `useModeratedUserContents` / `usePublishedPosts` accept an optional `pollInterval`, enabled only for the opened user's content in the detail view (not for the per-row prefetches in the inbox list).

**Non-disruptive merge** — refreshed results are dispatched into the reducer as a new `REFRESH_DATA` action, which merges rather than replaces:
- The opened user, focused user, focused post, and deep-linked (`?user=`) user keep their local versions (which may hold optimistic updates from in-flight actions) and are never removed.
- Other existing items are updated in place, keeping their list position; items that vanished server-side (e.g. handled by another moderator) are removed; new arrivals are appended at the end.
- Users pending in the undo queue or already actioned (history) are never re-added, since the server-side action only executes when the undo window expires.
- Locally reviewed posts are never re-added: `REMOVE_POST` is dispatched before its mutation resolves, so a new `removedPostIds` state field tracks them.
- `REFRESH_DATA` never touches the active tab, focus, undo queue, or the open composer.

**Content focus anchoring** — the detail view's content focus is index-based into a newest-first list, so a refresh that inserts/removes items would silently shift focus (and the keyboard handler would act on the wrong item). `ModerationInboxInner` now re-anchors the index to the previously focused item's id via a new `SET_FOCUSED_CONTENT_INDEX` action (which, unlike `OPEN_CONTENT`, doesn't close the composer). Anchoring is suppressed while either content query hasn't returned yet, so partially loaded lists don't cause spurious jumps.

## Testing

- 8 new unit tests in `moderationInboxReducer.tests.ts` covering `REFRESH_DATA` (append/update/remove, focused/opened/deep-linked protection, undo-queue/history exclusion, `removedPostIds` exclusion, focus/tab/composer untouched), `REMOVE_POST` id tracking, and `SET_FOCUSED_CONTENT_INDEX`; all 33 tests in the suite pass.
- `yarn tsc` and eslint on all changed files pass.
- Manual UI testing wasn't possible in this environment: the dev server pulls its database credentials from a linked Vercel environment, which isn't available here.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-860394a5-4678-4676-876d-97f7ee16daa7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-860394a5-4678-4676-876d-97f7ee16daa7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1217396402021172) by [Unito](https://www.unito.io)
