### PR TITLE
Supermod: put Remove, Purge, and Disable Permissions on one row

### DIFF
--- a/packages/lesswrong/components/sunshineDashboard/supermod/ModerationActionButtons.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/supermod/ModerationActionButtons.tsx
@@ -61,8 +61,7 @@ const ModerationActionButtons = ({user, currentUser, addToUndoQueue, dispatch}: 
     handleApproveCurrentOnly,
     handleSnooze,
     handleSnoozeCustom,
-    handleRejectContentAndRemove,
-    handleRestrictAndNotify,
+    handleRemoveNeedsReview,
     handlePurge,
   } = useModerationUserActions({ selectedUser: user, currentUser, addToUndoQueue });
 
@@ -106,27 +105,17 @@ const ModerationActionButtons = ({user, currentUser, addToUndoQueue, dispatch}: 
     ],
     [
       {
-        label: 'Reject Latest & Remove',
-        keystroke: 'X',
-        tooltip: "Opens the rejection-reason dialog, then rejects this user's most recent unapproved post or comment with that reason, and removes the user from the review queue (without approving them).",
-        onClick: handleRejectContentAndRemove,
+        label: 'Remove',
+        keystroke: 'Q',
+        tooltip: "Remove this user from the review queue without approving them or snoozing. Their content stays unreviewed. Signs a 'removed from review queue without snooze/approval' note in their moderator notes.",
+        onClick: handleRemoveNeedsReview,
       },
-      {
-        label: 'Reject, Restrict & Notify',
-        keystroke: 'Shift+R',
-        tooltip: "Opens the rejection-reason dialog, then a message dialog. Rejects this user's most recent unapproved post or comment, disables their posting, commenting, messaging, and voting, sends them the message as a moderator PM, and removes them from the review queue.",
-        onClick: handleRestrictAndNotify,
-      },
-    ],
-    [
       {
         label: 'Purge',
         keystroke: 'P',
         tooltip: "Deletes all of this user's posts, comments, sequences, and votes, bans them for 1000 years, and removes them from the review queue. Asks for confirmation first, and signs a 'Purge' note in their moderator notes.",
         onClick: handlePurge,
       },
-    ],
-    [
       {
         label: allPermissionsDisabled ? 'Enable Permissions' : 'Disable Permissions',
         keystroke: 'Shift+P',

--- a/packages/lesswrong/components/sunshineDashboard/supermod/ModerationUserKeyboardHandler.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/supermod/ModerationUserKeyboardHandler.tsx
@@ -61,6 +61,7 @@ const ModerationUserKeyboardHandler = ({
     handleSnoozeCustom,
     handleRejectContentAndRemove,
     handleRestrictAndNotify,
+    handleRemoveNeedsReview,
     handlePurge,
     updateUserWith,
     getModSignatureWithNote,
@@ -87,18 +88,6 @@ const ModerationUserKeyboardHandler = ({
   const selectedContentId = selectedContent?._id ?? null;
   const selectedContentCollectionName = selectedContent ? (isPost(selectedContent) ? 'Posts' as const : 'Comments' as const) : 'Posts' as const;
   const { handleRerunLlmCheck, isRunningLlmCheck } = useRerunLlmCheck(selectedContentId, selectedContentCollectionName, dispatch);
-
-  const handleRemoveNeedsReview = useCallback(() => {
-    if (!selectedUser) return;
-    const notes = selectedUser.sunshineNotes || '';
-    const newNotes = getModSignatureWithNote('removed from review queue without snooze/approval') + notes;
-    void updateUserWith({
-      needsReview: false,
-      reviewedByUserId: null,
-      reviewedAt: selectedUser.reviewedAt ? new Date() : null,
-      sunshineNotes: newNotes,
-    }, 'Removed from queue');
-  }, [selectedUser, getModSignatureWithNote, updateUserWith]);
 
   const handleBan = useCallback(() => {
     if (!selectedUser) return;

--- a/packages/lesswrong/components/sunshineDashboard/supermod/useModerationUserActions.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/supermod/useModerationUserActions.tsx
@@ -149,6 +149,18 @@ export function useModerationUserActions({
     });
   }, [selectedUser, openDialog, handleSnooze]);
 
+  const handleRemoveNeedsReview = useCallback(() => {
+    if (!selectedUser) return;
+    const notes = selectedUser.sunshineNotes || '';
+    const newNotes = getModSignatureWithNote('removed from review queue without snooze/approval') + notes;
+    void updateUserWith({
+      needsReview: false,
+      reviewedByUserId: null,
+      reviewedAt: selectedUser.reviewedAt ? new Date() : null,
+      sunshineNotes: newNotes,
+    }, 'Removed from queue');
+  }, [selectedUser, getModSignatureWithNote, updateUserWith]);
+
   const handlePurge = useCallback(() => {
     if (!selectedUser) return;
     if (!confirm("Are you sure you want to delete all this user's posts, comments, sequences, and votes?")) return;
@@ -254,6 +266,7 @@ export function useModerationUserActions({
     handleSnoozeCustom,
     handleRejectContentAndRemove,
     handleRestrictAndNotify,
+    handleRemoveNeedsReview,
     handlePurge,
     updateUserWith,
     getModSignatureWithNote,


### PR DESCRIPTION
## Summary
- Adds **Remove [Q]** to the Moderator Actions sidebar, on the same row as Purge, before Purge.
- Removes the **Reject Latest & Remove** and **Reject, Restrict & Notify** buttons from the sidebar (keyboard shortcuts `X` and `Shift+R` still work).
- Moves **Disable Permissions** onto that same row.

<img src="https://raw.githubusercontent.com/ForumMagnum/ForumMagnum/screenshots/supermod-mod-actions-remove-purge/moderator-actions-buttons.png" width="420" alt="Moderator Actions with Remove, Purge, and Disable Permissions on one row" />

## Test plan
- [ ] Open a user in the supermod inbox detail view and expand Moderator Actions.
- [ ] Confirm the third row is Remove [Q], Purge [P], Disable Permissions [⇧P], with no Reject Latest / Restrict & Notify buttons.
- [ ] Confirm Remove still takes the user out of the queue without approving or snoozing (same as the existing `Q` shortcut).


Made with [Cursor](https://cursor.com)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1217449112450266) by [Unito](https://www.unito.io)
