### PR TITLE
Add Purge button to supermod Moderator Actions sidebar

### DIFF
--- a/packages/lesswrong/components/sunshineDashboard/supermod/ModerationActionButtons.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/supermod/ModerationActionButtons.tsx
@@ -50,6 +50,7 @@ const ModerationActionButtons = ({user, currentUser, addToUndoQueue}: {
     handleSnoozeCustom,
     handleRejectContentAndRemove,
     handleRestrictAndNotify,
+    handlePurge,
   } = useModerationUserActions({ selectedUser: user, currentUser, addToUndoQueue });
 
   const moderatorActionRows = [
@@ -93,6 +94,14 @@ const ModerationActionButtons = ({user, currentUser, addToUndoQueue}: {
         keystroke: 'Shift+R',
         tooltip: "Opens the rejection-reason dialog, then a message dialog. Rejects this user's most recent unapproved post or comment, disables their posting, commenting, messaging, and voting, sends them the message as a moderator PM, and removes them from the review queue.",
         onClick: handleRestrictAndNotify,
+      },
+    ],
+    [
+      {
+        label: 'Purge',
+        keystroke: 'P',
+        tooltip: "Deletes all of this user's posts, comments, sequences, and votes, bans them for 1000 years, and removes them from the review queue. Asks for confirmation first, and signs a 'Purge' note in their moderator notes.",
+        onClick: handlePurge,
       },
     ],
   ];

--- a/packages/lesswrong/components/sunshineDashboard/supermod/ModerationUserKeyboardHandler.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/supermod/ModerationUserKeyboardHandler.tsx
@@ -61,6 +61,7 @@ const ModerationUserKeyboardHandler = ({
     handleSnoozeCustom,
     handleRejectContentAndRemove,
     handleRestrictAndNotify,
+    handlePurge,
     updateUserWith,
     getModSignatureWithNote,
     posts,
@@ -113,24 +114,6 @@ const ModerationUserKeyboardHandler = ({
       banned: moment().add(banMonths, 'months').toDate(),
       sunshineNotes: newNotes,
     }, 'Banned 3mo');
-  }, [selectedUser, currentUser, getModSignatureWithNote, updateUserWith]);
-
-  const handlePurge = useCallback(() => {
-    if (!selectedUser) return;
-    if (!confirm("Are you sure you want to delete all this user's posts, comments, sequences, and votes?")) return;
-
-    const notes = selectedUser.sunshineNotes || '';
-    const newNotes = getModSignatureWithNote('Purge') + notes;
-    void updateUserWith({
-      sunshineFlagged: false,
-      reviewedByUserId: currentUser._id,
-      nullifyVotes: true,
-      deleteContent: true,
-      needsReview: false,
-      reviewedAt: new Date(),
-      banned: moment().add(1000, 'years').toDate(),
-      sunshineNotes: newNotes,
-    }, 'Purged');
   }, [selectedUser, currentUser, getModSignatureWithNote, updateUserWith]);
 
   const handleFlag = useCallback(() => {

--- a/packages/lesswrong/components/sunshineDashboard/supermod/useModerationUserActions.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/supermod/useModerationUserActions.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback } from 'react';
+import moment from 'moment';
 import { useDialog } from '@/components/common/withDialog';
 import { useMutation } from '@apollo/client/react';
 import { gql } from '@/lib/generated/gql-codegen';
@@ -148,6 +149,24 @@ export function useModerationUserActions({
     });
   }, [selectedUser, openDialog, handleSnooze]);
 
+  const handlePurge = useCallback(() => {
+    if (!selectedUser) return;
+    if (!confirm("Are you sure you want to delete all this user's posts, comments, sequences, and votes?")) return;
+
+    const notes = selectedUser.sunshineNotes || '';
+    const newNotes = getModSignatureWithNote('Purge') + notes;
+    void updateUserWith({
+      sunshineFlagged: false,
+      reviewedByUserId: currentUser._id,
+      nullifyVotes: true,
+      deleteContent: true,
+      needsReview: false,
+      reviewedAt: new Date(),
+      banned: moment().add(1000, 'years').toDate(),
+      sunshineNotes: newNotes,
+    }, 'Purged');
+  }, [selectedUser, currentUser, getModSignatureWithNote, updateUserWith]);
+
   const handleRestrictAndNotify = useCallback(() => {
     if (!selectedUser) return;
     
@@ -235,6 +254,7 @@ export function useModerationUserActions({
     handleSnoozeCustom,
     handleRejectContentAndRemove,
     handleRestrictAndNotify,
+    handlePurge,
     updateUserWith,
     getModSignatureWithNote,
     posts,


### PR DESCRIPTION
## Summary
- Adds a "Purge [P]" button as its own standalone row in the supermod sidebar's Moderator Actions section, directly beneath the Reject Latest & Remove / Reject, Restrict & Notify row.
- Moves `handlePurge` from `ModerationUserKeyboardHandler` into the shared `useModerationUserActions` hook so the button and the existing `P` keyboard shortcut use the same implementation.

## Test plan
- [ ] Open the supermod inbox detail view and confirm the Purge button appears as its own row under the reject buttons.
- [ ] Confirm clicking it shows the confirmation dialog and the `P` hotkey still works.

Made with [Cursor](https://cursor.com)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1217436755337421) by [Unito](https://www.unito.io)
