### PR TITLE
Add Shift-P hotkey to toggle all supermod permissions at once

### DIFF
--- a/packages/lesswrong/components/sunshineDashboard/supermod/ModerationActionButtons.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/supermod/ModerationActionButtons.tsx
@@ -128,9 +128,11 @@ const ModerationActionButtons = ({user, currentUser, addToUndoQueue, dispatch}: 
     ],
     [
       {
-        label: 'Enable/Disable Permissions',
+        label: allPermissionsDisabled ? 'Enable Permissions' : 'Disable Permissions',
         keystroke: 'Shift+P',
-        tooltip: "Disable posting, commenting, messaging, and voting. If all four are already disabled, enable them all instead. Signs an 'all permissions disabled/enabled' note in their moderator notes.",
+        tooltip: allPermissionsDisabled
+          ? "Re-enable posting, commenting, messaging, and voting. Signs an 'all permissions enabled' note in their moderator notes."
+          : "Disable posting, commenting, messaging, and voting. Signs an 'all permissions disabled' note in their moderator notes.",
         onClick: toggleAllPermissions,
         active: allPermissionsDisabled,
       },

--- a/packages/lesswrong/components/sunshineDashboard/supermod/ModerationActionButtons.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/supermod/ModerationActionButtons.tsx
@@ -3,6 +3,10 @@ import { defineStyles, useStyles } from '@/components/hooks/useStyles';
 import LWTooltip from '@/components/common/LWTooltip';
 import KeystrokeDisplay from './KeystrokeDisplay';
 import { useModerationUserActions } from './useModerationUserActions';
+import { useUserContentPermissions } from './useUserContentPermissions';
+import type { InboxAction } from './inboxReducer';
+import { areAllContentPermissionsDisabled } from './helpers';
+import classNames from 'classnames';
 
 const styles = defineStyles('ModerationActionButtons', (theme: ThemeType) => ({
   actionsColumn: {
@@ -33,13 +37,22 @@ const styles = defineStyles('ModerationActionButtons', (theme: ThemeType) => ({
       backgroundColor: theme.palette.grey[50],
       borderColor: theme.palette.grey[400],
     },
+    '&.active': {
+      backgroundColor: theme.palette.error.light,
+      borderColor: theme.palette.error.main,
+      color: theme.palette.error.contrastText,
+      '&:hover': {
+        backgroundColor: theme.palette.error.main,
+      },
+    },
   },
 }));
 
-const ModerationActionButtons = ({user, currentUser, addToUndoQueue}: {
+const ModerationActionButtons = ({user, currentUser, addToUndoQueue, dispatch}: {
   user: SunshineUsersList;
   currentUser: UsersCurrent;
   addToUndoQueue: (actionLabel: string, executeAction: () => Promise<void>) => void;
+  dispatch: React.ActionDispatch<[action: InboxAction]>;
 }) => {
   const classes = useStyles(styles);
 
@@ -53,7 +66,16 @@ const ModerationActionButtons = ({user, currentUser, addToUndoQueue}: {
     handlePurge,
   } = useModerationUserActions({ selectedUser: user, currentUser, addToUndoQueue });
 
-  const moderatorActionRows = [
+  const { toggleAllPermissions } = useUserContentPermissions(user, dispatch);
+  const allPermissionsDisabled = areAllContentPermissionsDisabled(user);
+
+  const moderatorActionRows: Array<Array<{
+    label: string;
+    keystroke: string;
+    tooltip: string;
+    onClick: () => void;
+    active?: boolean;
+  }>> = [
     [
       {
         label: 'Approve',
@@ -104,17 +126,26 @@ const ModerationActionButtons = ({user, currentUser, addToUndoQueue}: {
         onClick: handlePurge,
       },
     ],
+    [
+      {
+        label: 'Enable/Disable Permissions',
+        keystroke: 'Shift+P',
+        tooltip: "Disable posting, commenting, messaging, and voting. If all four are already disabled, enable them all instead. Signs an 'all permissions disabled/enabled' note in their moderator notes.",
+        onClick: toggleAllPermissions,
+        active: allPermissionsDisabled,
+      },
+    ],
   ];
 
   return (
     <div className={classes.actionsColumn}>
       {moderatorActionRows.map((row, rowIndex) => (
         <div key={rowIndex} className={classes.actionRow}>
-          {row.map(({label, keystroke, tooltip, onClick}) => (
+          {row.map(({label, keystroke, tooltip, onClick, active}) => (
             <LWTooltip key={label} title={tooltip} placement="left">
-              <div className={classes.actionButton} onClick={onClick}>
+              <div className={classNames(classes.actionButton, active && 'active')} onClick={onClick}>
                 <span>{label}</span>
-                <KeystrokeDisplay keystroke={keystroke} splitBeforeTranslation />
+                <KeystrokeDisplay keystroke={keystroke} splitBeforeTranslation activeContext={!!active} />
               </div>
             </LWTooltip>
           ))}

--- a/packages/lesswrong/components/sunshineDashboard/supermod/ModerationUserKeyboardHandler.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/supermod/ModerationUserKeyboardHandler.tsx
@@ -73,6 +73,7 @@ const ModerationUserKeyboardHandler = ({
     toggleDisableCommenting,
     toggleDisableMessaging,
     toggleDisableVoting,
+    toggleAllPermissions,
   } = useUserContentPermissions(selectedUser, dispatch);
   
   const allContent = useMemo(() => {
@@ -294,6 +295,13 @@ const ModerationUserKeyboardHandler = ({
     execute: toggleDisableVoting,
   }), [isDetailView, selectedUser, toggleDisableVoting]);
 
+  const toggleAllPermissionsCommand: CommandPaletteItem = useMemo(() => ({
+    label: 'Enable/Disable Permissions',
+    keystroke: 'Shift+P',
+    isDisabled: () => !isDetailView || !selectedUser,
+    execute: toggleAllPermissions,
+  }), [isDetailView, selectedUser, toggleAllPermissions]);
+
   const nextContentOrUserCommand: CommandPaletteItem = useMemo(() => ({
     label: isDetailView ? 'Next Content Item' : 'Next User',
     keystroke: 'ArrowDown',
@@ -353,11 +361,11 @@ const ModerationUserKeyboardHandler = ({
     purgeCommand,
     flagCommand,
     copyUserIdCommand,
-    disablePostingCommand, disableCommentingCommand, disableMessagingCommand, disableVotingCommand,
+    disablePostingCommand, disableCommentingCommand, disableMessagingCommand, disableVotingCommand, toggleAllPermissionsCommand,
     nextContentOrUserCommand, previousContentOrUserCommand, nextUserOrTabCommand, previousUserOrTabCommand,
     openOrCloseDetailViewCommand, undoMostRecentActionCommand,
     ban3moCommand,
-  ], [rerunLlmCheckCommand, approveCommand, approveCurrentOnlyCommand, snooze10Command, snoozeCustomCommand, removeCommand, ban3moCommand, purgeCommand, flagCommand, copyUserIdCommand, rejectOrUnrejectCommand, rejectLatestAndRemoveCommand, restrictAndNotifyCommand, disablePostingCommand, disableCommentingCommand, disableMessagingCommand, disableVotingCommand, nextContentOrUserCommand, previousContentOrUserCommand, nextUserOrTabCommand, previousUserOrTabCommand, openOrCloseDetailViewCommand, undoMostRecentActionCommand]);
+  ], [rerunLlmCheckCommand, approveCommand, approveCurrentOnlyCommand, snooze10Command, snoozeCustomCommand, removeCommand, ban3moCommand, purgeCommand, flagCommand, copyUserIdCommand, rejectOrUnrejectCommand, rejectLatestAndRemoveCommand, restrictAndNotifyCommand, disablePostingCommand, disableCommentingCommand, disableMessagingCommand, disableVotingCommand, toggleAllPermissionsCommand, nextContentOrUserCommand, previousContentOrUserCommand, nextUserOrTabCommand, previousUserOrTabCommand, openOrCloseDetailViewCommand, undoMostRecentActionCommand]);
 
   useSupermodKeyboardCommands({
     commands,

--- a/packages/lesswrong/components/sunshineDashboard/supermod/ModerationUserKeyboardHandler.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/supermod/ModerationUserKeyboardHandler.tsx
@@ -6,7 +6,7 @@ import type { InboxAction, UndoHistoryItem } from './inboxReducer';
 import { useUserContentPermissions } from './useUserContentPermissions';
 import { useRejectContent } from '@/components/hooks/useRejectContent';
 import { useModerationUserActions } from './useModerationUserActions';
-import { canRejectContent, ContentItem, isPost } from './helpers';
+import { areAllContentPermissionsDisabled, canRejectContent, ContentItem, isPost } from './helpers';
 import { useMessages } from '@/components/common/withMessages';
 import { useRerunLlmCheck } from './useRerunLlmCheck';
 
@@ -296,7 +296,7 @@ const ModerationUserKeyboardHandler = ({
   }), [isDetailView, selectedUser, toggleDisableVoting]);
 
   const toggleAllPermissionsCommand: CommandPaletteItem = useMemo(() => ({
-    label: 'Enable/Disable Permissions',
+    label: selectedUser && areAllContentPermissionsDisabled(selectedUser) ? 'Enable Permissions' : 'Disable Permissions',
     keystroke: 'Shift+P',
     isDisabled: () => !isDetailView || !selectedUser,
     execute: toggleAllPermissions,

--- a/packages/lesswrong/components/sunshineDashboard/supermod/SupermodModeratorActions.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/supermod/SupermodModeratorActions.tsx
@@ -78,7 +78,7 @@ const SupermodModeratorActions = ({user, currentUser, addToUndoQueue, dispatch}:
         />
       </div>
       {!isCollapsed && <>
-        <ModerationActionButtons user={user} currentUser={currentUser} addToUndoQueue={addToUndoQueue} />
+        <ModerationActionButtons user={user} currentUser={currentUser} addToUndoQueue={addToUndoQueue} dispatch={dispatch} />
         <div className={classes.rateLimitSection}>
           <ModerationPermissionButtons user={user} dispatch={dispatch} />
           <div

--- a/packages/lesswrong/components/sunshineDashboard/supermod/helpers.ts
+++ b/packages/lesswrong/components/sunshineDashboard/supermod/helpers.ts
@@ -1,5 +1,19 @@
 export type ContentItem = SunshinePostsList | SunshineCommentsList;
 
+export function areAllContentPermissionsDisabled(user: {
+  postingDisabled?: boolean | null;
+  allCommentingDisabled?: boolean | null;
+  conversationsDisabled?: boolean | null;
+  votingDisabled?: boolean | null;
+}): boolean {
+  return !!(
+    user.postingDisabled &&
+    user.allCommentingDisabled &&
+    user.conversationsDisabled &&
+    user.votingDisabled
+  );
+}
+
 export function isPost(item: ContentItem): item is SunshinePostsList {
   return 'title' in item && item.title !== null;
 };

--- a/packages/lesswrong/components/sunshineDashboard/supermod/useUserContentPermissions.ts
+++ b/packages/lesswrong/components/sunshineDashboard/supermod/useUserContentPermissions.ts
@@ -7,6 +7,7 @@ import type { InboxAction } from './inboxReducer';
 import { VOTING_DISABLED } from '@/lib/collections/moderatorActions/constants';
 import { useDebouncedCallback } from '@/components/hooks/useDebouncedCallback';
 import type { MutateResult } from '@apollo/client';
+import { areAllContentPermissionsDisabled } from './helpers';
 
 const SunshineUsersListUpdateMutation = gql(`
   mutation updateUserContentPermissions($selector: SelectorInput!, $data: UpdateUserDataInput!) {
@@ -219,11 +220,73 @@ export function useUserContentPermissions(
     }
   }, [user, currentUser, updateModeratorAction, createModeratorAction, updateUser, dispatch]);
 
+  const toggleAllPermissions = useCallback(() => {
+    if (!user || !currentUser) return;
+
+    const disableAll = !areAllContentPermissionsDisabled(user);
+    const abled = disableAll ? 'disabled' : 'enabled';
+    const modDisplayName = currentUser.displayName ?? 'Unknown';
+    const currentNotes = user.sunshineNotes || '';
+    const newNotes = getSignatureWithNote(modDisplayName, `all permissions ${abled}`) + currentNotes;
+
+    dispatch({
+      type: 'UPDATE_USER',
+      userId: user._id,
+      fields: {
+        sunshineNotes: newNotes,
+        postingDisabled: disableAll,
+        allCommentingDisabled: disableAll,
+        conversationsDisabled: disableAll,
+        votingDisabled: disableAll,
+      },
+    });
+
+    void queueMutation(async () => {
+      if (disableAll) {
+        if (!user.votingDisabled) {
+          await createModeratorAction({
+            variables: {
+              data: {
+                userId: user._id,
+                type: VOTING_DISABLED,
+              },
+            },
+          });
+        }
+      } else {
+        const votingDisabledAction = user.moderatorActions?.find(
+          action => action.type === VOTING_DISABLED && !action.endedAt
+        );
+        if (votingDisabledAction) {
+          await updateModeratorAction({
+            variables: {
+              selector: { _id: votingDisabledAction._id },
+              data: { endedAt: new Date() },
+            },
+          });
+        }
+      }
+
+      await updateUser({
+        variables: {
+          selector: { _id: user._id },
+          data: {
+            postingDisabled: disableAll,
+            allCommentingDisabled: disableAll,
+            conversationsDisabled: disableAll,
+            sunshineNotes: newNotes,
+          },
+        },
+      }).then(debouncedSourceOfTruthUpdate);
+    });
+  }, [user, currentUser, dispatch, queueMutation, createModeratorAction, updateModeratorAction, updateUser, debouncedSourceOfTruthUpdate]);
+
   return {
     toggleDisablePosting,
     toggleDisableCommenting,
     toggleDisableMessaging,
     toggleDisableVoting,
+    toggleAllPermissions,
   };
 }
 

--- a/packages/lesswrong/unitTests/supermodContentPermissions.tests.ts
+++ b/packages/lesswrong/unitTests/supermodContentPermissions.tests.ts
@@ -1,0 +1,41 @@
+import { areAllContentPermissionsDisabled } from '@/components/sunshineDashboard/supermod/helpers';
+
+describe('areAllContentPermissionsDisabled', () => {
+  it('returns false when no permissions are disabled', () => {
+    expect(areAllContentPermissionsDisabled({
+      postingDisabled: false,
+      allCommentingDisabled: false,
+      conversationsDisabled: false,
+      votingDisabled: false,
+    })).toBe(false);
+  });
+
+  it('returns false when only some permissions are disabled', () => {
+    expect(areAllContentPermissionsDisabled({
+      postingDisabled: true,
+      allCommentingDisabled: true,
+      conversationsDisabled: false,
+      votingDisabled: true,
+    })).toBe(false);
+  });
+
+  it('returns true when posting, commenting, messaging, and voting are all disabled', () => {
+    expect(areAllContentPermissionsDisabled({
+      postingDisabled: true,
+      allCommentingDisabled: true,
+      conversationsDisabled: true,
+      votingDisabled: true,
+    })).toBe(true);
+  });
+
+  it('treats null/undefined permission flags as not disabled', () => {
+    expect(areAllContentPermissionsDisabled({
+      postingDisabled: true,
+      allCommentingDisabled: true,
+      conversationsDisabled: null,
+      votingDisabled: true,
+    })).toBe(false);
+
+    expect(areAllContentPermissionsDisabled({})).toBe(false);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Adds a `Shift+P` command to the supermod user detail view that disables all four content permissions (posting, commenting, messaging, voting) in one keypress; if all four are already disabled, it re-enables them all instead.
- The command appears in the cmd-K palette and as its own button row in the Moderator Actions sidebar section, with a ⇧P keystroke chip. The label is dynamic: "Disable Permissions" normally, "Enable Permissions" when all four are already disabled. The button (and its keystroke chip) highlights red when all permissions are disabled, matching the Post/Comment/Message/Vote permission boxes.
- Implementation: new `toggleAllPermissions` in `useUserContentPermissions`, which optimistically updates all four fields in the inbox reducer, then (via the existing sequential mutation queue) creates/ends the `VOTING_DISABLED` moderator action and updates the three user booleans in a single `updateUser` mutation. Signs an "all permissions disabled/enabled" note in the moderator notes.
- The all-off/all-on decision uses a new `areAllContentPermissionsDisabled` helper (covered by unit tests in `supermodContentPermissions.tests.ts`).

## Screenshots

Default state — "Disable Permissions" button in the Moderator Actions sidebar:

[Disable Permissions button in Moderator Actions sidebar](https://cursor.com/agents/bc-ee4e95a0-72f5-4ddc-8319-9f3148f0fb45/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshot_disable_permissions_label_default_state.webp)

After pressing Shift+P — all four permission boxes turn red and the button becomes a red "Enable Permissions":

[Enable Permissions button highlighted with all permissions disabled](https://cursor.com/agents/bc-ee4e95a0-72f5-4ddc-8319-9f3148f0fb45/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshot_enable_permissions_label_all_disabled.webp)

The cmd-K palette entry (while all permissions are disabled, it reads "Enable Permissions"):

[Enable Permissions in the command palette](https://cursor.com/agents/bc-ee4e95a0-72f5-4ddc-8319-9f3148f0fb45/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshot_cmdk_enable_permissions_label.webp)

Demo video of the full toggle cycle, including the dynamic label and the palette entry:

[dynamic_enable_disable_permissions_label_demo.mp4](https://cursor.com/agents/bc-ee4e95a0-72f5-4ddc-8319-9f3148f0fb45/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdynamic_enable_disable_permissions_label_demo.mp4)

## Test plan
- [x] `yarn unit` passes for `supermodContentPermissions.tests.ts` and `moderationInboxReducer.tests.ts`
- [x] eslint passes on all touched files; `yarn tsc` reports no new errors (only pre-existing `.next/types/routes` errors also present on master)
- [x] Manually tested against a local Postgres with the E2E dev server: Shift+P disables all four permissions (boxes + button highlight, label flips to "Enable Permissions", mod note signed), second press re-enables and label flips back
- [x] Verified server persistence in the DB after each toggle: the three user booleans flip, and the `VOTING_DISABLED` moderator action is created on disable and ended on re-enable

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ee4e95a0-72f5-4ddc-8319-9f3148f0fb45?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ee4e95a0-72f5-4ddc-8319-9f3148f0fb45&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1217448397030790) by [Unito](https://www.unito.io)
