### PR TITLE
Supermod: Escape closes the focused DM/Reject sidebar section

### DIFF
--- a/packages/lesswrong/components/editor/focusLexicalEditor.ts
+++ b/packages/lesswrong/components/editor/focusLexicalEditor.ts
@@ -81,14 +81,16 @@ export const focusLexicalEditorWhenReady = (container: HTMLDivElement | null) =>
  * Once the editor is blurred, ArrowUp/ArrowDown navigate the content list
  * again. React's own listener is on document too, so only
  * stopImmediatePropagation keeps the event from reaching it.
+ * Returns whether the event was a bare Escape (so callers can react to it).
  */
 export const blurEditorOnEscape = (event: ReactKeyboardEvent) => {
-  if (event.key !== 'Escape' || event.metaKey || event.ctrlKey || event.altKey || event.shiftKey) return;
+  if (event.key !== 'Escape' || event.metaKey || event.ctrlKey || event.altKey || event.shiftKey) return false;
   event.preventDefault();
   event.nativeEvent.stopImmediatePropagation();
   if (document.activeElement instanceof HTMLElement) {
     document.activeElement.blur();
   }
+  return true;
 };
 
 /**

--- a/packages/lesswrong/components/sunshineDashboard/GroupedModerationTemplateList.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/GroupedModerationTemplateList.tsx
@@ -496,13 +496,13 @@ const HiddenTemplatesSection = ({hiddenTemplates, expanded, onToggleExpanded, on
  * The search box drives the same keyboard flow as the rejection dialog: "/" opens and
  * focuses it, up/down move the selection through the visible templates, Enter applies
  * the selected one, Tab (or ArrowUp past the top of the list) jumps to the composer,
- * and Escape closes the search.
+ * and Escape closes the search (and, via `onEscape`, the section around it).
  *
  * `focusSearchToken` is bumped by the composer above the list when the moderator
  * presses ArrowDown on its last line; it opens and focuses the search with nothing
  * selected, so the next ArrowDown steps into the template list.
  */
-const GroupedModerationTemplateList = ({ collectionName, onTemplateClick, highlightedTemplateNames, onFocusComposer, focusSearchToken, active = true }: {
+const GroupedModerationTemplateList = ({ collectionName, onTemplateClick, highlightedTemplateNames, onFocusComposer, focusSearchToken, active = true, onEscape }: {
   collectionName: TemplateType,
   onTemplateClick: (template: ModerationTemplateFragment) => void,
   highlightedTemplateNames?: Set<string>,
@@ -511,6 +511,8 @@ const GroupedModerationTemplateList = ({ collectionName, onTemplateClick, highli
   // False while the list's composer tab is hidden (but kept mounted to
   // preserve drafts), so the "/" shortcut only reaches the visible list
   active?: boolean,
+  // Called when Escape is pressed in the search; closes the sidebar section containing the list
+  onEscape?: () => void,
 }) => {
   const classes = useStyles(styles);
   const currentUser = useCurrentUser();
@@ -683,6 +685,7 @@ const GroupedModerationTemplateList = ({ collectionName, onTemplateClick, highli
         // stopImmediatePropagation keeps the event from reaching it.
         event.nativeEvent.stopImmediatePropagation();
         handleCloseSearch();
+        onEscape?.();
         break;
     }
   };

--- a/packages/lesswrong/components/sunshineDashboard/SunshineUserMessages.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineUserMessages.tsx
@@ -308,12 +308,18 @@ const SunshineUserMessagesInner = ({user, currentUser, posts, comments, focusedC
     handleStartConversation();
   };
 
+  // Escape while focused inside a section closes it, like clicking its tab again
+  const handleCloseSidebarTab = () => {
+    setSidebarTab(null);
+  };
+
   const dmTabContents = <>
     {embeddedConversationId ? (
       <ComposerKeydownWrapper
         className={classes.conversationForm}
         containerRef={dmEditorContainerRef}
         onArrowDownPastEnd={() => setTemplateSearchToken(token => token + 1)}
+        onEscape={handleCloseSidebarTab}
       >
         <MessagesNewForm
           conversationId={embeddedConversationId}
@@ -341,6 +347,7 @@ const SunshineUserMessagesInner = ({user, currentUser, posts, comments, focusedC
       onFocusComposer={handleFocusComposer}
       focusSearchToken={templateSearchToken}
       active={dmTabActive}
+      onEscape={handleCloseSidebarTab}
     />
   </>;
 
@@ -403,7 +410,7 @@ const SunshineUserMessagesInner = ({user, currentUser, posts, comments, focusedC
     </div>
     {canReject && focusedContent && (
       <div className={classNames({ [classes.hiddenTabContent]: !rejectTabActive })}>
-        <RejectContentPanel user={user} focusedContent={focusedContent} active={rejectTabActive} />
+        <RejectContentPanel user={user} focusedContent={focusedContent} active={rejectTabActive} onEscape={handleCloseSidebarTab} />
       </div>
     )}
   </div>;

--- a/packages/lesswrong/components/sunshineDashboard/supermod/ComposerKeydownWrapper.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/supermod/ComposerKeydownWrapper.tsx
@@ -2,19 +2,23 @@ import React from 'react';
 import { blurEditorOnEscape, callOnArrowDownPastEditorEnd } from '@/components/editor/focusLexicalEditor';
 
 /**
- * Wrapper div for a supermod sidebar composer. Escape blurs the editor
- * (rather than letting the supermod Escape handler on document close the
- * detail view), and ArrowDown on the composer's last line hands focus to the
- * template search below it.
+ * Wrapper div for a supermod sidebar composer. Escape blurs the editor and
+ * calls `onEscape` (rather than letting the supermod Escape handler on
+ * document close the detail view), and ArrowDown on the composer's last line
+ * hands focus to the template search below it.
  */
-const ComposerKeydownWrapper = ({ containerRef, onArrowDownPastEnd, className, children }: {
+const ComposerKeydownWrapper = ({ containerRef, onArrowDownPastEnd, onEscape, className, children }: {
   containerRef: React.RefObject<HTMLDivElement | null>,
   onArrowDownPastEnd: () => void,
+  // Called on a bare Escape, after the editor is blurred; closes the sidebar section
+  onEscape?: () => void,
   className?: string,
   children: React.ReactNode,
 }) => {
   const handleKeyDown = (e: React.KeyboardEvent) => {
-    blurEditorOnEscape(e);
+    if (blurEditorOnEscape(e)) {
+      onEscape?.();
+    }
     callOnArrowDownPastEditorEnd(e, onArrowDownPastEnd);
   };
   return <div className={className} ref={containerRef} onKeyDown={handleKeyDown}>

--- a/packages/lesswrong/components/sunshineDashboard/supermod/RejectContentPanel.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/supermod/RejectContentPanel.tsx
@@ -151,7 +151,7 @@ function extractBoldLead(html: string): string {
  * uses it verbatim, substituting the content link for the "[content]"
  * placeholder.
  */
-const RejectContentEditor = ({ user, focusedContent, active, editorContainerRef, composerFocusToken, registerToggleTemplate, onArrowDownPastEnd }: {
+const RejectContentEditor = ({ user, focusedContent, active, editorContainerRef, composerFocusToken, registerToggleTemplate, onArrowDownPastEnd, onEscape }: {
   user: SunshineUsersList,
   focusedContent: ContentItem,
   // False while the panel is hidden (but kept mounted to preserve the draft)
@@ -161,6 +161,8 @@ const RejectContentEditor = ({ user, focusedContent, active, editorContainerRef,
   composerFocusToken: number,
   registerToggleTemplate: (fn: (template: ModerationTemplateFragment) => void) => void,
   onArrowDownPastEnd: () => void,
+  // Escape in the composer closes the panel's tab, as if it were clicked again
+  onEscape: () => void,
 }) => {
   const classes = useStyles(styles);
   const { rejectContent } = useRejectContent();
@@ -268,7 +270,7 @@ const RejectContentEditor = ({ user, focusedContent, active, editorContainerRef,
       <div className={classes.collapsedIntro}>{standardRejectionIntroPlaintext}</div>
       {addedTemplates.map(template => <div key={template.templateId} className={classes.reasonLead}>{template.lead}</div>)}
     </div>}
-    {editorOpen && <ComposerKeydownWrapper className={classes.editorContainer} containerRef={editorContainerRef} onArrowDownPastEnd={onArrowDownPastEnd}>
+    {editorOpen && <ComposerKeydownWrapper className={classes.editorContainer} containerRef={editorContainerRef} onArrowDownPastEnd={onArrowDownPastEnd} onEscape={onEscape}>
       <ContentStyles contentType='comment'>
         <LexicalEditor
           key={lexicalEditorVersion}
@@ -289,10 +291,12 @@ const RejectContentEditor = ({ user, focusedContent, active, editorContainerRef,
  * Stays mounted while `active` is false so the draft survives the tab
  * being toggled closed and reopened.
  */
-const RejectContentPanel = ({ user, focusedContent, active }: {
+const RejectContentPanel = ({ user, focusedContent, active, onEscape }: {
   user: SunshineUsersList,
   focusedContent: ContentItem,
   active: boolean,
+  // Escape anywhere in the panel closes its tab, as if it were clicked again
+  onEscape: () => void,
 }) => {
   const [templateSearchToken, setTemplateSearchToken] = useState(0);
   const [composerFocusToken, setComposerFocusToken] = useState(0);
@@ -319,6 +323,7 @@ const RejectContentPanel = ({ user, focusedContent, active }: {
       composerFocusToken={composerFocusToken}
       registerToggleTemplate={registerToggleTemplate}
       onArrowDownPastEnd={() => setTemplateSearchToken(token => token + 1)}
+      onEscape={onEscape}
     />
     <GroupedModerationTemplateList
       collectionName="Rejections"
@@ -326,6 +331,7 @@ const RejectContentPanel = ({ user, focusedContent, active }: {
       focusSearchToken={templateSearchToken}
       active={active}
       onFocusComposer={() => setComposerFocusToken(token => token + 1)}
+      onEscape={onEscape}
     />
   </>;
 };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

On `/admin/supermod`, pressing Escape while focused inside the "Send DM" or "Reject" sidebar section now closes that section (`setSidebarTab(null)`), exactly as if its tab had been clicked a second time. Previously Escape only blurred the composer editor (or closed the template search) and left the section open.

## Changes

- `blurEditorOnEscape` now returns whether it handled a bare Escape, so callers can react to it.
- `ComposerKeydownWrapper` takes an optional `onEscape` callback, invoked after the editor is blurred.
- `GroupedModerationTemplateList` takes an optional `onEscape` callback, invoked when Escape is pressed in the template search (in addition to closing the search). This covers the common case where the search is the auto-focused element right after a section is opened.
- `RejectContentPanel` threads a required `onEscape` prop into its composer and template list.
- `SunshineUserMessages` passes a `setSidebarTab(null)` handler into the DM composer, the DM template list, and the reject panel.

Drafts survive as before, since sections stay mounted (just hidden) when toggled closed. The `stopImmediatePropagation` calls in the existing Escape handlers are preserved, so the document-level supermod Escape handler still does not close the whole user detail view in the same keypress.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8315dc70-cec7-4ce6-943c-1829cbf372bf?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8315dc70-cec7-4ce6-943c-1829cbf372bf&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1217397250138346) by [Unito](https://www.unito.io)
