### PR TITLE
Add 'Open in new tab' item to quick take triple-dot menu

### DIFF
--- a/packages/lesswrong/components/dropdowns/comments/CommentActions.tsx
+++ b/packages/lesswrong/components/dropdowns/comments/CommentActions.tsx
@@ -17,6 +17,7 @@ import PinToProfileDropdownItem from "./PinToProfileDropdownItem";
 import DropdownMenu from "../DropdownMenu";
 import CopyMarkdownDropdownItem from "../CopyMarkdownDropdownItem";
 import ShortformFrontpageDropdownItem from "./ShortformFrontpageDropdownItem";
+import OpenQuickTakeInNewTabDropdownItem from "./OpenQuickTakeInNewTabDropdownItem";
 import { CommentSubscriptionsDropdownItem } from "./CommentSubscriptionsDropdownItem";
 import BanUserFromPostDropdownItem from "./BanUserFromPostDropdownItem";
 import LockThreadDropdownItem from "./LockThreadDropdownItem";
@@ -64,6 +65,7 @@ const CommentActions = ({comment, post, tag, showEdit}: {
       <PinToProfileDropdownItem comment={comment} post={post} />
       <CommentSubscriptionsDropdownItem comment={comment} post={post} />
       {!comment.draft && <BookmarkDropdownItem documentId={comment._id} collectionName="Comments" preventMenuClose />}
+      <OpenQuickTakeInNewTabDropdownItem comment={comment} post={post} />
       <ReportCommentDropdownItem comment={comment} post={post} />
       {comment.postId && <CopyMarkdownDropdownItem path={`/api/post/${comment.postId}/comments/${comment._id}`} />}
       <MoveToAlignmentCommentDropdownItem comment={comment} post={postDetails} />

--- a/packages/lesswrong/components/dropdowns/comments/OpenQuickTakeInNewTabDropdownItem.tsx
+++ b/packages/lesswrong/components/dropdowns/comments/OpenQuickTakeInNewTabDropdownItem.tsx
@@ -1,0 +1,40 @@
+import React, { useCallback } from "react";
+import { commentGetPageUrlFromIds } from "../../../lib/collections/comments/helpers";
+import { useLocation } from "../../../lib/routeUtil";
+import { useTracking } from "../../../lib/analyticsEvents";
+import DropdownItem from "../DropdownItem";
+
+const OpenQuickTakeInNewTabDropdownItem = ({comment, post}: {
+  comment: CommentsList,
+  post?: PostsMinimumInfo,
+}) => {
+  const { captureEvent } = useTracking();
+  const { pathname } = useLocation();
+
+  const handleOpenInNewTab = useCallback(() => {
+    const url = commentGetPageUrlFromIds({
+      postId: comment.postId,
+      postSlug: post?.slug,
+      commentId: comment._id,
+    });
+    captureEvent("openQuickTakeInNewTab", {commentId: comment._id});
+    window.open(url, "_blank", "noopener,noreferrer");
+  }, [comment._id, comment.postId, post?.slug, captureEvent]);
+
+  // Don't show when already viewing the quick take's own post page (e.g. its
+  // permalink), where opening it in a new tab would be redundant.
+  const onOwnPostPage = pathname.startsWith(`/posts/${comment.postId}`);
+  if (!comment.shortform || comment.topLevelCommentId || !comment.postId || comment.draft || onOwnPostPage) {
+    return null;
+  }
+
+  return (
+    <DropdownItem
+      title="Open in new tab"
+      icon="ArrowRight"
+      onClick={handleOpenInNewTab}
+    />
+  );
+};
+
+export default OpenQuickTakeInNewTabDropdownItem;


### PR DESCRIPTION
Adds an "Open in new tab" item to the triple-dot menu on quick takes, which opens the quick take's permalink (`/posts/<postId>/<slug>?commentId=<id>`) in a new tab. Previously the only way to get to an individual quick take from the frontpage was clicking the timestamp.

- Only shown for top-level shortform comments (actual quick takes) — not replies or regular comments.
- Hidden when already viewing the quick take's own post page (e.g. its permalink), where it would be redundant.

Verified in the running app: the item appears between "Save" and "Report" on the frontpage Quick Takes section, opens the correct permalink in a new tab, and is absent from the menu on the permalink page itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1217479171155016) by [Unito](https://www.unito.io)
