### PR TITLE
Collapse supermod Moderator Actions by default

### DIFF
--- a/packages/lesswrong/components/sunshineDashboard/supermod/SupermodModeratorActions.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/supermod/SupermodModeratorActions.tsx
@@ -63,7 +63,7 @@ const SupermodModeratorActions = ({user, currentUser, addToUndoQueue, dispatch}:
   const { moderatorActionsCollapsed, setModeratorActionsCollapsed } = useLocalStorageState(
     'moderatorActionsCollapsed',
     (key) => `supermod_${key}`,
-    'false'
+    'true'
   );
   const isCollapsed = moderatorActionsCollapsed === 'true';
 


### PR DESCRIPTION
## Summary
- Moderator Actions in the supermod sidebar now start collapsed for users who have not saved a collapse preference.
- Existing localStorage preferences are unchanged: users who already expanded or collapsed the section keep that setting.

## Test plan
- [ ] Open supermod in a browser with no `supermod_moderatorActionsCollapsed` localStorage key and confirm Moderator Actions is collapsed
- [ ] Expand the section, refresh, and confirm it stays expanded
- [ ] Collapse it again, refresh, and confirm it stays collapsed


Made with [Cursor](https://cursor.com)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1217448048163159) by [Unito](https://www.unito.io)
