### PR TITLE
Fix code paths where posts/comments never get an LLM (Pangram) evaluation

### DIFF
--- a/packages/lesswrong/server/callbacks/postCallbackFunctions.tsx
+++ b/packages/lesswrong/server/callbacks/postCallbackFunctions.tsx
@@ -1148,7 +1148,7 @@ export async function oldPostsLastCommentedAt(post: DbPost, context: ResolverCon
 }
 
 export async function maybeCreateAutomatedContentEvaluation(post: DbPost, oldPost: DbPost | null, context: ResolverContext) {
-  if (shouldPerformAutomatedContentEvaluationOnPost(post, oldPost, context)) {
+  if (shouldPerformAutomatedContentEvaluationOnPost(post, oldPost)) {
     const revision = await getLatestContentsRevision(post, context);
     if (revision) {
       await createAutomatedContentEvaluation(revision, context, { autoreject: true });
@@ -1156,8 +1156,8 @@ export async function maybeCreateAutomatedContentEvaluation(post: DbPost, oldPos
   }
 }
 
-function shouldPerformAutomatedContentEvaluationOnPost(post: DbPost, oldPost: DbPost | null, context: ResolverContext) {
-  // oldPost is null when the post was created already-published
+function shouldPerformAutomatedContentEvaluationOnPost(post: DbPost, oldPost: DbPost | null) {
+  // On create there's no oldPost; "being published" just means the post isn't a draft
   const isBeingPublished = oldPost ? (!post.draft && oldPost.draft) : !post.draft;
   if (!isBeingPublished) return false;
 

--- a/packages/lesswrong/server/callbacks/postCallbackFunctions.tsx
+++ b/packages/lesswrong/server/callbacks/postCallbackFunctions.tsx
@@ -1147,7 +1147,7 @@ export async function oldPostsLastCommentedAt(post: DbPost, context: ResolverCon
   await Posts.rawUpdateOne({ _id: post._id }, {$set: { lastCommentedAt: post.postedAt }})
 }
 
-export async function maybeCreateAutomatedContentEvaluation(post: DbPost, oldPost: DbPost, context: ResolverContext) {
+export async function maybeCreateAutomatedContentEvaluation(post: DbPost, oldPost: DbPost | null, context: ResolverContext) {
   if (shouldPerformAutomatedContentEvaluationOnPost(post, oldPost, context)) {
     const revision = await getLatestContentsRevision(post, context);
     if (revision) {
@@ -1156,9 +1156,11 @@ export async function maybeCreateAutomatedContentEvaluation(post: DbPost, oldPos
   }
 }
 
-function shouldPerformAutomatedContentEvaluationOnPost(post: DbPost, oldPost: DbPost, context: ResolverContext) {
-  //Only when undrafting
-  if (post.draft || !oldPost.draft) return false;
+function shouldPerformAutomatedContentEvaluationOnPost(post: DbPost, oldPost: DbPost | null, context: ResolverContext) {
+  // Only when publishing: undrafting an existing post, or creating a post
+  // that's published from the start (oldPost is null on creation)
+  const isBeingPublished = oldPost ? (!post.draft && oldPost.draft) : !post.draft;
+  if (!isBeingPublished) return false;
 
   // Skip for AF
   if (!isLW()) return false;

--- a/packages/lesswrong/server/callbacks/postCallbackFunctions.tsx
+++ b/packages/lesswrong/server/callbacks/postCallbackFunctions.tsx
@@ -1157,8 +1157,7 @@ export async function maybeCreateAutomatedContentEvaluation(post: DbPost, oldPos
 }
 
 function shouldPerformAutomatedContentEvaluationOnPost(post: DbPost, oldPost: DbPost | null, context: ResolverContext) {
-  // Only when publishing: undrafting an existing post, or creating a post
-  // that's published from the start (oldPost is null on creation)
+  // oldPost is null when the post was created already-published
   const isBeingPublished = oldPost ? (!post.draft && oldPost.draft) : !post.draft;
   if (!isBeingPublished) return false;
 

--- a/packages/lesswrong/server/collections/automatedContentEvaluations/helpers.ts
+++ b/packages/lesswrong/server/collections/automatedContentEvaluations/helpers.ts
@@ -11,6 +11,7 @@ import { getAdminTeamAccount } from "@/server/utils/adminTeamAccount";
 import { computeContextFromUser } from "@/server/vulcan-lib/apollo-server/context";
 import { stripExcludedContentForAIDetection } from "./preprocessing";
 import { PANGRAM_AUTOREJECT_THRESHOLD } from "@/lib/collections/automatedContentEvaluations/constants";
+import { sleep } from "@/lib/utils/asyncUtils";
 
 const saplingResponseSchema = z.object({
   score: z.number(),
@@ -58,6 +59,38 @@ export interface PangramEvaluationResult {
   }[] | null;
 }
 
+// Transient Pangram failures (timeouts, 5xxs) used to permanently leave content
+// without an evaluation, so retry a couple of times before giving up.
+const PANGRAM_RETRY_DELAYS_MS = [1000, 4000];
+
+async function fetchPangramWithRetries(key: string, textToCheck: string): Promise<Response> {
+  let lastError: Error | null = null;
+  for (let attempt = 0; attempt <= PANGRAM_RETRY_DELAYS_MS.length; attempt++) {
+    if (attempt > 0) {
+      await sleep(PANGRAM_RETRY_DELAYS_MS[attempt - 1]);
+    }
+    try {
+      const response = await fetch('https://text.api.pangram.com/v3', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-api-key': key,
+        },
+        body: JSON.stringify({ text: textToCheck }),
+      });
+      if (response.status >= 500) {
+        const errorText = await response.text().catch(() => 'Unable to read error response');
+        lastError = new Error(`Pangram API request failed with status ${response.status}: ${errorText}`);
+        continue;
+      }
+      return response;
+    } catch (e) {
+      lastError = e instanceof Error ? e : new Error(`Pangram API request failed: ${e}`);
+    }
+  }
+  throw lastError ?? new Error("Pangram API request failed");
+}
+
 export async function getPangramEvaluationForText(text: string): Promise<PangramEvaluationResult> {
   const key = process.env.PANGRAM_API_KEY;
   if (!key) {
@@ -68,14 +101,7 @@ export async function getPangramEvaluationForText(text: string): Promise<Pangram
   // an entire long post in one go isn't usually worth the extra $$$.
   const textToCheck = text.slice(0, 30_000);
 
-  const response = await fetch('https://text.api.pangram.com/v3', {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      'x-api-key': key,
-    },
-    body: JSON.stringify({ text: textToCheck }),
-  });
+  const response = await fetchPangramWithRetries(key, textToCheck);
 
   if (!response.ok) {
     const errorText = await response.text().catch(() => 'Unable to read error response');
@@ -230,6 +256,18 @@ interface CreateAutomatedContentEvaluationOptions {
   autoreject?: boolean;
 }
 
+async function parentDocumentIsDraft(collectionName: DbRevision['collectionName'], documentId: string): Promise<boolean> {
+  if (collectionName === "Posts") {
+    const post = await Posts.findOne({ _id: documentId });
+    return !post || !!post.draft;
+  }
+  if (collectionName === "Comments") {
+    const comment = await Comments.findOne({ _id: documentId });
+    return !comment || !!comment.draft;
+  }
+  return true;
+}
+
 export async function createAutomatedContentEvaluation(
   revision: DbRevision,
   context: ResolverContext,
@@ -237,10 +275,17 @@ export async function createAutomatedContentEvaluation(
 ) {
   const { autoreject } = options;
 
-  // we shouldn't be ending up running this on revisions where draft is true (which is for autosaves) but if we did we'd want to return early.
-  if (revision.draft) return;
   const documentId = revision.documentId;
   if (!documentId) return;
+
+  // Revisions with draft=true are usually autosaves, which we don't want to evaluate.
+  // But a document that gets published without a simultaneous content edit (e.g. a
+  // collaborative-editing post, or a publish from outside the editor form) keeps
+  // pointing at its last draft revision: no new revision is created, and the
+  // revision's own draft flag is only cleared later (via ensurePostHasNonDraftContents),
+  // if ever. So before skipping, check whether the parent document itself is still a
+  // draft; if it's published, evaluate the revision even though it's flagged as draft.
+  if (revision.draft && await parentDocumentIsDraft(revision.collectionName, documentId)) return;
 
   const pangramEvaluation = await getPangramEvaluation(revision).catch((err) => {
     // eslint-disable-next-line no-console

--- a/packages/lesswrong/server/collections/automatedContentEvaluations/helpers.ts
+++ b/packages/lesswrong/server/collections/automatedContentEvaluations/helpers.ts
@@ -59,7 +59,7 @@ export interface PangramEvaluationResult {
   }[] | null;
 }
 
-// There's no backfill sweep, so one transient failure permanently skips the content
+// The publish-time pipeline has no later retry, so ride out transient failures here
 const PANGRAM_RETRY_DELAYS_MS = [1000, 4000];
 
 async function fetchPangramWithRetries(key: string, textToCheck: string): Promise<Response> {
@@ -77,6 +77,7 @@ async function fetchPangramWithRetries(key: string, textToCheck: string): Promis
         },
         body: JSON.stringify({ text: textToCheck }),
       });
+      // Retry 5xx and network errors; 4xx returns for the normal !response.ok handling
       if (response.status >= 500) {
         const errorText = await response.text().catch(() => 'Unable to read error response');
         lastError = new Error(`Pangram API request failed with status ${response.status}: ${errorText}`);
@@ -87,7 +88,9 @@ async function fetchPangramWithRetries(key: string, textToCheck: string): Promis
       lastError = e instanceof Error ? e : new Error(`Pangram API request failed: ${e}`);
     }
   }
-  throw lastError ?? new Error("Pangram API request failed");
+  const finalError = lastError ?? new Error("Pangram API request failed");
+  captureException(finalError);
+  throw finalError;
 }
 
 export async function getPangramEvaluationForText(text: string): Promise<PangramEvaluationResult> {
@@ -256,7 +259,8 @@ interface CreateAutomatedContentEvaluationOptions {
 }
 
 async function parentDocumentIsDraft(collectionName: DbRevision['collectionName'], documentId: string): Promise<boolean> {
-  // Fresh findOne (not loaders): the caller may have flipped draft this same request
+  // Fresh findOne (not loaders): the caller may have flipped draft this same request,
+  // and the moderation resolvers only hold a revision. Missing docs count as draft.
   if (collectionName === "Posts") {
     const post = await Posts.findOne({ _id: documentId });
     return !post || !!post.draft;
@@ -280,8 +284,9 @@ export async function createAutomatedContentEvaluation(
   if (!documentId) return;
 
   // Draft revisions are usually autosaves, which we don't evaluate. But publishing
-  // without a body edit creates no new revision, so a published document can still
-  // point at a draft-flagged revision — trust the document's draft state instead.
+  // without a body edit creates no new revision, and ensurePostHasNonDraftContents
+  // (which clears the stale flag) is skipped for unreviewed authors — so trust the
+  // document's own draft state rather than the revision's.
   if (revision.draft && await parentDocumentIsDraft(revision.collectionName, documentId)) return;
 
   const pangramEvaluation = await getPangramEvaluation(revision).catch((err) => {

--- a/packages/lesswrong/server/collections/automatedContentEvaluations/helpers.ts
+++ b/packages/lesswrong/server/collections/automatedContentEvaluations/helpers.ts
@@ -59,8 +59,7 @@ export interface PangramEvaluationResult {
   }[] | null;
 }
 
-// Transient Pangram failures (timeouts, 5xxs) used to permanently leave content
-// without an evaluation, so retry a couple of times before giving up.
+// There's no backfill sweep, so one transient failure permanently skips the content
 const PANGRAM_RETRY_DELAYS_MS = [1000, 4000];
 
 async function fetchPangramWithRetries(key: string, textToCheck: string): Promise<Response> {
@@ -257,6 +256,7 @@ interface CreateAutomatedContentEvaluationOptions {
 }
 
 async function parentDocumentIsDraft(collectionName: DbRevision['collectionName'], documentId: string): Promise<boolean> {
+  // Fresh findOne (not loaders): the caller may have flipped draft this same request
   if (collectionName === "Posts") {
     const post = await Posts.findOne({ _id: documentId });
     return !post || !!post.draft;
@@ -265,6 +265,7 @@ async function parentDocumentIsDraft(collectionName: DbRevision['collectionName'
     const comment = await Comments.findOne({ _id: documentId });
     return !comment || !!comment.draft;
   }
+  // Fail closed: revisions of other collections keep the old always-skip behavior
   return true;
 }
 
@@ -278,13 +279,9 @@ export async function createAutomatedContentEvaluation(
   const documentId = revision.documentId;
   if (!documentId) return;
 
-  // Revisions with draft=true are usually autosaves, which we don't want to evaluate.
-  // But a document that gets published without a simultaneous content edit (e.g. a
-  // collaborative-editing post, or a publish from outside the editor form) keeps
-  // pointing at its last draft revision: no new revision is created, and the
-  // revision's own draft flag is only cleared later (via ensurePostHasNonDraftContents),
-  // if ever. So before skipping, check whether the parent document itself is still a
-  // draft; if it's published, evaluate the revision even though it's flagged as draft.
+  // Draft revisions are usually autosaves, which we don't evaluate. But publishing
+  // without a body edit creates no new revision, so a published document can still
+  // point at a draft-flagged revision — trust the document's draft state instead.
   if (revision.draft && await parentDocumentIsDraft(revision.collectionName, documentId)) return;
 
   const pangramEvaluation = await getPangramEvaluation(revision).catch((err) => {

--- a/packages/lesswrong/server/collections/posts/mutations.ts
+++ b/packages/lesswrong/server/collections/posts/mutations.ts
@@ -204,6 +204,8 @@ export async function createPost({ data }: { data: CreatePostDataInput & { _id?:
     props: asyncProperties,
   });
 
+  backgroundTask(maybeCreateAutomatedContentEvaluation(documentWithId, null, context));
+
   return documentWithId;
 }
 


### PR DESCRIPTION
## Why many posts/comments never got LLM graded

Three separate gaps meant content could silently end up with no `AutomatedContentEvaluation`:

1. **Publish-without-edit was silently skipped.** `createAutomatedContentEvaluation` returned early on any revision with `draft: true` (intended to skip autosaves). But when a document is published without a simultaneous content edit — collaborative-editing posts, publishes from outside the editor form, undrafted draft comments — no new revision is created, so `contents_latest` still points at the last draft revision. The only thing that clears that revision's `draft` flag is `ensurePostHasNonDraftContents` inside `onPostPublished`, and `updatedPostMaybeTriggerReview` doesn't call `onPostPublished` while `authorIsUnreviewed` is true — which is exactly the population the supermod inbox looks at. Fix: before skipping a draft revision, check whether the parent post/comment is itself still a draft; if it's published, evaluate anyway.

2. **Posts created directly as published were never evaluated.** The evaluation hook only existed on `updatePost`'s draft→published transition; `createPost` had no hook at all, so posts created with `draft: false` from the start (API clients, imports) got no evaluation. `createPost` now triggers the same evaluation (`maybeCreateAutomatedContentEvaluation` accepts `oldPost: null` for creation, mirroring the comment-side callback).

3. **Transient Pangram API failures were permanent.** A timeout/network error/5xx during the background evaluation was caught, logged to Sentry, and the content simply never got a record (no retry anywhere). The Pangram request is now retried twice with backoff (1s, 4s) on network errors and 5xx responses before giving up. 4xx responses still fail immediately.

Not changed (deliberate, per existing code comments): comments by already-reviewed users are still skipped, and Alignment Forum content is still skipped.

## Testing

- `yarn tsc` — no errors in changed files (pre-existing errors in `fly/` and missing `.next` generated types are unrelated to this change).

---
_Generated by [Claude Code](https://claude.ai/code/session_01W8P5eYiVAivscDwTXtsJzy)_

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1217492355312989) by [Unito](https://www.unito.io)
