### PR TITLE
Hide intercom and LLM chat buttons on supermod page

### DIFF
--- a/packages/lesswrong/components/layout/Layout.tsx
+++ b/packages/lesswrong/components/layout/Layout.tsx
@@ -164,6 +164,9 @@ const styles = defineStyles("Layout", (theme: ThemeType) => ({
   },
 }));
 
+const isPathnameWithHiddenFloatingButtons = (pathname: string) =>
+  pathname.startsWith('/inbox') || pathname.startsWith('/research') || pathname.startsWith('/admin/supermod');
+
 const Layout = ({children}: {
   children?: React.ReactNode,
 }) => {
@@ -183,7 +186,7 @@ const Layout = ({children}: {
 
   // (isLW()) && isHomeRoute(prerenderablePathname) && (!currentUser?.hideFrontpageMap) && !cookies[HIDE_MAP_COOKIE]
   
-  const hideIntercom = prerenderablePathname.startsWith('/inbox') || prerenderablePathname.startsWith('/research');
+  const hideIntercom = isPathnameWithHiddenFloatingButtons(prerenderablePathname);
 
   let headerBackgroundColor: ColorString|undefined = undefined;
   if (isBlackBarTitle) {
@@ -295,7 +298,7 @@ const LlmSidebarWrapper = ({children}: {
   const classes = useStyles(styles);
   const currentUser = useCurrentUser();
   const prerenderablePathname = usePrerenderablePathname();
-  const hideLlmChatButton = prerenderablePathname.startsWith('/inbox') || prerenderablePathname.startsWith('/research');
+  const hideLlmChatButton = isPathnameWithHiddenFloatingButtons(prerenderablePathname);
   const [cookies, setCookie] = useCookiesWithConsent([SHOW_LLM_CHAT_COOKIE]);
 
   const [showLlmChatSidebar, setShowLlmChatSidebar] = useState(false);


### PR DESCRIPTION
On `/admin/supermod`, the floating intercom and LLM chat launcher buttons in the bottom-right corner overlap the moderation inbox UI. This hides both buttons on that route, the same way they're already hidden on `/inbox` and `/research`.

Since the intercom check and the LLM chat button check in `Layout.tsx` were identical pathname conditions duplicated in two places, this extracts them into a shared `isPathnameWithHiddenFloatingButtons` helper and adds `/admin/supermod` to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JGhVUZpL1r6DQAusRRCPg3

---
_Generated by [Claude Code](https://claude.ai/code/session_01JGhVUZpL1r6DQAusRRCPg3)_

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1217490644223367) by [Unito](https://www.unito.io)
