### PR TITLE
Auto-rescore posts missing an LLM score in the supermod user detail view

### DIFF
--- a/packages/lesswrong/components/sunshineDashboard/supermod/ModerationUserDetailView.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/supermod/ModerationUserDetailView.tsx
@@ -8,6 +8,7 @@ import ModerationUndoHistory from './ModerationUndoHistory';
 import ModerationUserInfoColumn from './ModerationUserInfoColumn';
 import { prettyScrollbars } from '@/themes/styleUtils';
 import type { SelectedSidebarTab } from './sidebarTabs';
+import { useAutoRescoreMissingLlmScores } from './useRerunLlmCheck';
 
 const styles = defineStyles('ModerationUserDetailView', (theme: ThemeType) => ({
   root: {
@@ -69,6 +70,10 @@ const ModerationUserDetailView = ({
   currentUser: UsersCurrent;
 }) => {
   const classes = useStyles(styles);
+
+  // Posts that never got an LLM score (failed or skipped evaluation at publish
+  // time) get rescored automatically when they show up in this view
+  useAutoRescoreMissingLlmScores(posts, dispatch);
 
   const setSidebarTab = useCallback(
     (tab: SelectedSidebarTab) => dispatch({ type: 'SET_SIDEBAR_TAB', tab }),

--- a/packages/lesswrong/components/sunshineDashboard/supermod/ModerationUserDetailView.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/supermod/ModerationUserDetailView.tsx
@@ -71,8 +71,6 @@ const ModerationUserDetailView = ({
 }) => {
   const classes = useStyles(styles);
 
-  // Posts that never got an LLM score (failed or skipped evaluation at publish
-  // time) get rescored automatically when they show up in this view
   useAutoRescoreMissingLlmScores(posts, dispatch);
 
   const setSidebarTab = useCallback(

--- a/packages/lesswrong/components/sunshineDashboard/supermod/useRerunLlmCheck.ts
+++ b/packages/lesswrong/components/sunshineDashboard/supermod/useRerunLlmCheck.ts
@@ -69,8 +69,9 @@ export function useRerunLlmCheck(
   };
 }
 
-// Drafts get scored when published; scoring one now could capture a stale autosave.
-// Rejected posts are included: highlight rules read scores on rejected content too.
+// Drafts are excluded: rerunLlmCheck follows contents_latest blindly, so it would
+// score an in-progress autosave that the publish-time pipeline deliberately skips.
+// Rejected posts are included: templateHighlightRules reads their scores too.
 function postNeedsLlmRescore(post: SunshinePostsList): boolean {
   return !post.draft && post.automatedContentEvaluations?.pangramScore == null;
 }
@@ -82,8 +83,10 @@ function findNextPostToRescore(posts: SunshinePostsList[], attemptedPostIds: Set
 /**
  * Backfills missing Pangram scores for posts shown in the user detail view, via
  * the same mutation as the manual "LLM" button (which records scores, never
- * autorejects). Sequential, to avoid bursts against the paid Pangram API. Each
- * post is attempted once per mount; the manual button remains the fallback.
+ * autorejects). Sequential, to bound spend against the paid Pangram API: at most
+ * the ~20 posts the view fetches, each attempted once per mount, with the manual
+ * button as the fallback. Not coordinated with the manual button — a concurrent
+ * manual rerun just wastes one duplicate check.
  */
 export function useAutoRescoreMissingLlmScores(
   posts: SunshinePostsList[],
@@ -96,6 +99,15 @@ export function useAutoRescoreMissingLlmScores(
   // user switch) aren't dropped — the effect can't re-fire while the loop is going
   const latestPostsRef = useRef(posts);
   latestPostsRef.current = posts;
+  // Unmount-only cancellation: the work-starting effect below re-runs whenever
+  // posts change, so its own cleanup must not cancel the in-flight loop
+  const unmountedRef = useRef(false);
+  useEffect(() => {
+    unmountedRef.current = false;
+    return () => {
+      unmountedRef.current = true;
+    };
+  }, []);
 
   useEffect(() => {
     if (isRescoringRef.current || !findNextPostToRescore(posts, attemptedPostIdsRef.current)) {
@@ -104,7 +116,7 @@ export function useAutoRescoreMissingLlmScores(
     isRescoringRef.current = true;
 
     void (async () => {
-      for (;;) {
+      while (!unmountedRef.current) {
         const post = findNextPostToRescore(latestPostsRef.current, attemptedPostIdsRef.current);
         if (!post) break;
         const postId = post._id;
@@ -125,7 +137,8 @@ export function useAutoRescoreMissingLlmScores(
           });
           const newAce = result.data?.rerunLlmCheck;
           if (newAce) {
-            // The inbox tabs render reducer-owned copies of posts; keep those in sync
+            // This view's list updates via the cache write above; the inbox tabs
+            // render reducer-owned copies of posts, so sync those too
             dispatch({
               type: 'UPDATE_POST',
               postId,
@@ -133,11 +146,14 @@ export function useAutoRescoreMissingLlmScores(
             });
           }
         } catch {
-          // Silent: no toast spam from a background backfill; manual button remains
+          // Silent: a background backfill shouldn't toast per failure
         }
       }
-      dispatch({ type: 'SET_LLM_CHECK_RUNNING', documentId: null });
       isRescoringRef.current = false;
+      // After unmount a newer view's loop may own the shared spinner slot
+      if (!unmountedRef.current) {
+        dispatch({ type: 'SET_LLM_CHECK_RUNNING', documentId: null });
+      }
     })();
   }, [posts, dispatch, rerunLlmCheck]);
 }

--- a/packages/lesswrong/components/sunshineDashboard/supermod/useRerunLlmCheck.ts
+++ b/packages/lesswrong/components/sunshineDashboard/supermod/useRerunLlmCheck.ts
@@ -69,20 +69,21 @@ export function useRerunLlmCheck(
   };
 }
 
-// Drafts are deliberately excluded: the evaluation pipeline scores content on
-// publish, and scoring an unpublished draft would just produce a stale result.
+// Drafts get scored when published; scoring one now could capture a stale autosave.
+// Rejected posts are included: highlight rules read scores on rejected content too.
 function postNeedsLlmRescore(post: SunshinePostsList): boolean {
   return !post.draft && post.automatedContentEvaluations?.pangramScore == null;
 }
 
+function findNextPostToRescore(posts: SunshinePostsList[], attemptedPostIds: Set<string>): SunshinePostsList | undefined {
+  return posts.find((post) => postNeedsLlmRescore(post) && !attemptedPostIds.has(post._id));
+}
+
 /**
- * When the moderation user-detail view shows posts that never got an LLM
- * (Pangram) score — because the evaluation failed or was skipped at publish
- * time — automatically rescore them, one at a time, instead of waiting for a
- * moderator to click the manual "LLM" rerun button on each item.
- *
- * Failures are silent (each item is only attempted once per mount) and leave
- * the manual rerun button in place as the fallback.
+ * Backfills missing Pangram scores for posts shown in the user detail view, via
+ * the same mutation as the manual "LLM" button (which records scores, never
+ * autorejects). Sequential, to avoid bursts against the paid Pangram API. Each
+ * post is attempted once per mount; the manual button remains the fallback.
  */
 export function useAutoRescoreMissingLlmScores(
   posts: SunshinePostsList[],
@@ -91,28 +92,31 @@ export function useAutoRescoreMissingLlmScores(
   const [rerunLlmCheck] = useMutation(RerunLlmCheckMutation);
   const attemptedPostIdsRef = useRef<Set<string>>(new Set());
   const isRescoringRef = useRef(false);
+  // The drain loop reads the latest posts, so ones arriving mid-run (e.g. after a
+  // user switch) aren't dropped — the effect can't re-fire while the loop is going
+  const latestPostsRef = useRef(posts);
+  latestPostsRef.current = posts;
 
   useEffect(() => {
-    const postsToRescore = posts.filter(
-      (post) => postNeedsLlmRescore(post) && !attemptedPostIdsRef.current.has(post._id)
-    );
-    if (isRescoringRef.current || !postsToRescore.length) return;
-
-    isRescoringRef.current = true;
-    for (const post of postsToRescore) {
-      attemptedPostIdsRef.current.add(post._id);
+    if (isRescoringRef.current || !findNextPostToRescore(posts, attemptedPostIdsRef.current)) {
+      return;
     }
+    isRescoringRef.current = true;
 
     void (async () => {
-      for (const post of postsToRescore) {
-        dispatch({ type: 'SET_LLM_CHECK_RUNNING', documentId: post._id });
+      for (;;) {
+        const post = findNextPostToRescore(latestPostsRef.current, attemptedPostIdsRef.current);
+        if (!post) break;
+        const postId = post._id;
+        attemptedPostIdsRef.current.add(postId);
+        dispatch({ type: 'SET_LLM_CHECK_RUNNING', documentId: postId });
         try {
           const result = await rerunLlmCheck({
-            variables: { documentId: post._id, collectionName: 'Posts' },
+            variables: { documentId: postId, collectionName: 'Posts' },
             update: (cache, { data }) => {
               if (!data?.rerunLlmCheck) return;
               cache.modify({
-                id: cache.identify({ __typename: 'Post', _id: post._id }),
+                id: cache.identify({ __typename: 'Post', _id: postId }),
                 fields: {
                   automatedContentEvaluations: () => data.rerunLlmCheck,
                 },
@@ -121,17 +125,17 @@ export function useAutoRescoreMissingLlmScores(
           });
           const newAce = result.data?.rerunLlmCheck;
           if (newAce) {
+            // The inbox tabs render reducer-owned copies of posts; keep those in sync
             dispatch({
               type: 'UPDATE_POST',
-              postId: post._id,
+              postId,
               fields: { automatedContentEvaluations: newAce },
             });
           }
         } catch {
-          // Best-effort: the manual rerun button remains as the fallback
+          // Silent: no toast spam from a background backfill; manual button remains
         }
       }
-      // Also re-triggers this effect, picking up any posts that appeared mid-run
       dispatch({ type: 'SET_LLM_CHECK_RUNNING', documentId: null });
       isRescoringRef.current = false;
     })();

--- a/packages/lesswrong/components/sunshineDashboard/supermod/useRerunLlmCheck.ts
+++ b/packages/lesswrong/components/sunshineDashboard/supermod/useRerunLlmCheck.ts
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import { useMutation } from '@apollo/client/react';
 import { gql } from '@/lib/generated/gql-codegen';
 import { useMessages } from '@/components/common/withMessages';
@@ -67,4 +67,73 @@ export function useRerunLlmCheck(
     handleRerunLlmCheck,
     isRunningLlmCheck: loading,
   };
+}
+
+// Drafts are deliberately excluded: the evaluation pipeline scores content on
+// publish, and scoring an unpublished draft would just produce a stale result.
+function postNeedsLlmRescore(post: SunshinePostsList): boolean {
+  return !post.draft && post.automatedContentEvaluations?.pangramScore == null;
+}
+
+/**
+ * When the moderation user-detail view shows posts that never got an LLM
+ * (Pangram) score — because the evaluation failed or was skipped at publish
+ * time — automatically rescore them, one at a time, instead of waiting for a
+ * moderator to click the manual "LLM" rerun button on each item.
+ *
+ * Failures are silent (each item is only attempted once per mount) and leave
+ * the manual rerun button in place as the fallback.
+ */
+export function useAutoRescoreMissingLlmScores(
+  posts: SunshinePostsList[],
+  dispatch: React.Dispatch<InboxAction>
+) {
+  const [rerunLlmCheck] = useMutation(RerunLlmCheckMutation);
+  const attemptedPostIdsRef = useRef<Set<string>>(new Set());
+  const isRescoringRef = useRef(false);
+
+  useEffect(() => {
+    const postsToRescore = posts.filter(
+      (post) => postNeedsLlmRescore(post) && !attemptedPostIdsRef.current.has(post._id)
+    );
+    if (isRescoringRef.current || !postsToRescore.length) return;
+
+    isRescoringRef.current = true;
+    for (const post of postsToRescore) {
+      attemptedPostIdsRef.current.add(post._id);
+    }
+
+    void (async () => {
+      for (const post of postsToRescore) {
+        dispatch({ type: 'SET_LLM_CHECK_RUNNING', documentId: post._id });
+        try {
+          const result = await rerunLlmCheck({
+            variables: { documentId: post._id, collectionName: 'Posts' },
+            update: (cache, { data }) => {
+              if (!data?.rerunLlmCheck) return;
+              cache.modify({
+                id: cache.identify({ __typename: 'Post', _id: post._id }),
+                fields: {
+                  automatedContentEvaluations: () => data.rerunLlmCheck,
+                },
+              });
+            },
+          });
+          const newAce = result.data?.rerunLlmCheck;
+          if (newAce) {
+            dispatch({
+              type: 'UPDATE_POST',
+              postId: post._id,
+              fields: { automatedContentEvaluations: newAce },
+            });
+          }
+        } catch {
+          // Best-effort: the manual rerun button remains as the fallback
+        }
+      }
+      // Also re-triggers this effect, picking up any posts that appeared mid-run
+      dispatch({ type: 'SET_LLM_CHECK_RUNNING', documentId: null });
+      isRescoringRef.current = false;
+    })();
+  }, [posts, dispatch, rerunLlmCheck]);
 }

--- a/packages/lesswrong/components/sunshineDashboard/supermod/useRerunLlmCheck.ts
+++ b/packages/lesswrong/components/sunshineDashboard/supermod/useRerunLlmCheck.ts
@@ -83,10 +83,10 @@ function findNextPostToRescore(posts: SunshinePostsList[], attemptedPostIds: Set
 /**
  * Backfills missing Pangram scores for posts shown in the user detail view, via
  * the same mutation as the manual "LLM" button (which records scores, never
- * autorejects). Sequential, to bound spend against the paid Pangram API: at most
- * the ~20 posts the view fetches, each attempted once per mount, with the manual
- * button as the fallback. Not coordinated with the manual button — a concurrent
- * manual rerun just wastes one duplicate check.
+ * autorejects). Sequential, to pace spend on the paid Pangram API: each post is
+ * attempted at most once per mount (the view fetches ~20 posts per viewed user),
+ * with the manual button as the fallback. Not coordinated with the manual button
+ * — a concurrent manual rerun just wastes one duplicate check.
  */
 export function useAutoRescoreMissingLlmScores(
   posts: SunshinePostsList[],
@@ -96,63 +96,68 @@ export function useAutoRescoreMissingLlmScores(
   const attemptedPostIdsRef = useRef<Set<string>>(new Set());
   const isRescoringRef = useRef(false);
   // The drain loop reads the latest posts, so ones arriving mid-run (e.g. after a
-  // user switch) aren't dropped — the effect can't re-fire while the loop is going
+  // user switch) aren't dropped; effect re-runs during a drain bail on the latch
   const latestPostsRef = useRef(posts);
-  latestPostsRef.current = posts;
-  // Unmount-only cancellation: the work-starting effect below re-runs whenever
-  // posts change, so its own cleanup must not cancel the in-flight loop
+  // Unmount-only cancellation: the work effect re-runs whenever posts change, so
+  // it deliberately has no cleanup; re-setting false covers StrictMode remounts
   const unmountedRef = useRef(false);
   useEffect(() => {
     unmountedRef.current = false;
     return () => {
       unmountedRef.current = true;
+      // Free the shared spinner slot; a successor view's effects run after this
+      dispatch({ type: 'SET_LLM_CHECK_RUNNING', documentId: null });
     };
-  }, []);
+  }, [dispatch]);
 
   useEffect(() => {
+    latestPostsRef.current = posts;
     if (isRescoringRef.current || !findNextPostToRescore(posts, attemptedPostIdsRef.current)) {
       return;
     }
     isRescoringRef.current = true;
 
     void (async () => {
-      while (!unmountedRef.current) {
-        const post = findNextPostToRescore(latestPostsRef.current, attemptedPostIdsRef.current);
-        if (!post) break;
-        const postId = post._id;
-        attemptedPostIdsRef.current.add(postId);
-        dispatch({ type: 'SET_LLM_CHECK_RUNNING', documentId: postId });
-        try {
-          const result = await rerunLlmCheck({
-            variables: { documentId: postId, collectionName: 'Posts' },
-            update: (cache, { data }) => {
-              if (!data?.rerunLlmCheck) return;
-              cache.modify({
-                id: cache.identify({ __typename: 'Post', _id: postId }),
-                fields: {
-                  automatedContentEvaluations: () => data.rerunLlmCheck,
-                },
-              });
-            },
-          });
-          const newAce = result.data?.rerunLlmCheck;
-          if (newAce) {
-            // This view's list updates via the cache write above; the inbox tabs
-            // render reducer-owned copies of posts, so sync those too
-            dispatch({
-              type: 'UPDATE_POST',
-              postId,
-              fields: { automatedContentEvaluations: newAce },
+      try {
+        while (!unmountedRef.current) {
+          const post = findNextPostToRescore(latestPostsRef.current, attemptedPostIdsRef.current);
+          if (!post) break;
+          const postId = post._id;
+          attemptedPostIdsRef.current.add(postId);
+          dispatch({ type: 'SET_LLM_CHECK_RUNNING', documentId: postId });
+          try {
+            const result = await rerunLlmCheck({
+              variables: { documentId: postId, collectionName: 'Posts' },
+              update: (cache, { data }) => {
+                if (!data?.rerunLlmCheck) return;
+                cache.modify({
+                  id: cache.identify({ __typename: 'Post', _id: postId }),
+                  fields: {
+                    automatedContentEvaluations: () => data.rerunLlmCheck,
+                  },
+                });
+              },
             });
+            const newAce = result.data?.rerunLlmCheck;
+            if (newAce) {
+              // This view's list updates via the cache write above; the inbox tabs
+              // render reducer-owned copies of posts, so sync those too
+              dispatch({
+                type: 'UPDATE_POST',
+                postId,
+                fields: { automatedContentEvaluations: newAce },
+              });
+            }
+          } catch {
+            // Silent: a background backfill shouldn't toast per failure
           }
-        } catch {
-          // Silent: a background backfill shouldn't toast per failure
         }
-      }
-      isRescoringRef.current = false;
-      // After unmount a newer view's loop may own the shared spinner slot
-      if (!unmountedRef.current) {
-        dispatch({ type: 'SET_LLM_CHECK_RUNNING', documentId: null });
+      } finally {
+        isRescoringRef.current = false;
+        // After unmount the cleanup above already freed the shared spinner slot
+        if (!unmountedRef.current) {
+          dispatch({ type: 'SET_LLM_CHECK_RUNNING', documentId: null });
+        }
       }
     })();
   }, [posts, dispatch, rerunLlmCheck]);


### PR DESCRIPTION
When the supermod user detail view shows posts that never got a Pangram evaluation (background check failed or was skipped at publish time), it now automatically runs the same `rerunLlmCheck` mutation the manual "LLM" button uses, instead of waiting for a moderator to click it on each item.

Details:
- New `useAutoRescoreMissingLlmScores(posts, dispatch)` hook in `useRerunLlmCheck.ts`, called from `ModerationUserDetailView`.
- Posts are rescored **sequentially** (no parallel Pangram bursts), with the existing per-item "Checking…" spinner shown via `SET_LLM_CHECK_RUNNING`.
- Each post is only attempted **once per mount** — failures are silent and leave the manual "LLM" rerun button in place as the fallback, so a flaky Pangram API can't cause a retry loop.
- **Drafts are excluded**: evaluation happens at publish time, and scoring an unpublished draft would just produce a result that goes stale on publish.
- Comments are not auto-rescored (the request was scoped to posts; comments keep the manual rerun button). Happy to extend it if wanted.

Companion to #12770, which fixes the code paths that caused evaluations to go missing in the first place.

## Testing

- `yarn tsc` — no errors in changed files.

---
_Generated by [Claude Code](https://claude.ai/code/session_01W8P5eYiVAivscDwTXtsJzy)_

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1217487694914087) by [Unito](https://www.unito.io)
