### PR TITLE
SimpleMod: standalone Tinder-style per-item moderation app

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
     "depcruise:validate": "dependency-cruiser packages app --validate .dependency-cruiser.js",
     "unused-graphql-fragments": "ts-node --swc -r tsconfig-paths/register scripts/unusedGraphqlFragments.ts",
     "unused-jss-classes": "ts-node --swc -r tsconfig-paths/register scripts/unusedJssClasses.ts",
-    "next-start": "NODE_OPTIONS='--inspect --no-deprecation --enable-source-maps' next start"
+    "next-start": "NODE_OPTIONS='--inspect --no-deprecation --enable-source-maps' next start",
+    "simplemod": "next dev simplemod --turbopack -p 3030"
   },
   "dependencies": {
     "@ai-sdk/gateway": "^3.0.84",
@@ -200,6 +201,7 @@
     "esbuild": "^0.25.0",
     "feedparser-promised": "^1.2.2",
     "fp-ts": "^2.13.1",
+    "framer-motion": "^13.1.0",
     "geist": "^1.7.2",
     "google-auth-library": "^10.0.0",
     "gpt-3-encoder": "^1.1.3",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "unused-graphql-fragments": "ts-node --swc -r tsconfig-paths/register scripts/unusedGraphqlFragments.ts",
     "unused-jss-classes": "ts-node --swc -r tsconfig-paths/register scripts/unusedJssClasses.ts",
     "next-start": "NODE_OPTIONS='--inspect --no-deprecation --enable-source-maps' next start",
-    "simplemod": "next dev simplemod --turbopack -p 3030"
+    "simplemod": "scripts/runSimplemod.sh"
   },
   "dependencies": {
     "@ai-sdk/gateway": "^3.0.84",

--- a/packages/lesswrong/components/hooks/useModeratedUserContents.ts
+++ b/packages/lesswrong/components/hooks/useModeratedUserContents.ts
@@ -16,8 +16,8 @@ const SunshineCommentsListMultiQuery = gql(`
 `);
 
 export function useModeratedUserContents(userId: string, contentLimit = 20) {
-  const { posts = [] } = usePublishedPosts(userId, contentLimit, false);
-  const { data: commentsData } = useQuery(SunshineCommentsListMultiQuery, {
+  const { posts } = usePublishedPosts(userId, contentLimit, false);
+  const { data: commentsData, loading: commentsLoading } = useQuery(SunshineCommentsListMultiQuery, {
     variables: {
       selector: { sunshineNewUsersComments: { userId } },
       limit: contentLimit,
@@ -30,10 +30,11 @@ export function useModeratedUserContents(userId: string, contentLimit = 20) {
 
   // In ModerationContentDetail, we embed a post page wrapper into the moderation detail view.
   // Hydrating the apollo cache here lets us avoid a loading spinner when going through a user's posts that way.
-  useHydrateModerationPostCache(posts);
+  useHydrateModerationPostCache(posts ?? []);
 
   return {
-    posts,
+    posts: posts ?? [],
     comments,
+    loading: !posts || (commentsLoading && !commentsData),
   };
 }

--- a/packages/lesswrong/components/sunshineDashboard/supermod/ModerationActionButton.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/supermod/ModerationActionButton.tsx
@@ -19,26 +19,30 @@ export const moderatorActionHighlightStyles = (theme: ThemeType) => ({
   },
   green: {
     borderColor: theme.palette.primary.main,
+    boxShadow: `0 0 0 1px ${theme.palette.primary.main}`,
     '&:hover': {
-      borderColor: theme.palette.primary.dark,
+      borderColor: theme.palette.primary.main,
     },
   },
   gold: {
-    borderColor: theme.palette.panelBackground.reviewGold,
+    borderColor: theme.palette.bookPromotion.starGold,
+    boxShadow: `0 0 0 1px ${theme.palette.bookPromotion.starGold}`,
     '&:hover': {
-      borderColor: theme.palette.panelBackground.reviewGold,
+      borderColor: theme.palette.bookPromotion.starGold,
     },
   },
   black: {
     borderColor: theme.palette.grey[900],
+    boxShadow: `0 0 0 1px ${theme.palette.grey[900]}`,
     '&:hover': {
       borderColor: theme.palette.grey[900],
     },
   },
   red: {
     borderColor: theme.palette.error.main,
+    boxShadow: `0 0 0 1px ${theme.palette.error.main}`,
     '&:hover': {
-      borderColor: theme.palette.error.dark,
+      borderColor: theme.palette.error.main,
     },
   },
 });

--- a/packages/lesswrong/components/sunshineDashboard/supermod/ModerationActionButton.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/supermod/ModerationActionButton.tsx
@@ -1,0 +1,94 @@
+import React from 'react';
+import { defineStyles, useStyles } from '@/components/hooks/useStyles';
+import LWTooltip from '@/components/common/LWTooltip';
+import KeystrokeDisplay from './KeystrokeDisplay';
+import type { ModeratorActionHighlightStyle } from './actionHighlightRules';
+import classNames from 'classnames';
+
+/**
+ * Outline treatments for highlighted moderator action buttons; class names match
+ * `ModeratorActionHighlightStyle`. Also spread into ModerationPermissionButtons'
+ * styles so the Message permission button can be highlighted the same way.
+ */
+export const moderatorActionHighlightStyles = (theme: ThemeType) => ({
+  subtleOutline: {
+    borderColor: theme.palette.grey[600],
+    '&:hover': {
+      borderColor: theme.palette.grey[700],
+    },
+  },
+  green: {
+    borderColor: theme.palette.primary.main,
+    '&:hover': {
+      borderColor: theme.palette.primary.dark,
+    },
+  },
+  gold: {
+    borderColor: theme.palette.panelBackground.reviewGold,
+    '&:hover': {
+      borderColor: theme.palette.panelBackground.reviewGold,
+    },
+  },
+  black: {
+    borderColor: theme.palette.grey[900],
+    '&:hover': {
+      borderColor: theme.palette.grey[900],
+    },
+  },
+  red: {
+    borderColor: theme.palette.error.main,
+    '&:hover': {
+      borderColor: theme.palette.error.dark,
+    },
+  },
+});
+
+const styles = defineStyles('ModerationActionButton', (theme: ThemeType) => ({
+  actionButton: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: 4,
+    padding: '4px 4px 4px 6px',
+    border: `1px solid ${theme.palette.grey[300]}`,
+    borderRadius: 4,
+    backgroundColor: theme.palette.background.paper,
+    cursor: 'pointer',
+    fontSize: 12,
+    transition: 'all 0.15s ease',
+    '&:hover': {
+      backgroundColor: theme.palette.grey[50],
+      borderColor: theme.palette.grey[400],
+    },
+    '&.active': {
+      backgroundColor: theme.palette.error.light,
+      borderColor: theme.palette.error.main,
+      color: theme.palette.error.contrastText,
+      '&:hover': {
+        backgroundColor: theme.palette.error.main,
+      },
+    },
+  },
+  ...moderatorActionHighlightStyles(theme),
+}));
+
+const ModerationActionButton = ({label, keystroke, tooltip, onClick, active=false, highlightStyle=null}: {
+  label: string;
+  keystroke: string;
+  tooltip: string;
+  onClick: () => void;
+  active?: boolean;
+  highlightStyle?: ModeratorActionHighlightStyle | null;
+}) => {
+  const classes = useStyles(styles);
+  return (
+    <LWTooltip title={tooltip} placement="left">
+      <div className={classNames(classes.actionButton, active && 'active', highlightStyle && classes[highlightStyle])} onClick={onClick}>
+        <span>{label}</span>
+        <KeystrokeDisplay keystroke={keystroke} splitBeforeTranslation activeContext={active} />
+      </div>
+    </LWTooltip>
+  );
+};
+
+export default ModerationActionButton;

--- a/packages/lesswrong/components/sunshineDashboard/supermod/ModerationActionButtons.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/supermod/ModerationActionButtons.tsx
@@ -1,13 +1,11 @@
 import React from 'react';
 import { defineStyles, useStyles } from '@/components/hooks/useStyles';
-import LWTooltip from '@/components/common/LWTooltip';
-import KeystrokeDisplay from './KeystrokeDisplay';
+import ModerationActionButton from './ModerationActionButton';
 import { useModerationUserActions } from './useModerationUserActions';
 import { useUserContentPermissions } from './useUserContentPermissions';
 import type { InboxAction } from './inboxReducer';
 import { areAllContentPermissionsDisabled } from './helpers';
-import type { HighlightableModeratorAction } from './actionHighlightRules';
-import classNames from 'classnames';
+import { getActionHighlightStyle, type HighlightableModeratorAction, type ModeratorActionHighlightLevel } from './actionHighlightRules';
 
 const styles = defineStyles('ModerationActionButtons', (theme: ThemeType) => ({
   actionsColumn: {
@@ -22,41 +20,6 @@ const styles = defineStyles('ModerationActionButtons', (theme: ThemeType) => ({
     gap: 4,
     flexWrap: 'wrap',
   },
-  actionButton: {
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-    gap: 4,
-    padding: '4px 4px 4px 6px',
-    border: `1px solid ${theme.palette.grey[300]}`,
-    borderRadius: 4,
-    backgroundColor: theme.palette.background.paper,
-    cursor: 'pointer',
-    fontSize: 12,
-    transition: 'all 0.15s ease',
-    '&:hover': {
-      backgroundColor: theme.palette.grey[50],
-      borderColor: theme.palette.grey[400],
-    },
-    '&.active': {
-      backgroundColor: theme.palette.error.light,
-      borderColor: theme.palette.error.main,
-      color: theme.palette.error.contrastText,
-      '&:hover': {
-        backgroundColor: theme.palette.error.main,
-      },
-    },
-  },
-  highlighted: {
-    backgroundColor: theme.palette.grey[900],
-    borderColor: theme.palette.grey[900],
-    color: theme.palette.grey[100],
-    fontWeight: 600,
-    '&:hover': {
-      backgroundColor: theme.palette.grey[800],
-      borderColor: theme.palette.grey[800],
-    },
-  },
 }));
 
 const ModerationActionButtons = ({user, currentUser, addToUndoQueue, dispatch, highlightedActions, onlyHighlighted=false}: {
@@ -64,7 +27,7 @@ const ModerationActionButtons = ({user, currentUser, addToUndoQueue, dispatch, h
   currentUser: UsersCurrent;
   addToUndoQueue: (actionLabel: string, executeAction: () => Promise<void>) => void;
   dispatch: React.ActionDispatch<[action: InboxAction]>;
-  highlightedActions?: Set<HighlightableModeratorAction>;
+  highlightedActions?: Map<HighlightableModeratorAction, ModeratorActionHighlightLevel>;
   onlyHighlighted?: boolean;
 }) => {
   const classes = useStyles(styles);
@@ -148,30 +111,41 @@ const ModerationActionButtons = ({user, currentUser, addToUndoQueue, dispatch, h
     ],
   ];
 
-  const visibleActionRows = onlyHighlighted
-    ? moderatorActionRows
-        .map(row => row.filter(({highlightKey}) => highlightKey && highlightedActions?.has(highlightKey)))
-        .filter(row => row.length > 0)
-    : moderatorActionRows;
-
-  if (visibleActionRows.length === 0) {
-    return null;
+  // When showing only the highlighted actions (i.e. while the section is collapsed),
+  // render the buttons bare so they all flow together in the parent's wrapping row.
+  if (onlyHighlighted) {
+    const highlightedButtons = moderatorActionRows
+      .flat()
+      .filter(({highlightKey}) => highlightKey && highlightedActions?.has(highlightKey));
+    return <>
+      {highlightedButtons.map(({label, keystroke, tooltip, onClick, active, highlightKey}) => (
+        <ModerationActionButton
+          key={label}
+          label={label}
+          keystroke={keystroke}
+          tooltip={tooltip}
+          onClick={onClick}
+          active={!!active}
+          highlightStyle={highlightKey ? getActionHighlightStyle(highlightKey, highlightedActions?.get(highlightKey), true) : null}
+        />
+      ))}
+    </>;
   }
 
   return (
     <div className={classes.actionsColumn}>
-      {visibleActionRows.map((row, rowIndex) => (
+      {moderatorActionRows.map((row, rowIndex) => (
         <div key={rowIndex} className={classes.actionRow}>
           {row.map(({label, keystroke, tooltip, onClick, active, highlightKey}) => (
-            <LWTooltip key={label} title={tooltip} placement="left">
-              <div
-                className={classNames(classes.actionButton, active && 'active', highlightKey && highlightedActions?.has(highlightKey) && classes.highlighted)}
-                onClick={onClick}
-              >
-                <span>{label}</span>
-                <KeystrokeDisplay keystroke={keystroke} splitBeforeTranslation activeContext={!!active} />
-              </div>
-            </LWTooltip>
+            <ModerationActionButton
+              key={label}
+              label={label}
+              keystroke={keystroke}
+              tooltip={tooltip}
+              onClick={onClick}
+              active={!!active}
+              highlightStyle={highlightKey ? getActionHighlightStyle(highlightKey, highlightedActions?.get(highlightKey), false) : null}
+            />
           ))}
         </div>
       ))}

--- a/packages/lesswrong/components/sunshineDashboard/supermod/ModerationActionButtons.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/supermod/ModerationActionButtons.tsx
@@ -6,6 +6,7 @@ import { useModerationUserActions } from './useModerationUserActions';
 import { useUserContentPermissions } from './useUserContentPermissions';
 import type { InboxAction } from './inboxReducer';
 import { areAllContentPermissionsDisabled } from './helpers';
+import type { HighlightableModeratorAction } from './actionHighlightRules';
 import classNames from 'classnames';
 
 const styles = defineStyles('ModerationActionButtons', (theme: ThemeType) => ({
@@ -46,13 +47,25 @@ const styles = defineStyles('ModerationActionButtons', (theme: ThemeType) => ({
       },
     },
   },
+  highlighted: {
+    backgroundColor: theme.palette.grey[900],
+    borderColor: theme.palette.grey[900],
+    color: theme.palette.grey[100],
+    fontWeight: 600,
+    '&:hover': {
+      backgroundColor: theme.palette.grey[800],
+      borderColor: theme.palette.grey[800],
+    },
+  },
 }));
 
-const ModerationActionButtons = ({user, currentUser, addToUndoQueue, dispatch}: {
+const ModerationActionButtons = ({user, currentUser, addToUndoQueue, dispatch, highlightedActions, onlyHighlighted=false}: {
   user: SunshineUsersList;
   currentUser: UsersCurrent;
   addToUndoQueue: (actionLabel: string, executeAction: () => Promise<void>) => void;
   dispatch: React.ActionDispatch<[action: InboxAction]>;
+  highlightedActions?: Set<HighlightableModeratorAction>;
+  onlyHighlighted?: boolean;
 }) => {
   const classes = useStyles(styles);
 
@@ -74,6 +87,7 @@ const ModerationActionButtons = ({user, currentUser, addToUndoQueue, dispatch}: 
     tooltip: string;
     onClick: () => void;
     active?: boolean;
+    highlightKey?: HighlightableModeratorAction;
   }>> = [
     [
       {
@@ -81,6 +95,7 @@ const ModerationActionButtons = ({user, currentUser, addToUndoQueue, dispatch}: 
         keystroke: 'A',
         tooltip: "Approve this user and all their content. Marks them as reviewed by you, so their future posts and comments no longer need review. Clears any snooze and any flag, and signs an 'Approved' note in their moderator notes.",
         onClick: handleReview,
+        highlightKey: 'approve',
       },
     ],
     [
@@ -95,12 +110,14 @@ const ModerationActionButtons = ({user, currentUser, addToUndoQueue, dispatch}: 
         keystroke: 'Shift+S',
         tooltip: 'Same as Snooze 10, but opens a dialog to choose how many more posts or comments the user can make before they return to the review queue.',
         onClick: handleSnoozeCustom,
+        highlightKey: 'snoozeCustom',
       },
       {
         label: 'Approve Current Only',
         keystroke: 'Shift+A',
         tooltip: "Approve this user's existing unreviewed posts and comments and remove them from the queue, without marking the user as reviewed, so their future content will still need review. Also clears any snooze and any flag.",
         onClick: handleApproveCurrentOnly,
+        highlightKey: 'approveCurrentOnly',
       },
     ],
     [
@@ -109,12 +126,14 @@ const ModerationActionButtons = ({user, currentUser, addToUndoQueue, dispatch}: 
         keystroke: 'Q',
         tooltip: "Remove this user from the review queue without approving them or snoozing. Their content stays unreviewed. Signs a 'removed from review queue without snooze/approval' note in their moderator notes.",
         onClick: handleRemoveNeedsReview,
+        highlightKey: 'remove',
       },
       {
         label: 'Purge',
         keystroke: 'P',
         tooltip: "Deletes all of this user's posts, comments, sequences, and votes, bans them for 1000 years, and removes them from the review queue. Asks for confirmation first, and signs a 'Purge' note in their moderator notes.",
         onClick: handlePurge,
+        highlightKey: 'purge',
       },
       {
         label: allPermissionsDisabled ? 'Enable Permissions' : 'Disable Permissions',
@@ -124,17 +143,31 @@ const ModerationActionButtons = ({user, currentUser, addToUndoQueue, dispatch}: 
           : "Disable posting, commenting, messaging, and voting. Signs an 'all permissions disabled' note in their moderator notes.",
         onClick: toggleAllPermissions,
         active: allPermissionsDisabled,
+        highlightKey: 'disablePermissions',
       },
     ],
   ];
 
+  const visibleActionRows = onlyHighlighted
+    ? moderatorActionRows
+        .map(row => row.filter(({highlightKey}) => highlightKey && highlightedActions?.has(highlightKey)))
+        .filter(row => row.length > 0)
+    : moderatorActionRows;
+
+  if (visibleActionRows.length === 0) {
+    return null;
+  }
+
   return (
     <div className={classes.actionsColumn}>
-      {moderatorActionRows.map((row, rowIndex) => (
+      {visibleActionRows.map((row, rowIndex) => (
         <div key={rowIndex} className={classes.actionRow}>
-          {row.map(({label, keystroke, tooltip, onClick, active}) => (
+          {row.map(({label, keystroke, tooltip, onClick, active, highlightKey}) => (
             <LWTooltip key={label} title={tooltip} placement="left">
-              <div className={classNames(classes.actionButton, active && 'active')} onClick={onClick}>
+              <div
+                className={classNames(classes.actionButton, active && 'active', highlightKey && highlightedActions?.has(highlightKey) && classes.highlighted)}
+                onClick={onClick}
+              >
                 <span>{label}</span>
                 <KeystrokeDisplay keystroke={keystroke} splitBeforeTranslation activeContext={!!active} />
               </div>

--- a/packages/lesswrong/components/sunshineDashboard/supermod/ModerationInbox.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/supermod/ModerationInbox.tsx
@@ -383,7 +383,7 @@ const ModerationInboxInner = ({ users, posts, classifiedPosts, curationPosts, la
   const isCurationTab = state.activeTab === 'curation';
   const isPostLikeTab = isPostsTab || isCurationTab;
 
-  const { posts: userPosts, comments: userComments } = useModeratedUserContents(openedUser?._id ?? '');
+  const { posts: userPosts, comments: userComments, loading: userContentsLoading } = useModeratedUserContents(openedUser?._id ?? '');
 
   return (
     <CoreTagsKeyboardProvider>
@@ -445,6 +445,7 @@ const ModerationInboxInner = ({ users, posts, classifiedPosts, curationPosts, la
               user={openedUser}
               posts={userPosts}
               comments={userComments}
+              contentsLoading={userContentsLoading}
               focusedContentIndex={state.focusedContentIndex}
               runningLlmCheckId={state.runningLlmCheckId}
               sidebarTab={state.sidebarTab}

--- a/packages/lesswrong/components/sunshineDashboard/supermod/ModerationPermissionButtons.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/supermod/ModerationPermissionButtons.tsx
@@ -6,7 +6,8 @@ import classNames from 'classnames';
 import KeystrokeDisplay from './KeystrokeDisplay';
 import type { InboxAction } from './inboxReducer';
 import { useUserContentPermissions } from './useUserContentPermissions';
-import type { HighlightableModeratorAction } from './actionHighlightRules';
+import { getActionHighlightStyle, type HighlightableModeratorAction, type ModeratorActionHighlightLevel } from './actionHighlightRules';
+import { moderatorActionHighlightStyles } from './ModerationActionButton';
 
 const styles = defineStyles('ModerationPermissionButtons', (theme: ThemeType) => ({
   permissionButtonsContainer: {
@@ -37,16 +38,7 @@ const styles = defineStyles('ModerationPermissionButtons', (theme: ThemeType) =>
       },
     },
   },
-  highlighted: {
-    backgroundColor: theme.palette.grey[900],
-    borderColor: theme.palette.grey[900],
-    color: theme.palette.grey[100],
-    fontWeight: 600,
-    '&:hover': {
-      backgroundColor: theme.palette.grey[800],
-      borderColor: theme.palette.grey[800],
-    },
-  },
+  ...moderatorActionHighlightStyles(theme),
   permissionButtonLabel: {
     flexGrow: 1,
   },
@@ -60,7 +52,7 @@ const ModerationPermissionButtons = ({
 }: {
   user: SunshineUsersList;
   dispatch: React.ActionDispatch<[action: InboxAction]>;
-  highlightedActions?: Set<HighlightableModeratorAction>;
+  highlightedActions?: Map<HighlightableModeratorAction, ModeratorActionHighlightLevel>;
   onlyHighlighted?: boolean;
 }) => {
   const classes = useStyles(styles);
@@ -73,45 +65,48 @@ const ModerationPermissionButtons = ({
   } = useUserContentPermissions(user, dispatch);
 
   const messagingHighlighted = !!highlightedActions?.has('disableMessages');
+  const messageHighlightStyle = getActionHighlightStyle('disableMessages', highlightedActions?.get('disableMessages'), onlyHighlighted);
 
-  if (onlyHighlighted && !messagingHighlighted) {
-    return null;
+  const messageButton = (
+    <div 
+      className={classNames(classes.permissionButton, user.conversationsDisabled && 'active', messageHighlightStyle && classes[messageHighlightStyle])}
+      onClick={toggleDisableMessaging}
+    >
+      <span className={classes.permissionButtonLabel}>Message</span>
+      <KeystrokeDisplay keystroke="M" withMargin activeContext={!!user.conversationsDisabled} />
+    </div>
+  );
+
+  // When showing only the highlighted buttons (i.e. while the section is collapsed),
+  // render the button bare so it flows together in the parent's wrapping row.
+  if (onlyHighlighted) {
+    return messagingHighlighted ? messageButton : null;
   }
 
   return (
     <div className={classes.permissionButtonsContainer}>
-      {!onlyHighlighted && <>
-        <div 
-          className={classNames(classes.permissionButton, user.postingDisabled && 'active')}
-          onClick={toggleDisablePosting}
-        >
-          <span className={classes.permissionButtonLabel}>Post</span>
-          <KeystrokeDisplay keystroke="D" withMargin activeContext={!!user.postingDisabled} />
-        </div>
-        <div 
-          className={classNames(classes.permissionButton, user.allCommentingDisabled && 'active')}
-          onClick={toggleDisableCommenting}
-        >
-          <span className={classes.permissionButtonLabel}>Comment</span>
-          <KeystrokeDisplay keystroke="C" withMargin activeContext={!!user.allCommentingDisabled} />
-        </div>
-      </>}
       <div 
-        className={classNames(classes.permissionButton, user.conversationsDisabled && 'active', messagingHighlighted && classes.highlighted)}
-        onClick={toggleDisableMessaging}
+        className={classNames(classes.permissionButton, user.postingDisabled && 'active')}
+        onClick={toggleDisablePosting}
       >
-        <span className={classes.permissionButtonLabel}>Message</span>
-        <KeystrokeDisplay keystroke="M" withMargin activeContext={!!user.conversationsDisabled} />
+        <span className={classes.permissionButtonLabel}>Post</span>
+        <KeystrokeDisplay keystroke="D" withMargin activeContext={!!user.postingDisabled} />
       </div>
-      {!onlyHighlighted && (
-        <div 
-          className={classNames(classes.permissionButton, user.votingDisabled && 'active')}
-          onClick={() => toggleDisableVoting()}
-        >
-          <span className={classes.permissionButtonLabel}>Vote</span>
-          <KeystrokeDisplay keystroke="V" withMargin activeContext={!!user.votingDisabled} />
-        </div>
-      )}
+      <div 
+        className={classNames(classes.permissionButton, user.allCommentingDisabled && 'active')}
+        onClick={toggleDisableCommenting}
+      >
+        <span className={classes.permissionButtonLabel}>Comment</span>
+        <KeystrokeDisplay keystroke="C" withMargin activeContext={!!user.allCommentingDisabled} />
+      </div>
+      {messageButton}
+      <div 
+        className={classNames(classes.permissionButton, user.votingDisabled && 'active')}
+        onClick={() => toggleDisableVoting()}
+      >
+        <span className={classes.permissionButtonLabel}>Vote</span>
+        <KeystrokeDisplay keystroke="V" withMargin activeContext={!!user.votingDisabled} />
+      </div>
     </div>
   );
 };

--- a/packages/lesswrong/components/sunshineDashboard/supermod/ModerationPermissionButtons.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/supermod/ModerationPermissionButtons.tsx
@@ -6,6 +6,7 @@ import classNames from 'classnames';
 import KeystrokeDisplay from './KeystrokeDisplay';
 import type { InboxAction } from './inboxReducer';
 import { useUserContentPermissions } from './useUserContentPermissions';
+import type { HighlightableModeratorAction } from './actionHighlightRules';
 
 const styles = defineStyles('ModerationPermissionButtons', (theme: ThemeType) => ({
   permissionButtonsContainer: {
@@ -36,6 +37,16 @@ const styles = defineStyles('ModerationPermissionButtons', (theme: ThemeType) =>
       },
     },
   },
+  highlighted: {
+    backgroundColor: theme.palette.grey[900],
+    borderColor: theme.palette.grey[900],
+    color: theme.palette.grey[100],
+    fontWeight: 600,
+    '&:hover': {
+      backgroundColor: theme.palette.grey[800],
+      borderColor: theme.palette.grey[800],
+    },
+  },
   permissionButtonLabel: {
     flexGrow: 1,
   },
@@ -44,9 +55,13 @@ const styles = defineStyles('ModerationPermissionButtons', (theme: ThemeType) =>
 const ModerationPermissionButtons = ({
   user,
   dispatch,
+  highlightedActions,
+  onlyHighlighted=false,
 }: {
   user: SunshineUsersList;
   dispatch: React.ActionDispatch<[action: InboxAction]>;
+  highlightedActions?: Set<HighlightableModeratorAction>;
+  onlyHighlighted?: boolean;
 }) => {
   const classes = useStyles(styles);
 
@@ -57,36 +72,46 @@ const ModerationPermissionButtons = ({
     toggleDisableVoting,
   } = useUserContentPermissions(user, dispatch);
 
+  const messagingHighlighted = !!highlightedActions?.has('disableMessages');
+
+  if (onlyHighlighted && !messagingHighlighted) {
+    return null;
+  }
+
   return (
     <div className={classes.permissionButtonsContainer}>
+      {!onlyHighlighted && <>
+        <div 
+          className={classNames(classes.permissionButton, user.postingDisabled && 'active')}
+          onClick={toggleDisablePosting}
+        >
+          <span className={classes.permissionButtonLabel}>Post</span>
+          <KeystrokeDisplay keystroke="D" withMargin activeContext={!!user.postingDisabled} />
+        </div>
+        <div 
+          className={classNames(classes.permissionButton, user.allCommentingDisabled && 'active')}
+          onClick={toggleDisableCommenting}
+        >
+          <span className={classes.permissionButtonLabel}>Comment</span>
+          <KeystrokeDisplay keystroke="C" withMargin activeContext={!!user.allCommentingDisabled} />
+        </div>
+      </>}
       <div 
-        className={classNames(classes.permissionButton, user.postingDisabled && 'active')}
-        onClick={toggleDisablePosting}
-      >
-        <span className={classes.permissionButtonLabel}>Post</span>
-        <KeystrokeDisplay keystroke="D" withMargin activeContext={!!user.postingDisabled} />
-      </div>
-      <div 
-        className={classNames(classes.permissionButton, user.allCommentingDisabled && 'active')}
-        onClick={toggleDisableCommenting}
-      >
-        <span className={classes.permissionButtonLabel}>Comment</span>
-        <KeystrokeDisplay keystroke="C" withMargin activeContext={!!user.allCommentingDisabled} />
-      </div>
-      <div 
-        className={classNames(classes.permissionButton, user.conversationsDisabled && 'active')}
+        className={classNames(classes.permissionButton, user.conversationsDisabled && 'active', messagingHighlighted && classes.highlighted)}
         onClick={toggleDisableMessaging}
       >
         <span className={classes.permissionButtonLabel}>Message</span>
         <KeystrokeDisplay keystroke="M" withMargin activeContext={!!user.conversationsDisabled} />
       </div>
-      <div 
-        className={classNames(classes.permissionButton, user.votingDisabled && 'active')}
-        onClick={() => toggleDisableVoting()}
-      >
-        <span className={classes.permissionButtonLabel}>Vote</span>
-        <KeystrokeDisplay keystroke="V" withMargin activeContext={!!user.votingDisabled} />
-      </div>
+      {!onlyHighlighted && (
+        <div 
+          className={classNames(classes.permissionButton, user.votingDisabled && 'active')}
+          onClick={() => toggleDisableVoting()}
+        >
+          <span className={classes.permissionButtonLabel}>Vote</span>
+          <KeystrokeDisplay keystroke="V" withMargin activeContext={!!user.votingDisabled} />
+        </div>
+      )}
     </div>
   );
 };

--- a/packages/lesswrong/components/sunshineDashboard/supermod/ModerationSidebar.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/supermod/ModerationSidebar.tsx
@@ -69,7 +69,7 @@ const ModerationSidebar = ({
   return (
     <div className={classes.root}>
       <div className={classes.section}>
-        <SupermodModeratorActions user={user} currentUser={currentUser} addToUndoQueue={addToUndoQueue} dispatch={dispatch} />
+        <SupermodModeratorActions user={user} currentUser={currentUser} posts={posts} comments={comments} addToUndoQueue={addToUndoQueue} dispatch={dispatch} />
       </div>
       <div className={classes.section}>
         <div className={classes.userMessages}>

--- a/packages/lesswrong/components/sunshineDashboard/supermod/ModerationSidebar.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/supermod/ModerationSidebar.tsx
@@ -38,6 +38,7 @@ const ModerationSidebar = ({
   currentUser,
   posts,
   comments,
+  contentsLoading,
   focusedContent,
   sidebarTab,
   setSidebarTab,
@@ -48,6 +49,7 @@ const ModerationSidebar = ({
   currentUser: UsersCurrent;
   posts: SunshinePostsList[];
   comments: SunshineCommentsList[];
+  contentsLoading: boolean;
   focusedContent: ContentItem | null;
   sidebarTab: SelectedSidebarTab;
   setSidebarTab: (tab: SelectedSidebarTab) => void;
@@ -69,7 +71,7 @@ const ModerationSidebar = ({
   return (
     <div className={classes.root}>
       <div className={classes.section}>
-        <SupermodModeratorActions user={user} currentUser={currentUser} posts={posts} comments={comments} addToUndoQueue={addToUndoQueue} dispatch={dispatch} />
+        <SupermodModeratorActions user={user} currentUser={currentUser} posts={posts} comments={comments} contentsLoading={contentsLoading} addToUndoQueue={addToUndoQueue} dispatch={dispatch} />
       </div>
       <div className={classes.section}>
         <div className={classes.userMessages}>

--- a/packages/lesswrong/components/sunshineDashboard/supermod/ModerationUserDetailView.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/supermod/ModerationUserDetailView.tsx
@@ -49,6 +49,7 @@ const ModerationUserDetailView = ({
   user,
   posts,
   comments,
+  contentsLoading,
   focusedContentIndex,
   runningLlmCheckId,
   sidebarTab,
@@ -60,6 +61,7 @@ const ModerationUserDetailView = ({
   user: SunshineUsersList;
   posts: SunshinePostsList[];
   comments: SunshineCommentsList[];
+  contentsLoading: boolean;
   focusedContentIndex: number;
   runningLlmCheckId: string | null;
   sidebarTab: SelectedSidebarTab;
@@ -120,6 +122,7 @@ const ModerationUserDetailView = ({
             currentUser={currentUser}
             posts={posts}
             comments={comments}
+            contentsLoading={contentsLoading}
             focusedContent={focusedContent}
             sidebarTab={sidebarTab}
             setSidebarTab={setSidebarTab}

--- a/packages/lesswrong/components/sunshineDashboard/supermod/SupermodModeratorActions.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/supermod/SupermodModeratorActions.tsx
@@ -7,7 +7,7 @@ import ModeratorActionItem from '../ModeratorUserInfo/ModeratorActionItem';
 import ForumIcon from '@/components/common/ForumIcon';
 import { useLocalStorageState } from '@/components/hooks/useLocalStorageState';
 import { persistentDisplayedModeratorActions } from '@/lib/collections/moderatorActions/constants';
-import { getHighlightedModeratorActions, type HighlightableModeratorAction } from './actionHighlightRules';
+import { getHighlightedModeratorActions, type HighlightableModeratorAction, type ModeratorActionHighlightLevel } from './actionHighlightRules';
 import type { InboxAction } from './inboxReducer';
 import UserRateLimitItem from '../UserRateLimitItem';
 import classNames from 'classnames';
@@ -22,6 +22,12 @@ const styles = defineStyles('SupermodModeratorActions', (theme: ThemeType) => ({
     fontSize: 16,
     color: theme.palette.grey[600],
     cursor: 'pointer',
+  },
+  highlightedActionsRow: {
+    display: 'flex',
+    flexWrap: 'wrap',
+    gap: 4,
+    marginTop: 8,
   },
   modActionsColumn: {
     display: 'flex',
@@ -74,7 +80,7 @@ const SupermodModeratorActions = ({user, currentUser, posts, comments, contentsL
   // While the user's contents are still loading, the empty posts/comments lists would
   // spuriously satisfy the absence-based rules (e.g. Remove, Purge), so highlight nothing.
   const highlightedActions = useMemo(() => contentsLoading
-    ? new Set<HighlightableModeratorAction>()
+    ? new Map<HighlightableModeratorAction, ModeratorActionHighlightLevel>()
     : getHighlightedModeratorActions({
       user,
       moderatorActions: user.moderatorActions ?? [],
@@ -92,10 +98,12 @@ const SupermodModeratorActions = ({user, currentUser, posts, comments, contentsL
           onClick={() => setModeratorActionsCollapsed(isCollapsed ? 'false' : 'true')}
         />
       </div>
-      {isCollapsed && <>
-        <ModerationActionButtons user={user} currentUser={currentUser} addToUndoQueue={addToUndoQueue} dispatch={dispatch} highlightedActions={highlightedActions} onlyHighlighted />
-        <ModerationPermissionButtons user={user} dispatch={dispatch} highlightedActions={highlightedActions} onlyHighlighted />
-      </>}
+      {isCollapsed && highlightedActions.size > 0 && (
+        <div className={classes.highlightedActionsRow}>
+          <ModerationActionButtons user={user} currentUser={currentUser} addToUndoQueue={addToUndoQueue} dispatch={dispatch} highlightedActions={highlightedActions} onlyHighlighted />
+          <ModerationPermissionButtons user={user} dispatch={dispatch} highlightedActions={highlightedActions} onlyHighlighted />
+        </div>
+      )}
       {!isCollapsed && <>
         <ModerationActionButtons user={user} currentUser={currentUser} addToUndoQueue={addToUndoQueue} dispatch={dispatch} highlightedActions={highlightedActions} />
         <div className={classes.rateLimitSection}>

--- a/packages/lesswrong/components/sunshineDashboard/supermod/SupermodModeratorActions.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/supermod/SupermodModeratorActions.tsx
@@ -7,7 +7,7 @@ import ModeratorActionItem from '../ModeratorUserInfo/ModeratorActionItem';
 import ForumIcon from '@/components/common/ForumIcon';
 import { useLocalStorageState } from '@/components/hooks/useLocalStorageState';
 import { persistentDisplayedModeratorActions } from '@/lib/collections/moderatorActions/constants';
-import { getHighlightedModeratorActions } from './actionHighlightRules';
+import { getHighlightedModeratorActions, type HighlightableModeratorAction } from './actionHighlightRules';
 import type { InboxAction } from './inboxReducer';
 import UserRateLimitItem from '../UserRateLimitItem';
 import classNames from 'classnames';
@@ -51,11 +51,12 @@ const styles = defineStyles('SupermodModeratorActions', (theme: ThemeType) => ({
   }
 }));
 
-const SupermodModeratorActions = ({user, currentUser, posts, comments, addToUndoQueue, dispatch}: {
+const SupermodModeratorActions = ({user, currentUser, posts, comments, contentsLoading, addToUndoQueue, dispatch}: {
   user: SunshineUsersList,
   currentUser: UsersCurrent,
   posts: SunshinePostsList[],
   comments: SunshineCommentsList[],
+  contentsLoading: boolean,
   addToUndoQueue: (actionLabel: string, executeAction: () => Promise<void>) => void,
   dispatch: React.ActionDispatch<[action: InboxAction]>,
 }) => {
@@ -70,12 +71,16 @@ const SupermodModeratorActions = ({user, currentUser, posts, comments, addToUndo
   );
   const isCollapsed = moderatorActionsCollapsed === 'true';
 
-  const highlightedActions = useMemo(() => getHighlightedModeratorActions({
-    user,
-    moderatorActions: user.moderatorActions ?? [],
-    posts,
-    comments,
-  }), [user, posts, comments]);
+  // While the user's contents are still loading, the empty posts/comments lists would
+  // spuriously satisfy the absence-based rules (e.g. Remove, Purge), so highlight nothing.
+  const highlightedActions = useMemo(() => contentsLoading
+    ? new Set<HighlightableModeratorAction>()
+    : getHighlightedModeratorActions({
+      user,
+      moderatorActions: user.moderatorActions ?? [],
+      posts,
+      comments,
+    }), [user, posts, comments, contentsLoading]);
 
   return (
     <div>

--- a/packages/lesswrong/components/sunshineDashboard/supermod/SupermodModeratorActions.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/supermod/SupermodModeratorActions.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { defineStyles, useStyles } from '@/components/hooks/useStyles';
 import ModerationPermissionButtons from './ModerationPermissionButtons';
 import ModerationActionButtons from './ModerationActionButtons';
@@ -7,6 +7,7 @@ import ModeratorActionItem from '../ModeratorUserInfo/ModeratorActionItem';
 import ForumIcon from '@/components/common/ForumIcon';
 import { useLocalStorageState } from '@/components/hooks/useLocalStorageState';
 import { persistentDisplayedModeratorActions } from '@/lib/collections/moderatorActions/constants';
+import { getHighlightedModeratorActions } from './actionHighlightRules';
 import type { InboxAction } from './inboxReducer';
 import UserRateLimitItem from '../UserRateLimitItem';
 import classNames from 'classnames';
@@ -50,9 +51,11 @@ const styles = defineStyles('SupermodModeratorActions', (theme: ThemeType) => ({
   }
 }));
 
-const SupermodModeratorActions = ({user, currentUser, addToUndoQueue, dispatch}: {
+const SupermodModeratorActions = ({user, currentUser, posts, comments, addToUndoQueue, dispatch}: {
   user: SunshineUsersList,
   currentUser: UsersCurrent,
+  posts: SunshinePostsList[],
+  comments: SunshineCommentsList[],
   addToUndoQueue: (actionLabel: string, executeAction: () => Promise<void>) => void,
   dispatch: React.ActionDispatch<[action: InboxAction]>,
 }) => {
@@ -67,6 +70,13 @@ const SupermodModeratorActions = ({user, currentUser, addToUndoQueue, dispatch}:
   );
   const isCollapsed = moderatorActionsCollapsed === 'true';
 
+  const highlightedActions = useMemo(() => getHighlightedModeratorActions({
+    user,
+    moderatorActions: user.moderatorActions ?? [],
+    posts,
+    comments,
+  }), [user, posts, comments]);
+
   return (
     <div>
       <div className={classes.sectionTitleRow}>
@@ -77,10 +87,14 @@ const SupermodModeratorActions = ({user, currentUser, addToUndoQueue, dispatch}:
           onClick={() => setModeratorActionsCollapsed(isCollapsed ? 'false' : 'true')}
         />
       </div>
+      {isCollapsed && <>
+        <ModerationActionButtons user={user} currentUser={currentUser} addToUndoQueue={addToUndoQueue} dispatch={dispatch} highlightedActions={highlightedActions} onlyHighlighted />
+        <ModerationPermissionButtons user={user} dispatch={dispatch} highlightedActions={highlightedActions} onlyHighlighted />
+      </>}
       {!isCollapsed && <>
-        <ModerationActionButtons user={user} currentUser={currentUser} addToUndoQueue={addToUndoQueue} dispatch={dispatch} />
+        <ModerationActionButtons user={user} currentUser={currentUser} addToUndoQueue={addToUndoQueue} dispatch={dispatch} highlightedActions={highlightedActions} />
         <div className={classes.rateLimitSection}>
-          <ModerationPermissionButtons user={user} dispatch={dispatch} />
+          <ModerationPermissionButtons user={user} dispatch={dispatch} highlightedActions={highlightedActions} />
           <div
             className={classes.rateLimitButton}
             onClick={() => setShowRateLimitForm(!showRateLimitForm)}

--- a/packages/lesswrong/components/sunshineDashboard/supermod/actionHighlightRules.ts
+++ b/packages/lesswrong/components/sunshineDashboard/supermod/actionHighlightRules.ts
@@ -6,6 +6,30 @@ export const highlightableModeratorActions = ['approve', 'snoozeCustom', 'approv
 
 export type HighlightableModeratorAction = typeof highlightableModeratorActions[number];
 
+/**
+ * Highlighted moderator actions come in two layers:
+ * - Level 1: the action just shows up above the fold (while the section is collapsed) in its
+ *   normal styling, and gets a somewhat darker outline in the expanded view.
+ * - Level 2: the action's outline changes to a per-action color (see
+ *   `moderatorActionHighlightColors`) in both the collapsed and expanded views.
+ */
+export type ModeratorActionHighlightLevel = 1 | 2;
+
+export type ModeratorActionHighlightColor = 'green' | 'gold' | 'black' | 'red';
+
+export type ModeratorActionHighlightStyle = ModeratorActionHighlightColor | 'subtleOutline';
+
+/** Outline colors used when an action is highlighted at level 2 */
+export const moderatorActionHighlightColors: Record<HighlightableModeratorAction, ModeratorActionHighlightColor> = {
+  approve: 'green',
+  snoozeCustom: 'gold',
+  approveCurrentOnly: 'gold',
+  remove: 'black',
+  purge: 'red',
+  disablePermissions: 'black',
+  disableMessages: 'black',
+};
+
 export interface ActionHighlightContext {
   user: SunshineUsersList;
   moderatorActions: ModeratorActionDisplay[];
@@ -13,7 +37,7 @@ export interface ActionHighlightContext {
   comments: SunshineCommentsList[];
 }
 
-type ActionHighlightRule = (ctx: ActionHighlightContext) => boolean;
+type ActionHighlightRule = (ctx: ActionHighlightContext) => ModeratorActionHighlightLevel | null;
 
 const LLM_SCORE_HIGHLIGHT_THRESHOLD = 0.2;
 
@@ -22,51 +46,69 @@ const getLlmScore = (item: SunshinePostsList | SunshineCommentsList) => item.aut
 const isUnapproved = (item: SunshinePostsList | SunshineCommentsList) => !item.rejected && item.authorIsUnreviewed;
 
 /** The user has content awaiting review, and none of it looks LLM-written */
-const hasOnlyLowLlmScoreUnapprovedContent: ActionHighlightRule = ({ posts, comments }) => {
+const hasOnlyLowLlmScoreUnapprovedContent = ({ posts, comments }: ActionHighlightContext): boolean => {
   const unapprovedContents = [...posts, ...comments].filter(isUnapproved);
   return unapprovedContents.length >= 1 && !unapprovedContents.some(c => getLlmScore(c) > LLM_SCORE_HIGHLIGHT_THRESHOLD);
 };
 
 const ACTION_HIGHLIGHT_RULES: Record<HighlightableModeratorAction, ActionHighlightRule> = {
-  approve: hasOnlyLowLlmScoreUnapprovedContent,
-  snoozeCustom: hasOnlyLowLlmScoreUnapprovedContent,
-  approveCurrentOnly: hasOnlyLowLlmScoreUnapprovedContent,
+  approve: (ctx) => hasOnlyLowLlmScoreUnapprovedContent(ctx) ? 2 : null,
+  snoozeCustom: (ctx) => hasOnlyLowLlmScoreUnapprovedContent(ctx) ? 2 : null,
+  approveCurrentOnly: (ctx) => hasOnlyLowLlmScoreUnapprovedContent(ctx) ? 2 : null,
   // Everything the user has submitted has already been either approved or rejected
   remove: ({ posts, comments }) => {
     const allContents = [...posts, ...comments];
-    return !allContents.some(isUnapproved);
+    return !allContents.some(isUnapproved) ? 2 : null;
   },
   // The user has no approved content
   purge: ({ posts, comments }) => {
     const allContents = [...posts, ...comments];
-    return !allContents.some(c => !c.rejected && !c.authorIsUnreviewed);
+    return !allContents.some(c => !c.rejected && !c.authorIsUnreviewed) ? 2 : null;
   },
   // The user has at least two rejected contents, or their most recent content is rejected.
   // (The button toggles to "Enable Permissions" once everything is disabled, so don't suggest it then.)
   disablePermissions: ({ user, posts, comments }) => {
-    if (areAllContentPermissionsDisabled(user)) return false;
+    if (areAllContentPermissionsDisabled(user)) return null;
     const allContents = [...posts, ...comments];
     const rejectedContents = allContents.filter(c => c.rejected);
-    if (rejectedContents.length >= 2) return true;
+    if (rejectedContents.length >= 2) return 2;
     const mostRecentContent = maxBy(allContents, c => new Date(c.postedAt).getTime());
-    return !!mostRecentContent?.rejected;
+    return mostRecentContent?.rejected ? 2 : null;
   },
   // Same trigger as the "Lotsa DMs" message template
   disableMessages: ({ user, moderatorActions }) => {
-    if (user.conversationsDisabled) return false;
-    return moderatorActions.some(a => a.active && (a.type === FLAGGED_FOR_N_DMS || a.type === AUTO_BLOCKED_FROM_SENDING_DMS));
+    if (user.conversationsDisabled) return null;
+    const flaggedForDMs = moderatorActions.some(a => a.active && (a.type === FLAGGED_FOR_N_DMS || a.type === AUTO_BLOCKED_FROM_SENDING_DMS));
+    return flaggedForDMs ? 2 : null;
   },
 };
 
-export function getHighlightedModeratorActions(ctx: ActionHighlightContext): Set<HighlightableModeratorAction> {
-  const highlighted = new Set<HighlightableModeratorAction>();
+export function getHighlightedModeratorActions(ctx: ActionHighlightContext): Map<HighlightableModeratorAction, ModeratorActionHighlightLevel> {
+  const highlighted = new Map<HighlightableModeratorAction, ModeratorActionHighlightLevel>();
   for (const action of highlightableModeratorActions) {
     try {
-      if (ACTION_HIGHLIGHT_RULES[action](ctx)) highlighted.add(action);
+      const level = ACTION_HIGHLIGHT_RULES[action](ctx);
+      if (level) highlighted.set(action, level);
     } catch (e) {
       // eslint-disable-next-line no-console
       console.error(`Error evaluating highlight rule for moderator action "${action}":`, e);
     }
   }
   return highlighted;
+}
+
+/**
+ * Resolves which visual treatment (if any) a highlighted action's button should get.
+ * Level 1 actions look normal in the collapsed row (they're highlighted just by being
+ * there) and get a somewhat darker outline in the expanded view; level 2 actions get
+ * their per-action colored outline in both views.
+ */
+export function getActionHighlightStyle(
+  action: HighlightableModeratorAction,
+  level: ModeratorActionHighlightLevel | undefined,
+  inCollapsedRow: boolean,
+): ModeratorActionHighlightStyle | null {
+  if (!level) return null;
+  if (level === 2) return moderatorActionHighlightColors[action];
+  return inCollapsedRow ? null : 'subtleOutline';
 }

--- a/packages/lesswrong/components/sunshineDashboard/supermod/actionHighlightRules.ts
+++ b/packages/lesswrong/components/sunshineDashboard/supermod/actionHighlightRules.ts
@@ -1,0 +1,72 @@
+import { FLAGGED_FOR_N_DMS, AUTO_BLOCKED_FROM_SENDING_DMS } from "@/lib/collections/moderatorActions/constants";
+import { areAllContentPermissionsDisabled } from "./helpers";
+import maxBy from "lodash/maxBy";
+
+export const highlightableModeratorActions = ['approve', 'snoozeCustom', 'approveCurrentOnly', 'remove', 'purge', 'disablePermissions', 'disableMessages'] as const;
+
+export type HighlightableModeratorAction = typeof highlightableModeratorActions[number];
+
+export interface ActionHighlightContext {
+  user: SunshineUsersList;
+  moderatorActions: ModeratorActionDisplay[];
+  posts: SunshinePostsList[];
+  comments: SunshineCommentsList[];
+}
+
+type ActionHighlightRule = (ctx: ActionHighlightContext) => boolean;
+
+const LLM_SCORE_HIGHLIGHT_THRESHOLD = 0.2;
+
+const getLlmScore = (item: SunshinePostsList | SunshineCommentsList) => item.automatedContentEvaluations?.pangramScore ?? 0;
+
+const isUnapproved = (item: SunshinePostsList | SunshineCommentsList) => !item.rejected && item.authorIsUnreviewed;
+
+/** The user has content awaiting review, and none of it looks LLM-written */
+const hasOnlyLowLlmScoreUnapprovedContent: ActionHighlightRule = ({ posts, comments }) => {
+  const unapprovedContents = [...posts, ...comments].filter(isUnapproved);
+  return unapprovedContents.length >= 1 && !unapprovedContents.some(c => getLlmScore(c) > LLM_SCORE_HIGHLIGHT_THRESHOLD);
+};
+
+const ACTION_HIGHLIGHT_RULES: Record<HighlightableModeratorAction, ActionHighlightRule> = {
+  approve: hasOnlyLowLlmScoreUnapprovedContent,
+  snoozeCustom: hasOnlyLowLlmScoreUnapprovedContent,
+  approveCurrentOnly: hasOnlyLowLlmScoreUnapprovedContent,
+  // Everything the user has submitted has already been either approved or rejected
+  remove: ({ posts, comments }) => {
+    const allContents = [...posts, ...comments];
+    return !allContents.some(isUnapproved);
+  },
+  // The user has no approved content
+  purge: ({ posts, comments }) => {
+    const allContents = [...posts, ...comments];
+    return !allContents.some(c => !c.rejected && !c.authorIsUnreviewed);
+  },
+  // The user has at least two rejected contents, or their most recent content is rejected.
+  // (The button toggles to "Enable Permissions" once everything is disabled, so don't suggest it then.)
+  disablePermissions: ({ user, posts, comments }) => {
+    if (areAllContentPermissionsDisabled(user)) return false;
+    const allContents = [...posts, ...comments];
+    const rejectedContents = allContents.filter(c => c.rejected);
+    if (rejectedContents.length >= 2) return true;
+    const mostRecentContent = maxBy(allContents, c => new Date(c.postedAt).getTime());
+    return !!mostRecentContent?.rejected;
+  },
+  // Same trigger as the "Lotsa DMs" message template
+  disableMessages: ({ user, moderatorActions }) => {
+    if (user.conversationsDisabled) return false;
+    return moderatorActions.some(a => a.active && (a.type === FLAGGED_FOR_N_DMS || a.type === AUTO_BLOCKED_FROM_SENDING_DMS));
+  },
+};
+
+export function getHighlightedModeratorActions(ctx: ActionHighlightContext): Set<HighlightableModeratorAction> {
+  const highlighted = new Set<HighlightableModeratorAction>();
+  for (const action of highlightableModeratorActions) {
+    try {
+      if (ACTION_HIGHLIGHT_RULES[action](ctx)) highlighted.add(action);
+    } catch (e) {
+      // eslint-disable-next-line no-console
+      console.error(`Error evaluating highlight rule for moderator action "${action}":`, e);
+    }
+  }
+  return highlighted;
+}

--- a/packages/lesswrong/components/sunshineDashboard/supermod/actionHighlightRules.ts
+++ b/packages/lesswrong/components/sunshineDashboard/supermod/actionHighlightRules.ts
@@ -12,6 +12,10 @@ export type HighlightableModeratorAction = typeof highlightableModeratorActions[
  *   normal styling, and gets a somewhat darker outline in the expanded view.
  * - Level 2: the action's outline changes to a per-action color (see
  *   `moderatorActionHighlightColors`) in both the collapsed and expanded views.
+ *
+ * Highlights default to level 1; rules only return level 2 when there's particular evidence
+ * that the action should apply (e.g. actual rejections, or affirmatively human LLM scores),
+ * rather than just a compatible absence of information.
  */
 export type ModeratorActionHighlightLevel = 1 | 2;
 
@@ -45,37 +49,50 @@ const getLlmScore = (item: SunshinePostsList | SunshineCommentsList) => item.aut
 
 const isUnapproved = (item: SunshinePostsList | SunshineCommentsList) => !item.rejected && item.authorIsUnreviewed;
 
-/** The user has content awaiting review, and none of it looks LLM-written */
-const hasOnlyLowLlmScoreUnapprovedContent = ({ posts, comments }: ActionHighlightContext): boolean => {
+/**
+ * The user has content awaiting review, and none of it looks LLM-written. Level 2 when every
+ * unapproved content has actually been evaluated and scored human (particular evidence, rather
+ * than just an absence of high scores).
+ */
+const approveHighlightLevel: ActionHighlightRule = ({ posts, comments }) => {
   const unapprovedContents = [...posts, ...comments].filter(isUnapproved);
-  return unapprovedContents.length >= 1 && !unapprovedContents.some(c => getLlmScore(c) > LLM_SCORE_HIGHLIGHT_THRESHOLD);
+  if (unapprovedContents.length === 0) return null;
+  if (unapprovedContents.some(c => getLlmScore(c) > LLM_SCORE_HIGHLIGHT_THRESHOLD)) return null;
+  const allContentsEvaluatedAsHuman = unapprovedContents.every(c => c.automatedContentEvaluations?.pangramScore != null);
+  return allContentsEvaluatedAsHuman ? 2 : 1;
 };
 
 const ACTION_HIGHLIGHT_RULES: Record<HighlightableModeratorAction, ActionHighlightRule> = {
-  approve: (ctx) => hasOnlyLowLlmScoreUnapprovedContent(ctx) ? 2 : null,
-  snoozeCustom: (ctx) => hasOnlyLowLlmScoreUnapprovedContent(ctx) ? 2 : null,
-  approveCurrentOnly: (ctx) => hasOnlyLowLlmScoreUnapprovedContent(ctx) ? 2 : null,
-  // Everything the user has submitted has already been either approved or rejected
+  approve: approveHighlightLevel,
+  snoozeCustom: approveHighlightLevel,
+  approveCurrentOnly: approveHighlightLevel,
+  // Everything the user has submitted has already been either approved or rejected.
+  // Level 2 when that's the result of actual rejections rather than just having no pending content.
   remove: ({ posts, comments }) => {
     const allContents = [...posts, ...comments];
-    return !allContents.some(isUnapproved) ? 2 : null;
+    if (allContents.some(isUnapproved)) return null;
+    const rejectedContents = allContents.filter(c => c.rejected);
+    return rejectedContents.length >= 1 ? 2 : 1;
   },
-  // The user has no approved content
+  // The user has no approved content. Level 2 when multiple contents were actually rejected.
   purge: ({ posts, comments }) => {
     const allContents = [...posts, ...comments];
-    return !allContents.some(c => !c.rejected && !c.authorIsUnreviewed) ? 2 : null;
+    if (allContents.some(c => !c.rejected && !c.authorIsUnreviewed)) return null;
+    const rejectedContents = allContents.filter(c => c.rejected);
+    return rejectedContents.length >= 2 ? 2 : 1;
   },
-  // The user has at least two rejected contents, or their most recent content is rejected.
-  // (The button toggles to "Enable Permissions" once everything is disabled, so don't suggest it then.)
+  // Level 2 when the user has at least two rejected contents; level 1 when just their most
+  // recent content is rejected. (The button toggles to "Enable Permissions" once everything
+  // is disabled, so don't suggest it then.)
   disablePermissions: ({ user, posts, comments }) => {
     if (areAllContentPermissionsDisabled(user)) return null;
     const allContents = [...posts, ...comments];
     const rejectedContents = allContents.filter(c => c.rejected);
     if (rejectedContents.length >= 2) return 2;
     const mostRecentContent = maxBy(allContents, c => new Date(c.postedAt).getTime());
-    return mostRecentContent?.rejected ? 2 : null;
+    return mostRecentContent?.rejected ? 1 : null;
   },
-  // Same trigger as the "Lotsa DMs" message template
+  // Same trigger as the "Lotsa DMs" message template; the flag itself is particular evidence.
   disableMessages: ({ user, moderatorActions }) => {
     if (user.conversationsDisabled) return null;
     const flaggedForDMs = moderatorActions.some(a => a.active && (a.type === FLAGGED_FOR_N_DMS || a.type === AUTO_BLOCKED_FROM_SENDING_DMS));

--- a/packages/lesswrong/lib/collections/users/newSchema.ts
+++ b/packages/lesswrong/lib/collections/users/newSchema.ts
@@ -94,6 +94,26 @@ const getLastRemovedFromReviewQueueAt = async (context: ResolverContext, userId:
   return fieldChanges[0]?.createdAt ?? null;
 };
 
+export const getUserReviewGroup = async (context: ResolverContext, user: DbUser): Promise<ReviewGroup> => {
+  const [moderatorActions, lastRemovedFromReviewQueueAt] = await Promise.all([
+    getModeratorActionsForUser(context, user._id),
+    getLastRemovedFromReviewQueueAt(context, user._id),
+  ]);
+
+  const actionsWithActiveStatus = moderatorActions.map(action => ({
+    type: action.type,
+    active: isActionActive(action),
+    createdAt: action.createdAt,
+  }));
+  const baseGroup = getReviewGroupFromActions(actionsWithActiveStatus, lastRemovedFromReviewQueueAt);
+
+  if (baseGroup === 'newContent' && await getIsOffboardCandidate(context, user)) {
+    return 'offboard';
+  }
+
+  return baseGroup;
+};
+
 ///////////////////////////////////////
 // Order for the Schema is as follows. Change as you see fit:
 // 00.
@@ -3989,23 +4009,7 @@ const schema = {
       outputType: "ReviewGroup",
       canRead: ["sunshineRegiment", "admins"],
       resolver: async (doc, args, context) => {
-        const [moderatorActions, lastRemovedFromReviewQueueAt] = await Promise.all([
-          getModeratorActionsForUser(context, doc._id),
-          getLastRemovedFromReviewQueueAt(context, doc._id),
-        ]);
-
-        const actionsWithActiveStatus = moderatorActions.map(action => ({
-          type: action.type,
-          active: isActionActive(action),
-          createdAt: action.createdAt,
-        }));
-        const baseGroup = getReviewGroupFromActions(actionsWithActiveStatus, lastRemovedFromReviewQueueAt);
-
-        if (baseGroup === 'newContent' && await getIsOffboardCandidate(context, doc)) {
-          return 'offboard';
-        }
-
-        return baseGroup;
+        return await getUserReviewGroup(context, doc);
       },
     },
   },

--- a/packages/lesswrong/server/collections/automatedContentEvaluations/helpers.ts
+++ b/packages/lesswrong/server/collections/automatedContentEvaluations/helpers.ts
@@ -323,8 +323,10 @@ export async function rerunLlmCheck(
   // Run the Pangram evaluation - errors will propagate to the client with descriptive messages
   const pangramResult = await getPangramEvaluation(revision);
 
-  // Check if there's an existing ACE record for this revision
-  const existingAce = await AutomatedContentEvaluations.findOne({ revisionId: revision._id });
+  // Check if there's an existing ACE record for this revision. There's no
+  // unique index on revisionId, so take the newest record — readers that
+  // display evaluations resolve multiple records the same way.
+  const existingAce = await AutomatedContentEvaluations.findOne({ revisionId: revision._id }, { sort: { createdAt: -1 } });
 
   if (existingAce) {
     // Update the existing record with the new Pangram results

--- a/scripts/runSimplemod.sh
+++ b/scripts/runSimplemod.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+set -euo pipefail
+
+# Start the SimpleMod Next app on :3030 with a working PG_URL / ENV_NAME.
+# Worktrees don't share gitignored .env.local, so if this checkout doesn't
+# have one we reuse another worktree's or pull from Vercel.
+
+cd "$(dirname "$0")/.."
+
+ensure_env_local() {
+  if [[ -f .env.local ]]; then
+    return 0
+  fi
+
+  if [[ -d .vercel ]] && [[ "${SKIP_VERCEL_CODE_PULL:-}" != true ]]; then
+    echo "No .env.local — pulling from Vercel..."
+    if vercel env pull .env.local --yes --environment=development 2>/dev/null \
+      || vercel env pull .env.local --yes --environment=production; then
+      return 0
+    fi
+    echo "Vercel env pull failed."
+  fi
+
+  local worktree
+  while IFS= read -r worktree; do
+    if [[ -n "$worktree" && "$worktree" != "$PWD" && -f "$worktree/.env.local" ]]; then
+      echo "No .env.local — linking from $worktree"
+      ln -s "$worktree/.env.local" .env.local
+      return 0
+    fi
+  done < <(git worktree list --porcelain | awk '/^worktree / { print $2 }')
+
+  echo "No .env.local found."
+  echo "Fix: copy one from your main ForumMagnum checkout, or run:"
+  echo "  vercel link && vercel env pull .env.local"
+  exit 1
+}
+
+require_pg_url() {
+  if ! grep -qE '^PG_URL=.+' .env.local; then
+    echo ".env.local exists but PG_URL is missing or empty."
+    exit 1
+  fi
+}
+
+ensure_env_local
+require_pg_url
+
+echo "Starting SimpleMod on http://localhost:3030"
+exec node --no-deprecation ./node_modules/.bin/next dev simplemod --turbopack -p 3030 "$@"

--- a/simplemod/app/api/actions/approve-and-dm/route.ts
+++ b/simplemod/app/api/actions/approve-and-dm/route.ts
@@ -1,0 +1,14 @@
+import type { NextRequest } from 'next/server';
+import { handleActionRequest, requireCollectionName, requireString } from '../../../../src/server/actionRoute';
+import { approveItemAndDm } from '../../../../src/server/actions';
+
+export const dynamic = 'force-dynamic';
+
+export async function POST(req: NextRequest) {
+  return handleActionRequest(req, ({ context, moderator }, body) => approveItemAndDm(context, moderator, {
+    userId: requireString(body, 'userId'),
+    collectionName: requireCollectionName(body),
+    documentId: requireString(body, 'documentId'),
+    messageHtml: requireString(body, 'messageHtml'),
+  }));
+}

--- a/simplemod/app/api/actions/approve-user/route.ts
+++ b/simplemod/app/api/actions/approve-user/route.ts
@@ -1,0 +1,11 @@
+import type { NextRequest } from 'next/server';
+import { handleActionRequest, requireString } from '../../../../src/server/actionRoute';
+import { approveUser } from '../../../../src/server/actions';
+
+export const dynamic = 'force-dynamic';
+
+export async function POST(req: NextRequest) {
+  return handleActionRequest(req, ({ context, moderator }, body) =>
+    approveUser(context, moderator, requireString(body, 'userId'))
+  );
+}

--- a/simplemod/app/api/actions/approve/route.ts
+++ b/simplemod/app/api/actions/approve/route.ts
@@ -1,0 +1,13 @@
+import type { NextRequest } from 'next/server';
+import { handleActionRequest, requireCollectionName, requireString } from '../../../../src/server/actionRoute';
+import { approveItem } from '../../../../src/server/actions';
+
+export const dynamic = 'force-dynamic';
+
+export async function POST(req: NextRequest) {
+  return handleActionRequest(req, ({ context, moderator }, body) => approveItem(context, moderator, {
+    userId: requireString(body, 'userId'),
+    collectionName: requireCollectionName(body),
+    documentId: requireString(body, 'documentId'),
+  }));
+}

--- a/simplemod/app/api/actions/offboard/route.ts
+++ b/simplemod/app/api/actions/offboard/route.ts
@@ -1,0 +1,46 @@
+import type { NextRequest } from 'next/server';
+import { handleActionRequest, requireString } from '../../../../src/server/actionRoute';
+import { offboardUser } from '../../../../src/server/actions';
+import type { ReviewCollectionName } from '../../../../src/lib/types';
+
+export const dynamic = 'force-dynamic';
+
+interface RejectionInput {
+  collectionName: ReviewCollectionName;
+  documentId: string;
+  rejectedReason: string;
+}
+
+function parseRejections(value: unknown): RejectionInput[] {
+  if (value === undefined || value === null) {
+    return [];
+  }
+  if (!Array.isArray(value)) {
+    throw new Error('rejections must be an array');
+  }
+  return value.map((entry: unknown) => {
+    if (!entry || typeof entry !== 'object') {
+      throw new Error('Each rejection must be an object');
+    }
+    const { collectionName, documentId, rejectedReason } = entry as Record<string, unknown>;
+    if (collectionName !== 'Posts' && collectionName !== 'Comments') {
+      throw new Error('rejection collectionName must be Posts or Comments');
+    }
+    if (typeof documentId !== 'string' || !documentId) {
+      throw new Error('rejection documentId is required');
+    }
+    if (typeof rejectedReason !== 'string' || !rejectedReason) {
+      throw new Error('rejection rejectedReason is required');
+    }
+    return { collectionName, documentId, rejectedReason };
+  });
+}
+
+export async function POST(req: NextRequest) {
+  return handleActionRequest(req, ({ context, moderator }, body) => offboardUser(context, moderator, {
+    userId: requireString(body, 'userId'),
+    rejections: parseRejections(body.rejections),
+    removePermissions: body.removePermissions === true,
+    messageHtml: typeof body.messageHtml === 'string' && body.messageHtml ? body.messageHtml : undefined,
+  }));
+}

--- a/simplemod/app/api/actions/offboard/route.ts
+++ b/simplemod/app/api/actions/offboard/route.ts
@@ -1,5 +1,5 @@
 import type { NextRequest } from 'next/server';
-import { handleActionRequest, requireString } from '../../../../src/server/actionRoute';
+import { handleActionRequest, requireString, ValidationError } from '../../../../src/server/actionRoute';
 import { offboardUser } from '../../../../src/server/actions';
 import type { ReviewCollectionName } from '../../../../src/lib/types';
 
@@ -16,21 +16,21 @@ function parseRejections(value: unknown): RejectionInput[] {
     return [];
   }
   if (!Array.isArray(value)) {
-    throw new Error('rejections must be an array');
+    throw new ValidationError('rejections must be an array');
   }
   return value.map((entry: unknown) => {
     if (!entry || typeof entry !== 'object') {
-      throw new Error('Each rejection must be an object');
+      throw new ValidationError('Each rejection must be an object');
     }
     const { collectionName, documentId, rejectedReason } = entry as Record<string, unknown>;
     if (collectionName !== 'Posts' && collectionName !== 'Comments') {
-      throw new Error('rejection collectionName must be Posts or Comments');
+      throw new ValidationError('rejection collectionName must be Posts or Comments');
     }
     if (typeof documentId !== 'string' || !documentId) {
-      throw new Error('rejection documentId is required');
+      throw new ValidationError('rejection documentId is required');
     }
     if (typeof rejectedReason !== 'string' || !rejectedReason) {
-      throw new Error('rejection rejectedReason is required');
+      throw new ValidationError('rejection rejectedReason is required');
     }
     return { collectionName, documentId, rejectedReason };
   });

--- a/simplemod/app/api/actions/reject/route.ts
+++ b/simplemod/app/api/actions/reject/route.ts
@@ -1,0 +1,14 @@
+import type { NextRequest } from 'next/server';
+import { handleActionRequest, requireCollectionName, requireString } from '../../../../src/server/actionRoute';
+import { rejectItem } from '../../../../src/server/actions';
+
+export const dynamic = 'force-dynamic';
+
+export async function POST(req: NextRequest) {
+  return handleActionRequest(req, ({ context, moderator }, body) => rejectItem(context, moderator, {
+    userId: requireString(body, 'userId'),
+    collectionName: requireCollectionName(body),
+    documentId: requireString(body, 'documentId'),
+    rejectedReason: requireString(body, 'rejectedReason'),
+  }));
+}

--- a/simplemod/app/api/actions/run-check/route.ts
+++ b/simplemod/app/api/actions/run-check/route.ts
@@ -1,0 +1,44 @@
+import type { NextRequest } from 'next/server';
+import { rerunLlmCheck } from '@/server/collections/automatedContentEvaluations/helpers';
+import { handleActionRequest, requireCollectionName, requireString } from '../../../../src/server/actionRoute';
+import type { RunCheckResponse } from '../../../../src/lib/types';
+
+export const dynamic = 'force-dynamic';
+
+function toRunCheckResponse(ace: DbAutomatedContentEvaluation, alreadyExisted: boolean): RunCheckResponse {
+  return {
+    pangramScore: ace.pangramScore,
+    pangramFractionAi: ace.pangramFractionAi,
+    pangramPrediction: ace.pangramPrediction,
+    pangramWindowScores: ace.pangramWindowScores,
+    alreadyExisted,
+  };
+}
+
+// Runs a Pangram evaluation only when the latest revision doesn't already have
+// one — existing scores are never re-rolled from SimpleMod.
+export async function POST(req: NextRequest) {
+  return handleActionRequest(req, async ({ context }, body) => {
+    const collectionName = requireCollectionName(body);
+    const documentId = requireString(body, 'documentId');
+
+    const document = collectionName === 'Posts'
+      ? await context.Posts.findOne(documentId)
+      : await context.Comments.findOne(documentId);
+    if (!document) {
+      throw new Error(`Invalid ${collectionName} ID`);
+    }
+    if (document.contents_latest) {
+      const existing = await context.AutomatedContentEvaluations.findOne(
+        { revisionId: document.contents_latest },
+        { sort: { createdAt: -1 } },
+      );
+      if (existing?.pangramScore !== null && existing?.pangramScore !== undefined) {
+        return toRunCheckResponse(existing, true);
+      }
+    }
+
+    const ace = await rerunLlmCheck(documentId, collectionName, context);
+    return toRunCheckResponse(ace, false);
+  });
+}

--- a/simplemod/app/api/actions/skip/route.ts
+++ b/simplemod/app/api/actions/skip/route.ts
@@ -1,0 +1,11 @@
+import type { NextRequest } from 'next/server';
+import { handleActionRequest, requireString } from '../../../../src/server/actionRoute';
+import { skipUser } from '../../../../src/server/actions';
+
+export const dynamic = 'force-dynamic';
+
+export async function POST(req: NextRequest) {
+  return handleActionRequest(req, ({ context, moderator }, body) =>
+    skipUser(context, moderator, requireString(body, 'userId'))
+  );
+}

--- a/simplemod/app/api/health/route.ts
+++ b/simplemod/app/api/health/route.ts
@@ -1,0 +1,18 @@
+import { NextResponse } from 'next/server';
+import Users from '@/server/collections/users/collection';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
+  const health: { collectionLoaded: string; database: string } = {
+    collectionLoaded: Users.collectionName,
+    database: 'unavailable',
+  };
+  try {
+    const user = await Users.findOne({});
+    health.database = user ? 'connected' : 'connected (empty)';
+  } catch (error) {
+    health.database = `unavailable: ${error instanceof Error ? error.message : String(error)}`;
+  }
+  return NextResponse.json(health);
+}

--- a/simplemod/app/api/health/route.ts
+++ b/simplemod/app/api/health/route.ts
@@ -4,15 +4,12 @@ import Users from '@/server/collections/users/collection';
 export const dynamic = 'force-dynamic';
 
 export async function GET() {
-  const health: { collectionLoaded: string; database: string } = {
-    collectionLoaded: Users.collectionName,
-    database: 'unavailable',
-  };
   try {
-    const user = await Users.findOne({});
-    health.database = user ? 'connected' : 'connected (empty)';
+    await Users.findOne({});
+    return NextResponse.json({ ok: true });
   } catch (error) {
-    health.database = `unavailable: ${error instanceof Error ? error.message : String(error)}`;
+    // eslint-disable-next-line no-console
+    console.error('SimpleMod health check failed:', error);
+    return NextResponse.json({ ok: false }, { status: 503 });
   }
-  return NextResponse.json(health);
 }

--- a/simplemod/app/api/queue/route.ts
+++ b/simplemod/app/api/queue/route.ts
@@ -6,15 +6,29 @@ import type { QueueResponse } from '../../../src/lib/types';
 
 export const dynamic = 'force-dynamic';
 
+const QUICK_USER_LIMIT = 20;
+const QUICK_CARD_LIMIT = 3;
+
 export async function GET(req: NextRequest) {
   const session = await getModeratorSession(req);
   if (isErrorResponse(session)) {
     return session;
   }
-  const cards = await computeQueue(session.context);
-  const response: QueueResponse = {
-    cards,
-    moderator: { _id: session.moderator._id, displayName: session.moderator.displayName ?? '' },
-  };
-  return NextResponse.json(response);
+  const quick = req.nextUrl.searchParams.get('quick') === '1';
+  try {
+    const cards = await computeQueue(
+      session.context,
+      quick ? { userLimit: QUICK_USER_LIMIT, cardLimit: QUICK_CARD_LIMIT } : {},
+    );
+    const response: QueueResponse = {
+      cards,
+      moderator: { _id: session.moderator._id, displayName: session.moderator.displayName ?? '' },
+    };
+    return NextResponse.json(response);
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error('SimpleMod queue computation failed:', error);
+    const message = error instanceof Error ? error.message : String(error);
+    return NextResponse.json({ error: `Queue computation failed: ${message}` }, { status: 500 });
+  }
 }

--- a/simplemod/app/api/queue/route.ts
+++ b/simplemod/app/api/queue/route.ts
@@ -1,0 +1,20 @@
+import type { NextRequest } from 'next/server';
+import { NextResponse } from 'next/server';
+import { getModeratorSession, isErrorResponse } from '../../../src/server/fmAuth';
+import { computeQueue } from '../../../src/server/queue';
+import type { QueueResponse } from '../../../src/lib/types';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(req: NextRequest) {
+  const session = await getModeratorSession(req);
+  if (isErrorResponse(session)) {
+    return session;
+  }
+  const cards = await computeQueue(session.context);
+  const response: QueueResponse = {
+    cards,
+    moderator: { _id: session.moderator._id, displayName: session.moderator.displayName ?? '' },
+  };
+  return NextResponse.json(response);
+}

--- a/simplemod/app/api/session/route.ts
+++ b/simplemod/app/api/session/route.ts
@@ -22,6 +22,7 @@ export async function POST(req: NextRequest) {
   response.cookies.set('loginToken', loginToken, {
     httpOnly: true,
     sameSite: 'lax',
+    secure: process.env.NODE_ENV === 'production',
     maxAge: 60 * 60 * 24 * 90,
   });
   return response;

--- a/simplemod/app/api/session/route.ts
+++ b/simplemod/app/api/session/route.ts
@@ -1,0 +1,34 @@
+import type { NextRequest } from 'next/server';
+import { NextResponse } from 'next/server';
+import { getUser } from '@/server/vulcan-lib/apollo-server/getUserFromReq';
+import { userIsAdminOrMod } from '@/lib/vulcan-users/permissions';
+
+export const dynamic = 'force-dynamic';
+
+export async function POST(req: NextRequest) {
+  const body = await req.json().catch(() => null);
+  const loginToken = body?.loginToken;
+  if (typeof loginToken !== 'string' || !loginToken) {
+    return NextResponse.json({ error: 'loginToken is required' }, { status: 400 });
+  }
+  const user = await getUser(loginToken);
+  if (!user) {
+    return NextResponse.json({ error: 'Invalid login token' }, { status: 401 });
+  }
+  if (!userIsAdminOrMod(user)) {
+    return NextResponse.json({ error: 'Not a moderator' }, { status: 403 });
+  }
+  const response = NextResponse.json({ displayName: user.displayName });
+  response.cookies.set('loginToken', loginToken, {
+    httpOnly: true,
+    sameSite: 'lax',
+    maxAge: 60 * 60 * 24 * 90,
+  });
+  return response;
+}
+
+export async function DELETE() {
+  const response = NextResponse.json({ ok: true });
+  response.cookies.delete('loginToken');
+  return response;
+}

--- a/simplemod/app/api/templates/route.ts
+++ b/simplemod/app/api/templates/route.ts
@@ -1,0 +1,29 @@
+import type { NextRequest } from 'next/server';
+import { NextResponse } from 'next/server';
+import { getSqlClientOrThrow } from '@/server/sql/sqlClient';
+import { standardRejectionIntroHtml } from '@/lib/collections/moderationTemplates/rejectionIntro';
+import { getModeratorSession, isErrorResponse } from '../../../src/server/fmAuth';
+import type { ModerationTemplateData } from '../../../src/lib/types';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(req: NextRequest) {
+  const session = await getModeratorSession(req);
+  if (isErrorResponse(session)) {
+    return session;
+  }
+  const collectionName = req.nextUrl.searchParams.get('collection');
+  if (collectionName !== 'Rejections' && collectionName !== 'Messages') {
+    return NextResponse.json({ error: 'collection must be Rejections or Messages' }, { status: 400 });
+  }
+  const db = getSqlClientOrThrow();
+  const templates = await db.any<ModerationTemplateData>(`
+    SELECT t."_id", t."name", t."collectionName", r."html"
+    FROM "ModerationTemplates" t
+    LEFT JOIN "Revisions" r ON r."_id" = t."contents_latest"
+    WHERE t."collectionName" = $(collectionName)
+      AND t."deleted" IS NOT TRUE
+    ORDER BY t."order" ASC, t."name" ASC
+  `, { collectionName });
+  return NextResponse.json({ templates, rejectionIntroHtml: standardRejectionIntroHtml });
+}

--- a/simplemod/app/api/user-context/route.ts
+++ b/simplemod/app/api/user-context/route.ts
@@ -1,0 +1,22 @@
+import type { NextRequest } from 'next/server';
+import { NextResponse } from 'next/server';
+import { getModeratorSession, isErrorResponse } from '../../../src/server/fmAuth';
+import { getUserContentHistory } from '../../../src/server/userContext';
+import type { UserContextResponse } from '../../../src/lib/types';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(req: NextRequest) {
+  const session = await getModeratorSession(req);
+  if (isErrorResponse(session)) {
+    return session;
+  }
+  const userId = req.nextUrl.searchParams.get('userId');
+  if (!userId) {
+    return NextResponse.json({ error: 'userId is required' }, { status: 400 });
+  }
+  const response: UserContextResponse = {
+    items: await getUserContentHistory(userId),
+  };
+  return NextResponse.json(response);
+}

--- a/simplemod/app/globals.css
+++ b/simplemod/app/globals.css
@@ -1,19 +1,43 @@
 :root {
+  color-scheme: light dark;
   --bg: #f2f0ec;
   --card-bg: #ffffff;
   --text: #1a1a1a;
   --text-muted: #6b6b6b;
   --border: #e0ddd6;
+  --soft-bg: rgba(0, 0, 0, 0.04);
   --approve: #2e7d32;
   --approve-bg: #e8f5e9;
   --reject: #c62828;
   --reject-bg: #ffebee;
-  --dm: #1565c0;
-  --dm-bg: #e3f2fd;
   --accent: #5f4bb6;
+  --accent-soft: rgba(95, 75, 182, 0.08);
   --gold: #b8860b;
+  --stamp-bg: rgba(255, 255, 255, 0.85);
+  --overlay-bg: rgba(0, 0, 0, 0.35);
   --shadow: 0 2px 8px rgba(0, 0, 0, 0.08), 0 8px 32px rgba(0, 0, 0, 0.06);
   --font-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #19191c;
+    --card-bg: #242429;
+    --text: #e8e6e1;
+    --text-muted: #a1a09a;
+    --border: #3a3a41;
+    --soft-bg: rgba(255, 255, 255, 0.06);
+    --approve: #66bb6a;
+    --approve-bg: rgba(102, 187, 106, 0.14);
+    --reject: #ef5350;
+    --reject-bg: rgba(239, 83, 80, 0.14);
+    --accent: #9d8cff;
+    --accent-soft: rgba(157, 140, 255, 0.14);
+    --gold: #d4a634;
+    --stamp-bg: rgba(36, 36, 41, 0.85);
+    --overlay-bg: rgba(0, 0, 0, 0.6);
+    --shadow: 0 2px 8px rgba(0, 0, 0, 0.4), 0 8px 32px rgba(0, 0, 0, 0.3);
+  }
 }
 
 * {
@@ -42,7 +66,7 @@ kbd {
   font-size: 11px;
   font-family: inherit;
   color: var(--text-muted);
-  background: rgba(0, 0, 0, 0.05);
+  background: var(--soft-bg);
   border: 1px solid var(--border);
   border-radius: 4px;
 }
@@ -127,6 +151,37 @@ kbd {
   cursor: grabbing;
 }
 
+.swipe-card-busy {
+  opacity: 0.75;
+  transition: opacity 0.15s;
+}
+
+.skeleton-card {
+  position: absolute;
+  inset: 8px 0 16px;
+  background: var(--card-bg);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  box-shadow: var(--shadow);
+  padding: 22px 26px;
+}
+
+.skeleton-line {
+  height: 14px;
+  margin-bottom: 14px;
+  border-radius: 7px;
+  background: var(--soft-bg);
+  animation: skeleton-pulse 1.4s ease-in-out infinite;
+}
+
+.skeleton-line-wide { width: 60%; height: 22px; }
+.skeleton-line-half { width: 40%; }
+
+@keyframes skeleton-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.45; }
+}
+
 .swipe-stamp {
   position: absolute;
   top: 28px;
@@ -137,7 +192,7 @@ kbd {
   letter-spacing: 0.06em;
   border: 4px solid;
   border-radius: 8px;
-  background: rgba(255, 255, 255, 0.85);
+  background: var(--stamp-bg);
   pointer-events: none;
 }
 
@@ -204,7 +259,7 @@ kbd {
   padding: 1px 8px;
   font-size: 12px;
   border-radius: 10px;
-  background: rgba(0, 0, 0, 0.05);
+  background: var(--soft-bg);
   color: var(--text-muted);
 }
 
@@ -259,11 +314,42 @@ kbd {
   max-width: 100%;
 }
 
+.content-html a {
+  color: var(--accent);
+}
+
+.content-html blockquote {
+  margin: 8px 0;
+  padding: 2px 14px;
+  border-left: 3px solid var(--border);
+  color: var(--text-muted);
+}
+
+.content-html pre {
+  overflow-x: auto;
+  padding: 10px 12px;
+  background: var(--soft-bg);
+  border-radius: 8px;
+  font-size: 13px;
+}
+
+.content-html code {
+  background: var(--soft-bg);
+  padding: 1px 4px;
+  border-radius: 4px;
+  font-size: 13px;
+}
+
+.content-html pre code {
+  background: none;
+  padding: 0;
+}
+
 .content-html-compact {
   max-height: 120px;
   overflow-y: auto;
   padding: 8px 12px;
-  background: rgba(0, 0, 0, 0.03);
+  background: var(--soft-bg);
   border-radius: 8px;
 }
 
@@ -283,7 +369,7 @@ kbd {
   font-size: 12px;
   font-family: inherit;
   white-space: pre-wrap;
-  background: rgba(0, 0, 0, 0.03);
+  background: var(--soft-bg);
   border-radius: 8px;
 }
 
@@ -374,7 +460,7 @@ kbd {
   display: flex;
   align-items: center;
   justify-content: center;
-  background: rgba(0, 0, 0, 0.35);
+  background: var(--overlay-bg);
 }
 
 .composer {
@@ -397,7 +483,7 @@ kbd {
   margin-bottom: 6px;
   font-size: 13px;
   color: var(--text-muted);
-  background: rgba(0, 0, 0, 0.03);
+  background: var(--soft-bg);
   border-radius: 8px;
 }
 
@@ -427,7 +513,7 @@ kbd {
 
 .template-chip-selected {
   border-color: var(--accent);
-  background: rgba(95, 75, 182, 0.08);
+  background: var(--accent-soft);
   color: var(--accent);
   font-weight: 600;
 }
@@ -490,7 +576,7 @@ kbd {
 }
 
 .button-secondary {
-  background: rgba(0, 0, 0, 0.06);
+  background: var(--soft-bg);
   color: var(--text);
 }
 
@@ -538,4 +624,37 @@ kbd {
 
 .queue-done {
   z-index: 1;
+}
+
+/* ---- Small screens ---- */
+
+@media (max-width: 640px) {
+  .queue-hud {
+    flex-wrap: wrap;
+    gap: 10px;
+    padding-top: 10px;
+  }
+
+  .card-body {
+    padding: 16px 16px 20px;
+  }
+
+  .content-title {
+    font-size: 19px;
+  }
+
+  .swipe-stamp {
+    top: 16px;
+    font-size: 18px;
+    border-width: 3px;
+  }
+
+  .hotkey-legend {
+    display: none;
+  }
+
+  .composer {
+    padding: 16px;
+    max-height: 92vh;
+  }
 }

--- a/simplemod/app/globals.css
+++ b/simplemod/app/globals.css
@@ -112,12 +112,178 @@ kbd {
   font-size: 13px;
 }
 
+/* ---- Stage row & context panel ---- */
+
+.stage-row {
+  display: flex;
+  justify-content: center;
+  gap: 18px;
+  flex: 1;
+  min-height: 0;
+  width: min(720px, 94vw);
+}
+
+.stage-row-with-panel {
+  width: min(1120px, 96vw);
+}
+
+.context-panel {
+  width: 380px;
+  flex-shrink: 0;
+  min-height: 0;
+  overflow-y: auto;
+  margin: 8px 0 16px;
+  padding: 16px 18px;
+  background: var(--card-bg);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  box-shadow: var(--shadow);
+}
+
+.context-panel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 6px;
+}
+
+.context-panel-title {
+  font-weight: 700;
+  font-size: 16px;
+}
+
+.context-panel-close {
+  border: none;
+  background: none;
+  color: var(--text-muted);
+  cursor: pointer;
+  font-size: 14px;
+  padding: 4px;
+}
+
+.context-bio {
+  font-size: 13px;
+  max-height: 180px;
+  overflow-y: auto;
+}
+
+.context-panel-loading,
+.context-panel-error {
+  color: var(--text-muted);
+  font-size: 13px;
+  padding: 6px 0;
+}
+
+.context-panel-error {
+  color: var(--reject);
+}
+
+.context-item {
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  margin-bottom: 8px;
+  overflow: hidden;
+}
+
+.context-item-current {
+  border-color: var(--gold);
+}
+
+.context-item-header {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  width: 100%;
+  padding: 8px 10px;
+  border: none;
+  background: none;
+  color: var(--text);
+  text-align: left;
+  cursor: pointer;
+  font-size: 13px;
+  font-family: inherit;
+}
+
+.context-item-header:hover {
+  background: var(--soft-bg);
+}
+
+.context-item-title {
+  font-weight: 600;
+  line-height: 1.35;
+}
+
+.context-item-meta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  color: var(--text-muted);
+  font-size: 12px;
+}
+
+.context-item-body {
+  padding: 10px 12px;
+  border-top: 1px solid var(--border);
+  font-size: 13px;
+  max-height: 340px;
+  overflow-y: auto;
+}
+
+.chip-status-rejected {
+  background: var(--reject-bg);
+  color: var(--reject);
+}
+
+.chip-status-approved {
+  background: var(--approve-bg);
+  color: var(--approve);
+}
+
+.chip-status-draft {
+  background: var(--soft-bg);
+  color: var(--text-muted);
+}
+
+.chip-status-unreviewed {
+  background: var(--accent-soft);
+  color: var(--accent);
+}
+
+.chip-current {
+  background: var(--gold);
+  color: var(--card-bg);
+  font-weight: 700;
+}
+
+.hud-context-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  border: 1px solid var(--border);
+  background: none;
+  color: var(--text-muted);
+  border-radius: 6px;
+  padding: 3px 10px;
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.hud-context-toggle:hover {
+  background: var(--soft-bg);
+}
+
+.check-indicator {
+  color: var(--text-muted);
+  font-style: italic;
+}
+
 /* ---- Card stage ---- */
 
 .card-stage {
   position: relative;
   flex: 1;
-  width: min(720px, 94vw);
+  min-width: 0;
   min-height: 0;
   display: flex;
   align-items: stretch;
@@ -627,6 +793,21 @@ kbd {
 }
 
 /* ---- Small screens ---- */
+
+@media (max-width: 900px) {
+  .stage-row-with-panel {
+    width: min(720px, 94vw);
+  }
+
+  .context-panel {
+    position: fixed;
+    inset: 0 25% 0 0;
+    min-width: 300px;
+    z-index: 9;
+    margin: 0;
+    border-radius: 0 16px 16px 0;
+  }
+}
 
 @media (max-width: 640px) {
   .queue-hud {

--- a/simplemod/app/globals.css
+++ b/simplemod/app/globals.css
@@ -1,0 +1,541 @@
+:root {
+  --bg: #f2f0ec;
+  --card-bg: #ffffff;
+  --text: #1a1a1a;
+  --text-muted: #6b6b6b;
+  --border: #e0ddd6;
+  --approve: #2e7d32;
+  --approve-bg: #e8f5e9;
+  --reject: #c62828;
+  --reject-bg: #ffebee;
+  --dm: #1565c0;
+  --dm-bg: #e3f2fd;
+  --accent: #5f4bb6;
+  --gold: #b8860b;
+  --shadow: 0 2px 8px rgba(0, 0, 0, 0.08), 0 8px 32px rgba(0, 0, 0, 0.06);
+  --font-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  padding: 0;
+  height: 100%;
+  background: var(--bg);
+  color: var(--text);
+  font-family: var(--font-sans);
+  font-size: 15px;
+  line-height: 1.5;
+}
+
+button {
+  font-family: inherit;
+}
+
+kbd {
+  display: inline-block;
+  padding: 1px 6px;
+  font-size: 11px;
+  font-family: inherit;
+  color: var(--text-muted);
+  background: rgba(0, 0, 0, 0.05);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+}
+
+/* ---- Shell & HUD ---- */
+
+.queue-shell {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  height: 100vh;
+  overflow: hidden;
+}
+
+.queue-hud {
+  display: flex;
+  align-items: baseline;
+  gap: 20px;
+  width: min(720px, 94vw);
+  padding: 14px 4px 10px;
+}
+
+.queue-hud-title {
+  font-weight: 700;
+  font-size: 17px;
+  letter-spacing: 0.02em;
+}
+
+.queue-hud-counts {
+  display: flex;
+  gap: 14px;
+  color: var(--text-muted);
+  font-size: 13px;
+}
+
+.hud-offboard {
+  color: var(--reject);
+}
+
+.queue-hud-moderator {
+  margin-left: auto;
+  color: var(--text-muted);
+  font-size: 13px;
+}
+
+/* ---- Card stage ---- */
+
+.card-stage {
+  position: relative;
+  flex: 1;
+  width: min(720px, 94vw);
+  min-height: 0;
+  display: flex;
+  align-items: stretch;
+  justify-content: center;
+  padding-bottom: 8px;
+}
+
+.peek-card {
+  position: absolute;
+  inset: 8px 0 16px;
+  background: var(--card-bg);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  box-shadow: var(--shadow);
+}
+
+.swipe-card {
+  position: absolute;
+  inset: 8px 0 16px;
+  display: flex;
+  flex-direction: column;
+  background: var(--card-bg);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  box-shadow: var(--shadow);
+  cursor: grab;
+  overflow: hidden;
+}
+
+.swipe-card:active {
+  cursor: grabbing;
+}
+
+.swipe-stamp {
+  position: absolute;
+  top: 28px;
+  z-index: 2;
+  padding: 6px 14px;
+  font-size: 24px;
+  font-weight: 800;
+  letter-spacing: 0.06em;
+  border: 4px solid;
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.85);
+  pointer-events: none;
+}
+
+.swipe-stamp-right {
+  left: 24px;
+  color: var(--approve);
+  border-color: var(--approve);
+  transform: rotate(-12deg);
+}
+
+.swipe-stamp-left {
+  right: 24px;
+  color: var(--reject);
+  border-color: var(--reject);
+  transform: rotate(12deg);
+}
+
+.card-body {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 22px 26px 26px;
+}
+
+/* ---- User header ---- */
+
+.user-header {
+  margin-bottom: 12px;
+  padding-bottom: 12px;
+  border-bottom: 1px solid var(--border);
+}
+
+.user-header-main {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.user-name {
+  font-size: 18px;
+  font-weight: 700;
+}
+
+.user-header-stats {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-top: 4px;
+  color: var(--text-muted);
+  font-size: 13px;
+}
+
+.user-header-subtitle {
+  color: var(--gold);
+  font-weight: 600;
+}
+
+/* ---- Chips ---- */
+
+.chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 1px 8px;
+  font-size: 12px;
+  border-radius: 10px;
+  background: rgba(0, 0, 0, 0.05);
+  color: var(--text-muted);
+}
+
+.chip-flagged {
+  background: var(--reject-bg);
+  color: var(--reject);
+}
+
+.chip-offboard {
+  background: var(--reject-bg);
+  color: var(--reject);
+  font-weight: 600;
+}
+
+.chip-ai-high {
+  background: var(--reject-bg);
+  color: var(--reject);
+  font-weight: 600;
+}
+
+/* ---- Content ---- */
+
+.content-meta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 10px;
+  color: var(--text-muted);
+  font-size: 13px;
+}
+
+.content-title {
+  margin: 4px 0 10px;
+  font-size: 22px;
+  line-height: 1.3;
+}
+
+.content-context {
+  margin-bottom: 10px;
+  color: var(--text-muted);
+  font-style: italic;
+}
+
+.content-html {
+  font-size: 15px;
+  line-height: 1.6;
+  overflow-wrap: break-word;
+}
+
+.content-html img {
+  max-width: 100%;
+}
+
+.content-html-compact {
+  max-height: 120px;
+  overflow-y: auto;
+  padding: 8px 12px;
+  background: rgba(0, 0, 0, 0.03);
+  border-radius: 8px;
+}
+
+.section-label {
+  margin: 18px 0 6px;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.mod-notes {
+  max-height: 160px;
+  overflow-y: auto;
+  padding: 10px 12px;
+  font-size: 12px;
+  font-family: inherit;
+  white-space: pre-wrap;
+  background: rgba(0, 0, 0, 0.03);
+  border-radius: 8px;
+}
+
+/* ---- Wrap-up card ---- */
+
+.wrapup-message h2 {
+  margin: 8px 0;
+}
+
+.wrapup-hint {
+  color: var(--text-muted);
+}
+
+/* ---- Offboard card ---- */
+
+.offboard-reason {
+  margin: 8px 0;
+  padding: 8px 12px;
+  background: var(--reject-bg);
+  color: var(--reject);
+  border-radius: 8px;
+  font-weight: 600;
+}
+
+.offboard-items {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.offboard-item {
+  display: flex;
+  gap: 10px;
+  padding: 10px 12px;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  cursor: pointer;
+}
+
+.offboard-item-selected {
+  border-color: var(--reject);
+  background: var(--reject-bg);
+}
+
+.offboard-item-info {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.offboard-item-title {
+  font-weight: 600;
+}
+
+.offboard-item-meta {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  color: var(--text-muted);
+  font-size: 12px;
+}
+
+.offboard-item-excerpt {
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  color: var(--text-muted);
+  font-size: 13px;
+}
+
+.offboard-permissions-toggle {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 14px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+/* ---- Composer ---- */
+
+.composer-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 10;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.35);
+}
+
+.composer {
+  width: min(640px, 92vw);
+  max-height: 86vh;
+  overflow-y: auto;
+  padding: 22px 26px;
+  background: var(--card-bg);
+  border-radius: 16px;
+  box-shadow: var(--shadow);
+}
+
+.composer-title {
+  margin: 0 0 10px;
+  font-size: 19px;
+}
+
+.composer-intro {
+  padding: 10px 14px;
+  margin-bottom: 6px;
+  font-size: 13px;
+  color: var(--text-muted);
+  background: rgba(0, 0, 0, 0.03);
+  border-radius: 8px;
+}
+
+.composer-intro p {
+  margin: 4px 0;
+}
+
+.composer-section {
+  margin-bottom: 8px;
+}
+
+.composer-templates {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+
+.template-chip {
+  padding: 5px 12px;
+  font-size: 13px;
+  background: var(--card-bg);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  cursor: pointer;
+}
+
+.template-chip-selected {
+  border-color: var(--accent);
+  background: rgba(95, 75, 182, 0.08);
+  color: var(--accent);
+  font-weight: 600;
+}
+
+.composer-textarea {
+  width: 100%;
+  min-height: 90px;
+  padding: 10px 12px;
+  font-family: inherit;
+  font-size: 14px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  resize: vertical;
+}
+
+.composer-loading,
+.composer-error {
+  padding: 12px 0;
+  color: var(--text-muted);
+}
+
+.composer-error {
+  color: var(--reject);
+}
+
+.composer-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+  margin-top: 12px;
+}
+
+/* ---- Buttons, toast, legend ---- */
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 16px;
+  font-size: 14px;
+  border: none;
+  border-radius: 8px;
+  cursor: pointer;
+}
+
+.button:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+.button-primary {
+  background: var(--accent);
+  color: white;
+}
+
+.button-primary kbd {
+  background: rgba(255, 255, 255, 0.2);
+  border-color: transparent;
+  color: white;
+}
+
+.button-secondary {
+  background: rgba(0, 0, 0, 0.06);
+  color: var(--text);
+}
+
+.toast {
+  position: fixed;
+  bottom: 68px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 20;
+  padding: 10px 18px;
+  background: var(--text);
+  color: var(--bg);
+  border-radius: 8px;
+  box-shadow: var(--shadow);
+}
+
+.hotkey-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 18px;
+  justify-content: center;
+  width: min(720px, 94vw);
+  padding: 10px 0 14px;
+  color: var(--text-muted);
+  font-size: 13px;
+}
+
+.hotkey-legend-entry {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+/* ---- Messages ---- */
+
+.queue-message {
+  margin: auto;
+  text-align: center;
+  color: var(--text-muted);
+}
+
+.queue-message h2 {
+  color: var(--text);
+}
+
+.queue-done {
+  z-index: 1;
+}

--- a/simplemod/app/globals.css
+++ b/simplemod/app/globals.css
@@ -78,6 +78,7 @@ kbd {
   flex-direction: column;
   align-items: center;
   height: 100vh;
+  height: 100dvh;
   overflow: hidden;
 }
 
@@ -376,11 +377,26 @@ kbd {
   transform: rotate(12deg);
 }
 
+.swipe-card-content {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 0;
+}
+
 .card-body {
   flex: 1;
   min-height: 0;
   overflow-y: auto;
   padding: 22px 26px 26px;
+  background:
+    linear-gradient(var(--card-bg) 30%, transparent),
+    linear-gradient(transparent, var(--card-bg) 70%) 0 100%,
+    radial-gradient(farthest-side at 50% 0, rgba(0, 0, 0, 0.18), transparent),
+    radial-gradient(farthest-side at 50% 100%, rgba(0, 0, 0, 0.18), transparent) 0 100%;
+  background-repeat: no-repeat;
+  background-size: 100% 44px, 100% 44px, 100% 16px, 100% 16px;
+  background-attachment: local, local, scroll, scroll;
 }
 
 /* ---- User header ---- */
@@ -400,6 +416,12 @@ kbd {
 .user-name {
   font-size: 18px;
   font-weight: 700;
+  color: var(--text);
+  text-decoration: none;
+}
+
+.user-name:hover {
+  text-decoration: underline;
 }
 
 .user-header-stats {
@@ -474,6 +496,55 @@ kbd {
   font-size: 15px;
   line-height: 1.6;
   overflow-wrap: break-word;
+}
+
+.content-html-reading {
+  max-width: 68ch;
+  font-size: 16px;
+}
+
+.external-link {
+  color: var(--text-muted);
+  font-size: 12px;
+  text-decoration: none;
+}
+
+.external-link:hover {
+  color: var(--accent);
+  text-decoration: underline;
+}
+
+.chip-pangram {
+  color: var(--text);
+  font-weight: 600;
+}
+
+.parent-comment {
+  margin-bottom: 10px;
+  border-left: 3px solid var(--border);
+  padding-left: 10px;
+}
+
+.parent-comment-toggle {
+  border: none;
+  background: none;
+  padding: 2px 0;
+  color: var(--text-muted);
+  font-size: 13px;
+  cursor: pointer;
+  font-family: inherit;
+}
+
+.parent-comment-toggle:hover {
+  color: var(--text);
+}
+
+.parent-comment-body {
+  font-size: 13px;
+  color: var(--text-muted);
+  max-height: 220px;
+  overflow-y: auto;
+  padding: 4px 0;
 }
 
 .content-html img {
@@ -642,6 +713,10 @@ kbd {
 .composer-title {
   margin: 0 0 10px;
   font-size: 19px;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
 }
 
 .composer-intro {
@@ -752,6 +827,9 @@ kbd {
   left: 50%;
   transform: translateX(-50%);
   z-index: 20;
+  display: flex;
+  align-items: center;
+  gap: 12px;
   padding: 10px 18px;
   background: var(--text);
   color: var(--bg);
@@ -759,13 +837,85 @@ kbd {
   box-shadow: var(--shadow);
 }
 
+.toast-error {
+  background: var(--reject);
+  color: #fff;
+}
+
+.toast-close {
+  border: none;
+  background: none;
+  color: inherit;
+  cursor: pointer;
+  font-size: 13px;
+  padding: 2px;
+}
+
+.pending-action {
+  position: fixed;
+  bottom: 68px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 20;
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 10px 18px;
+  background: var(--card-bg);
+  border: 1px solid var(--gold);
+  color: var(--text);
+  border-radius: 10px;
+  box-shadow: var(--shadow);
+}
+
+.action-flash {
+  position: absolute;
+  top: 44px;
+  z-index: 5;
+  padding: 8px 18px;
+  font-size: 26px;
+  font-weight: 800;
+  letter-spacing: 0.04em;
+  border: 4px solid;
+  border-radius: 10px;
+  background: var(--stamp-bg);
+  pointer-events: none;
+  animation: action-flash-fade 0.8s ease-out forwards;
+}
+
+.action-flash-right {
+  left: 28px;
+  color: var(--approve);
+  border-color: var(--approve);
+  transform: rotate(-10deg);
+}
+
+.action-flash-left {
+  right: 28px;
+  color: var(--reject);
+  border-color: var(--reject);
+  transform: rotate(10deg);
+}
+
+@keyframes action-flash-fade {
+  0% { opacity: 0; }
+  15% { opacity: 1; }
+  70% { opacity: 1; }
+  100% { opacity: 0; }
+}
+
+.hud-decided {
+  color: var(--approve);
+  font-weight: 600;
+}
+
 .hotkey-legend {
   display: flex;
   flex-wrap: wrap;
-  gap: 18px;
+  gap: 8px;
   justify-content: center;
   width: min(720px, 94vw);
-  padding: 10px 0 14px;
+  padding: 8px 0 14px;
   color: var(--text-muted);
   font-size: 13px;
 }
@@ -774,6 +924,23 @@ kbd {
   display: inline-flex;
   align-items: center;
   gap: 6px;
+  border: none;
+  background: none;
+  color: var(--text-muted);
+  font-size: 13px;
+  font-family: inherit;
+  padding: 4px 8px;
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+.hotkey-legend-entry:hover {
+  background: var(--soft-bg);
+  color: var(--text);
+}
+
+.context-scrim {
+  display: none;
 }
 
 /* ---- Messages ---- */
@@ -807,6 +974,14 @@ kbd {
     margin: 0;
     border-radius: 0 16px 16px 0;
   }
+
+  .context-scrim {
+    display: block;
+    position: fixed;
+    inset: 0;
+    z-index: 8;
+    background: var(--overlay-bg);
+  }
 }
 
 @media (max-width: 640px) {
@@ -831,6 +1006,16 @@ kbd {
   }
 
   .hotkey-legend {
+    gap: 2px;
+    font-size: 12px;
+  }
+
+  .hotkey-legend-entry {
+    border: 1px solid var(--border);
+    padding: 4px 8px;
+  }
+
+  .hotkey-legend-entry kbd {
     display: none;
   }
 

--- a/simplemod/app/layout.tsx
+++ b/simplemod/app/layout.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import type { Metadata } from 'next';
+import './globals.css';
+
+export const metadata: Metadata = {
+  title: 'SimpleMod',
+  description: 'One item at a time moderation',
+};
+
+const RootLayout = ({ children }: { children: React.ReactNode }) => {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+};
+
+export default RootLayout;

--- a/simplemod/app/login/page.tsx
+++ b/simplemod/app/login/page.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import React, { useState } from 'react';
+import { useRouter } from 'next/navigation';
+
+const LoginPage = () => {
+  const router = useRouter();
+  const [loginToken, setLoginToken] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  const submit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    setSubmitting(true);
+    setError(null);
+    const response = await fetch('/api/session', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ loginToken: loginToken.trim() }),
+    });
+    if (response.ok) {
+      router.push('/');
+      return;
+    }
+    const body = await response.json().catch(() => null);
+    setError(body?.error ?? `Login failed (${response.status})`);
+    setSubmitting(false);
+  };
+
+  return (
+    <main style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', height: '100vh', gap: 16 }}>
+      <h1 style={{ margin: 0 }}>SimpleMod</h1>
+      <p style={{ maxWidth: 420, textAlign: 'center', color: 'var(--text-muted)' }}>
+        If you&apos;re logged into the forum on this host, no login is needed — go to the queue.
+        Otherwise paste a <code>loginToken</code> cookie value from a logged-in forum session.
+      </p>
+      <form onSubmit={submit} style={{ display: 'flex', gap: 8 }}>
+        <input
+          type="password"
+          value={loginToken}
+          onChange={event => setLoginToken(event.target.value)}
+          placeholder="loginToken"
+          style={{ padding: '8px 12px', border: '1px solid var(--border)', borderRadius: 6, width: 280 }}
+        />
+        <button type="submit" disabled={submitting || !loginToken.trim()} style={{ padding: '8px 16px', borderRadius: 6, border: 'none', background: 'var(--accent)', color: 'white', cursor: 'pointer' }}>
+          Log in
+        </button>
+      </form>
+      {error && <div style={{ color: 'var(--reject)' }}>{error}</div>}
+    </main>
+  );
+};
+
+export default LoginPage;

--- a/simplemod/app/page.tsx
+++ b/simplemod/app/page.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import ModQueueApp from '../src/components/ModQueueApp';
+
+const Home = () => {
+  return <ModQueueApp />;
+};
+
+export default Home;

--- a/simplemod/next.config.ts
+++ b/simplemod/next.config.ts
@@ -1,0 +1,40 @@
+import path from 'path';
+import { loadEnvConfig } from '@next/env';
+import type { NextConfig } from 'next';
+
+const repoRoot = path.join(__dirname, '..');
+
+loadEnvConfig(repoRoot, process.env.NODE_ENV !== 'production');
+process.env.FORUM_TYPE ??= 'LessWrong';
+
+const serverExternalPackages = [
+  'superagent-proxy', 'gpt-3-encoder', 'mathjax-full', 'turndown', 'cloudinary',
+  '@aws-sdk/client-cloudfront', 'jimp', 'juice', '@sentry/nextjs',
+  'request', 'stripe', 'openai', 'twitter-api-v2', 'draft-js', 'draft-convert', 'csso',
+  'js-tiktoken', 'cheerio', '@elastic/elasticsearch', '@googlemaps/google-maps-services-js',
+  'intercom-client', 'jsdom',
+  'react-dom/static',
+];
+
+const nextConfig: NextConfig = {
+  reactStrictMode: false,
+
+  turbopack: {
+    root: repoRoot,
+    resolveAlias: {
+      '@/server/*': { browser: '../packages/lesswrong/stubs/server/*' },
+      '@/client/*': { browser: '../packages/lesswrong/client/*', default: '../packages/lesswrong/stubs/client/*' },
+      '@/allComponents': '../packages/lesswrong/lib/generated/allComponents.ts',
+      '@/lib/sentryWrapper': '../packages/lesswrong/stubs/noSentry.ts',
+      '@/*': '../packages/lesswrong/*',
+
+      'superagent-proxy': '../packages/lesswrong/stubs/emptyModule.js',
+      'jsdom': {
+        browser: '../packages/lesswrong/stubs/emptyModule.js',
+      },
+    },
+  },
+  serverExternalPackages,
+};
+
+export default nextConfig;

--- a/simplemod/package.json
+++ b/simplemod/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "simplemod",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev . --turbopack -p 3030",
+    "build": "next build .",
+    "start": "next start . -p 3030"
+  }
+}

--- a/simplemod/src/components/Composer.tsx
+++ b/simplemod/src/components/Composer.tsx
@@ -2,6 +2,7 @@
 
 import React, { useEffect, useMemo, useState } from 'react';
 import classNames from 'classnames';
+import { getDraftMessageHtml } from '@/lib/collections/messages/helpers';
 import { fetchTemplates } from '../lib/api';
 import type { ModerationTemplateData } from '../lib/types';
 
@@ -41,10 +42,14 @@ interface TemplateSectionState extends SectionDraft {
   templates: ModerationTemplateData[];
 }
 
-function buildHtml(state: TemplateSectionState): string {
+// Templates go through the same processing FM's composers apply: strip the
+// moderator-only preamble (everything before a \\ marker) and substitute
+// {{displayName}}/{{firstName}}.
+function buildHtml(state: TemplateSectionState, recipientDisplayName: string): string {
   const templateHtml = state.selectedIds
     .map(id => state.templates.find(template => template._id === id)?.html ?? '')
     .filter(Boolean)
+    .map(html => getDraftMessageHtml({ html, displayName: recipientDisplayName }))
     .join('');
   return templateHtml + textToHtml(state.freeText);
 }
@@ -91,10 +96,11 @@ const TemplateSection = ({ label, state, onChange, autoFocus }: {
   );
 };
 
-const Composer = ({ mode, title, draftKey, rejectionCount = 0, submitLabel, onSubmit, onCancel }: {
+const Composer = ({ mode, title, draftKey, recipientDisplayName, rejectionCount = 0, submitLabel, onSubmit, onCancel }: {
   mode: ComposerMode;
   title: string;
   draftKey: string;
+  recipientDisplayName: string;
   rejectionCount?: number;
   submitLabel: string;
   onSubmit: (result: ComposerResult) => void;
@@ -163,12 +169,12 @@ const Composer = ({ mode, title, draftKey, rejectionCount = 0, submitLabel, onSu
   }, [draftKey, rejectionSection, messageSection]);
 
   const rejectedReason = useMemo(
-    () => rejectionSection ? buildHtml(rejectionSection) : '',
-    [rejectionSection],
+    () => rejectionSection ? buildHtml(rejectionSection, recipientDisplayName) : '',
+    [rejectionSection, recipientDisplayName],
   );
   const messageHtml = useMemo(
-    () => messageSection ? buildHtml(messageSection) : '',
-    [messageSection],
+    () => messageSection ? buildHtml(messageSection, recipientDisplayName) : '',
+    [messageSection, recipientDisplayName],
   );
 
   const canSubmit =

--- a/simplemod/src/components/Composer.tsx
+++ b/simplemod/src/components/Composer.tsx
@@ -12,6 +12,15 @@ export interface ComposerResult {
   messageHtml?: string;
 }
 
+interface SectionDraft {
+  selectedIds: string[];
+  freeText: string;
+}
+
+// Drafts survive Esc/backdrop dismissal so a stray close never destroys a
+// carefully-worded note. Keyed per item/user, cleared on submit.
+const draftStore = new Map<string, { rejection?: SectionDraft; message?: SectionDraft }>();
+
 function escapeHtml(text: string): string {
   return text
     .replace(/&/g, '&amp;')
@@ -28,10 +37,8 @@ function textToHtml(text: string): string {
     .join('');
 }
 
-interface TemplateSectionState {
+interface TemplateSectionState extends SectionDraft {
   templates: ModerationTemplateData[];
-  selectedIds: string[];
-  freeText: string;
 }
 
 function buildHtml(state: TemplateSectionState): string {
@@ -84,15 +91,10 @@ const TemplateSection = ({ label, state, onChange, autoFocus }: {
   );
 };
 
-const emptySection = (templates: ModerationTemplateData[]): TemplateSectionState => ({
-  templates,
-  selectedIds: [],
-  freeText: '',
-});
-
-const Composer = ({ mode, title, rejectionCount = 0, submitLabel, onSubmit, onCancel }: {
+const Composer = ({ mode, title, draftKey, rejectionCount = 0, submitLabel, onSubmit, onCancel }: {
   mode: ComposerMode;
   title: string;
+  draftKey: string;
   rejectionCount?: number;
   submitLabel: string;
   onSubmit: (result: ComposerResult) => void;
@@ -119,18 +121,28 @@ const Composer = ({ mode, title, rejectionCount = 0, submitLabel, onSubmit, onCa
 
   useEffect(() => {
     let cancelled = false;
+    const draft = draftStore.get(draftKey);
     const load = async () => {
       try {
-        if (needsRejection) {
-          const { templates, rejectionIntroHtml } = await fetchTemplates('Rejections');
-          if (cancelled) return;
-          setRejectionSection(emptySection(templates));
-          setRejectionIntro(rejectionIntroHtml);
+        const [rejections, messages] = await Promise.all([
+          needsRejection ? fetchTemplates('Rejections') : null,
+          needsMessage ? fetchTemplates('Messages') : null,
+        ]);
+        if (cancelled) return;
+        if (rejections) {
+          setRejectionSection({
+            templates: rejections.templates,
+            selectedIds: draft?.rejection?.selectedIds ?? [],
+            freeText: draft?.rejection?.freeText ?? '',
+          });
+          setRejectionIntro(rejections.rejectionIntroHtml);
         }
-        if (needsMessage) {
-          const { templates } = await fetchTemplates('Messages');
-          if (cancelled) return;
-          setMessageSection(emptySection(templates));
+        if (messages) {
+          setMessageSection({
+            templates: messages.templates,
+            selectedIds: draft?.message?.selectedIds ?? [],
+            freeText: draft?.message?.freeText ?? '',
+          });
         }
       } catch (error) {
         if (!cancelled) {
@@ -140,7 +152,15 @@ const Composer = ({ mode, title, rejectionCount = 0, submitLabel, onSubmit, onCa
     };
     void load();
     return () => { cancelled = true; };
-  }, [needsRejection, needsMessage]);
+  }, [needsRejection, needsMessage, draftKey]);
+
+  useEffect(() => {
+    if (!rejectionSection && !messageSection) return;
+    draftStore.set(draftKey, {
+      ...(rejectionSection ? { rejection: { selectedIds: rejectionSection.selectedIds, freeText: rejectionSection.freeText } } : {}),
+      ...(messageSection ? { message: { selectedIds: messageSection.selectedIds, freeText: messageSection.freeText } } : {}),
+    });
+  }, [draftKey, rejectionSection, messageSection]);
 
   const rejectedReason = useMemo(
     () => rejectionSection ? buildHtml(rejectionSection) : '',
@@ -157,6 +177,7 @@ const Composer = ({ mode, title, rejectionCount = 0, submitLabel, onSubmit, onCa
 
   const submit = () => {
     if (!canSubmit) return;
+    draftStore.delete(draftKey);
     onSubmit({
       ...(needsRejection && rejectedReason ? { rejectedReason } : {}),
       ...(needsMessage && messageHtml ? { messageHtml } : {}),
@@ -181,7 +202,7 @@ const Composer = ({ mode, title, rejectionCount = 0, submitLabel, onSubmit, onCa
   return (
     <div className="composer-overlay" onKeyDown={handleKeyDown} onMouseDown={handleBackdropMouseDown}>
       <div className="composer">
-        <h2 className="composer-title">{title}</h2>
+        <h2 className="composer-title" title={title}>{title}</h2>
         {loadError && <div className="composer-error">{loadError}</div>}
         {loading && !loadError && <div className="composer-loading">Loading templates…</div>}
         {needsRejection && rejectionSection && (

--- a/simplemod/src/components/Composer.tsx
+++ b/simplemod/src/components/Composer.tsx
@@ -107,6 +107,17 @@ const Composer = ({ mode, title, rejectionCount = 0, submitLabel, onSubmit, onCa
   const [loadError, setLoadError] = useState<string | null>(null);
 
   useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        onCancel();
+      }
+    };
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [onCancel]);
+
+  useEffect(() => {
     let cancelled = false;
     const load = async () => {
       try {
@@ -153,19 +164,22 @@ const Composer = ({ mode, title, rejectionCount = 0, submitLabel, onSubmit, onCa
   };
 
   const handleKeyDown = (event: React.KeyboardEvent) => {
-    if (event.key === 'Escape') {
-      event.preventDefault();
-      onCancel();
-    } else if (event.key === 'Enter' && (event.metaKey || event.ctrlKey)) {
+    if (event.key === 'Enter' && (event.metaKey || event.ctrlKey)) {
       event.preventDefault();
       submit();
+    }
+  };
+
+  const handleBackdropMouseDown = (event: React.MouseEvent) => {
+    if (event.target === event.currentTarget) {
+      onCancel();
     }
   };
 
   const loading = (needsRejection && !rejectionSection) || (needsMessage && !messageSection);
 
   return (
-    <div className="composer-overlay" onKeyDown={handleKeyDown}>
+    <div className="composer-overlay" onKeyDown={handleKeyDown} onMouseDown={handleBackdropMouseDown}>
       <div className="composer">
         <h2 className="composer-title">{title}</h2>
         {loadError && <div className="composer-error">{loadError}</div>}

--- a/simplemod/src/components/Composer.tsx
+++ b/simplemod/src/components/Composer.tsx
@@ -1,0 +1,207 @@
+'use client';
+
+import React, { useEffect, useMemo, useState } from 'react';
+import classNames from 'classnames';
+import { fetchTemplates } from '../lib/api';
+import type { ModerationTemplateData } from '../lib/types';
+
+export type ComposerMode = 'reject' | 'dm' | 'offboard';
+
+export interface ComposerResult {
+  rejectedReason?: string;
+  messageHtml?: string;
+}
+
+function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
+function textToHtml(text: string): string {
+  return text
+    .split(/\n{2,}/)
+    .map(paragraph => paragraph.trim())
+    .filter(Boolean)
+    .map(paragraph => `<p>${escapeHtml(paragraph).replace(/\n/g, '<br>')}</p>`)
+    .join('');
+}
+
+interface TemplateSectionState {
+  templates: ModerationTemplateData[];
+  selectedIds: string[];
+  freeText: string;
+}
+
+function buildHtml(state: TemplateSectionState): string {
+  const templateHtml = state.selectedIds
+    .map(id => state.templates.find(template => template._id === id)?.html ?? '')
+    .filter(Boolean)
+    .join('');
+  return templateHtml + textToHtml(state.freeText);
+}
+
+const TemplateSection = ({ label, state, onChange, autoFocus }: {
+  label: string;
+  state: TemplateSectionState;
+  onChange: (state: TemplateSectionState) => void;
+  autoFocus?: boolean;
+}) => {
+  const toggleTemplate = (id: string) => {
+    const selected = new Set(state.selectedIds);
+    if (selected.has(id)) {
+      selected.delete(id);
+    } else {
+      selected.add(id);
+    }
+    onChange({ ...state, selectedIds: [...selected] });
+  };
+
+  return (
+    <div className="composer-section">
+      <div className="section-label">{label}</div>
+      <div className="composer-templates">
+        {state.templates.map(template => (
+          <button
+            key={template._id}
+            type="button"
+            className={classNames('template-chip', state.selectedIds.includes(template._id) && 'template-chip-selected')}
+            onClick={() => toggleTemplate(template._id)}
+          >
+            {template.name}
+          </button>
+        ))}
+      </div>
+      <textarea
+        className="composer-textarea"
+        value={state.freeText}
+        autoFocus={autoFocus}
+        placeholder="Add your own words (optional if a template is selected)"
+        onChange={event => onChange({ ...state, freeText: event.target.value })}
+      />
+    </div>
+  );
+};
+
+const emptySection = (templates: ModerationTemplateData[]): TemplateSectionState => ({
+  templates,
+  selectedIds: [],
+  freeText: '',
+});
+
+const Composer = ({ mode, title, rejectionCount = 0, submitLabel, onSubmit, onCancel }: {
+  mode: ComposerMode;
+  title: string;
+  rejectionCount?: number;
+  submitLabel: string;
+  onSubmit: (result: ComposerResult) => void;
+  onCancel: () => void;
+}) => {
+  const needsRejection = mode === 'reject' || (mode === 'offboard' && rejectionCount > 0);
+  const needsMessage = mode === 'dm' || mode === 'offboard';
+
+  const [rejectionSection, setRejectionSection] = useState<TemplateSectionState | null>(null);
+  const [messageSection, setMessageSection] = useState<TemplateSectionState | null>(null);
+  const [rejectionIntro, setRejectionIntro] = useState('');
+  const [loadError, setLoadError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    const load = async () => {
+      try {
+        if (needsRejection) {
+          const { templates, rejectionIntroHtml } = await fetchTemplates('Rejections');
+          if (cancelled) return;
+          setRejectionSection(emptySection(templates));
+          setRejectionIntro(rejectionIntroHtml);
+        }
+        if (needsMessage) {
+          const { templates } = await fetchTemplates('Messages');
+          if (cancelled) return;
+          setMessageSection(emptySection(templates));
+        }
+      } catch (error) {
+        if (!cancelled) {
+          setLoadError(error instanceof Error ? error.message : String(error));
+        }
+      }
+    };
+    void load();
+    return () => { cancelled = true; };
+  }, [needsRejection, needsMessage]);
+
+  const rejectedReason = useMemo(
+    () => rejectionSection ? buildHtml(rejectionSection) : '',
+    [rejectionSection],
+  );
+  const messageHtml = useMemo(
+    () => messageSection ? buildHtml(messageSection) : '',
+    [messageSection],
+  );
+
+  const canSubmit =
+    (!needsRejection || !!rejectedReason) &&
+    (mode !== 'dm' || !!messageHtml);
+
+  const submit = () => {
+    if (!canSubmit) return;
+    onSubmit({
+      ...(needsRejection && rejectedReason ? { rejectedReason } : {}),
+      ...(needsMessage && messageHtml ? { messageHtml } : {}),
+    });
+  };
+
+  const handleKeyDown = (event: React.KeyboardEvent) => {
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      onCancel();
+    } else if (event.key === 'Enter' && (event.metaKey || event.ctrlKey)) {
+      event.preventDefault();
+      submit();
+    }
+  };
+
+  const loading = (needsRejection && !rejectionSection) || (needsMessage && !messageSection);
+
+  return (
+    <div className="composer-overlay" onKeyDown={handleKeyDown}>
+      <div className="composer">
+        <h2 className="composer-title">{title}</h2>
+        {loadError && <div className="composer-error">{loadError}</div>}
+        {loading && !loadError && <div className="composer-loading">Loading templates…</div>}
+        {needsRejection && rejectionSection && (
+          <>
+            {rejectionIntro && (
+              <div className="composer-intro" dangerouslySetInnerHTML={{ __html: rejectionIntro }} />
+            )}
+            <TemplateSection
+              label={mode === 'offboard' ? `Rejection reason (applied to ${rejectionCount} item${rejectionCount === 1 ? '' : 's'})` : 'Rejection reason'}
+              state={rejectionSection}
+              onChange={setRejectionSection}
+              autoFocus
+            />
+          </>
+        )}
+        {needsMessage && messageSection && (
+          <TemplateSection
+            label={mode === 'offboard' ? 'Message to user (optional)' : 'Message to user'}
+            state={messageSection}
+            onChange={setMessageSection}
+            autoFocus={mode === 'dm'}
+          />
+        )}
+        <div className="composer-actions">
+          <button type="button" className="button button-secondary" onClick={onCancel}>
+            Cancel <kbd>Esc</kbd>
+          </button>
+          <button type="button" className="button button-primary" disabled={!canSubmit} onClick={submit}>
+            {submitLabel} <kbd>⌘⏎</kbd>
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default Composer;

--- a/simplemod/src/components/ContentCard.tsx
+++ b/simplemod/src/components/ContentCard.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React from 'react';
+import React, { useState } from 'react';
 import type { ContentCardData } from '../lib/types';
 import UserHeader from './UserHeader';
 import HighlightedHtml from './HighlightedHtml';
@@ -8,28 +8,67 @@ import HighlightedHtml from './HighlightedHtml';
 export type CheckState = 'running' | 'failed' | null;
 
 export function formatPostedAt(postedAt: string): string {
-  return new Date(postedAt).toLocaleString('en-US', {
+  const date = new Date(postedAt);
+  const sameYear = date.getFullYear() === new Date().getFullYear();
+  return date.toLocaleString('en-US', {
     month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit',
+    ...(sameYear ? {} : { year: 'numeric' }),
   });
 }
 
-export const PangramBadge = ({ pangramScore, aiChoice }: { pangramScore: number | null; aiChoice: string | null }) => {
+// Same color curve as highlightHtmlWithPangramWindowScores' scoreToColour, so
+// the chip and the passage highlighting read on one scale.
+function pangramChipColor(score: number): string {
+  const adjustedRatio = Math.pow(Math.max(0, Math.min(1, score)), 0.7);
+  const hue = 120 - adjustedRatio * 120;
+  return `light-dark(hsl(${hue}, 100%, 85%), hsl(${hue}, 55%, 25%))`;
+}
+
+export const PangramBadge = ({ pangramScore, aiChoice, pangramPrediction }: {
+  pangramScore: number | null;
+  aiChoice: string | null;
+  pangramPrediction?: string | null;
+}) => {
   if (pangramScore === null && !aiChoice) {
     return null;
   }
-  const highScore = pangramScore !== null && pangramScore > 0.5;
   return (
-    <span className={highScore ? 'chip chip-ai-high' : 'chip'}>
-      {pangramScore !== null ? `Pangram ${Math.round(pangramScore * 100)}%` : null}
-      {pangramScore !== null && aiChoice ? ' · ' : null}
-      {aiChoice ? `LLM: ${aiChoice}` : null}
-    </span>
+    <>
+      {pangramScore !== null && (
+        <span
+          className="chip chip-pangram"
+          style={{ background: pangramChipColor(pangramScore) }}
+          title="Pangram AI-detection score. Passage highlighting uses the same green-to-red scale: more red = more likely AI-written."
+        >
+          Pangram {Math.round(pangramScore * 100)}%{pangramPrediction ? ` · ${pangramPrediction}` : ''}
+        </span>
+      )}
+      {aiChoice && <span className="chip" title="Automated LLM triage verdict">Auto-triage: {aiChoice}</span>}
+    </>
   );
 };
 
-const ContentCard = ({ card, checkState = null }: { card: ContentCardData; checkState?: CheckState }) => {
+const ParentCommentContext = ({ author, html }: { author: string | null; html: string }) => {
+  const [expanded, setExpanded] = useState(false);
+  return (
+    <div className="parent-comment">
+      <button type="button" className="parent-comment-toggle" onClick={() => setExpanded(!expanded)}>
+        {expanded ? '▾' : '▸'} Replying to {author ?? 'unknown user'}
+      </button>
+      {expanded && (
+        <div className="content-html parent-comment-body" dangerouslySetInnerHTML={{ __html: html }} />
+      )}
+    </div>
+  );
+};
+
+const ContentCard = ({ card, checkState = null, onRetryCheck }: {
+  card: ContentCardData;
+  checkState?: CheckState;
+  onRetryCheck?: () => void;
+}) => {
   const { user, item, remainingCount } = card;
-  const positionLabel = remainingCount > 1 ? `1 of ${remainingCount} unreviewed` : 'last unreviewed item';
+  const positionLabel = remainingCount > 1 ? `${remainingCount} unreviewed from this user` : 'last unreviewed item';
   return (
     <div className="card-body">
       <UserHeader user={user} subtitle={positionLabel} />
@@ -37,17 +76,26 @@ const ContentCard = ({ card, checkState = null }: { card: ContentCardData; check
         <span className="chip">{item.collectionName === 'Posts' ? 'Post' : 'Comment'}</span>
         <span>{formatPostedAt(item.postedAt)}</span>
         {item.baseScore !== null && <span>{item.baseScore} karma</span>}
-        <PangramBadge pangramScore={item.pangramScore} aiChoice={item.aiChoice} />
-        {item.pangramPrediction && <span className="chip">{item.pangramPrediction}</span>}
+        <PangramBadge pangramScore={item.pangramScore} aiChoice={item.aiChoice} pangramPrediction={item.pangramPrediction} />
         {checkState === 'running' && <span className="check-indicator">running AI check…</span>}
-        {checkState === 'failed' && item.pangramScore === null && <span className="check-indicator">AI check unavailable</span>}
+        {checkState === 'failed' && item.pangramScore === null && (
+          <button type="button" className="check-indicator check-retry" onClick={onRetryCheck}>
+            AI check unavailable — retry
+          </button>
+        )}
+        <a className="external-link" href={item.itemUrl} target="_blank" rel="noreferrer">open on site ↗</a>
       </div>
       {item.collectionName === 'Posts' ? (
         <h2 className="content-title">{item.title}</h2>
       ) : (
-        item.postTitle && <div className="content-context">Comment on: {item.postTitle}</div>
+        <>
+          {item.postTitle && <div className="content-context">Comment on: {item.postTitle}</div>}
+          {item.parentCommentHtml && (
+            <ParentCommentContext author={item.parentCommentAuthor} html={item.parentCommentHtml} />
+          )}
+        </>
       )}
-      <HighlightedHtml className="content-html" html={item.html} windowScores={item.pangramWindowScores} />
+      <HighlightedHtml className="content-html content-html-reading" html={item.html} windowScores={item.pangramWindowScores} />
     </div>
   );
 };

--- a/simplemod/src/components/ContentCard.tsx
+++ b/simplemod/src/components/ContentCard.tsx
@@ -3,6 +3,9 @@
 import React from 'react';
 import type { ContentCardData } from '../lib/types';
 import UserHeader from './UserHeader';
+import HighlightedHtml from './HighlightedHtml';
+
+export type CheckState = 'running' | 'failed' | null;
 
 export function formatPostedAt(postedAt: string): string {
   return new Date(postedAt).toLocaleString('en-US', {
@@ -24,7 +27,7 @@ export const PangramBadge = ({ pangramScore, aiChoice }: { pangramScore: number 
   );
 };
 
-const ContentCard = ({ card }: { card: ContentCardData }) => {
+const ContentCard = ({ card, checkState = null }: { card: ContentCardData; checkState?: CheckState }) => {
   const { user, item, remainingCount } = card;
   const positionLabel = remainingCount > 1 ? `1 of ${remainingCount} unreviewed` : 'last unreviewed item';
   return (
@@ -35,13 +38,16 @@ const ContentCard = ({ card }: { card: ContentCardData }) => {
         <span>{formatPostedAt(item.postedAt)}</span>
         {item.baseScore !== null && <span>{item.baseScore} karma</span>}
         <PangramBadge pangramScore={item.pangramScore} aiChoice={item.aiChoice} />
+        {item.pangramPrediction && <span className="chip">{item.pangramPrediction}</span>}
+        {checkState === 'running' && <span className="check-indicator">running AI check…</span>}
+        {checkState === 'failed' && item.pangramScore === null && <span className="check-indicator">AI check unavailable</span>}
       </div>
       {item.collectionName === 'Posts' ? (
         <h2 className="content-title">{item.title}</h2>
       ) : (
         item.postTitle && <div className="content-context">Comment on: {item.postTitle}</div>
       )}
-      <div className="content-html" dangerouslySetInnerHTML={{ __html: item.html ?? '<p><em>(no content)</em></p>' }} />
+      <HighlightedHtml className="content-html" html={item.html} windowScores={item.pangramWindowScores} />
     </div>
   );
 };

--- a/simplemod/src/components/ContentCard.tsx
+++ b/simplemod/src/components/ContentCard.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import React from 'react';
+import type { ContentCardData } from '../lib/types';
+import UserHeader from './UserHeader';
+
+export function formatPostedAt(postedAt: string): string {
+  return new Date(postedAt).toLocaleString('en-US', {
+    month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit',
+  });
+}
+
+export const PangramBadge = ({ pangramScore, aiChoice }: { pangramScore: number | null; aiChoice: string | null }) => {
+  if (pangramScore === null && !aiChoice) {
+    return null;
+  }
+  const highScore = pangramScore !== null && pangramScore > 0.5;
+  return (
+    <span className={highScore ? 'chip chip-ai-high' : 'chip'}>
+      {pangramScore !== null ? `Pangram ${Math.round(pangramScore * 100)}%` : null}
+      {pangramScore !== null && aiChoice ? ' · ' : null}
+      {aiChoice ? `LLM: ${aiChoice}` : null}
+    </span>
+  );
+};
+
+const ContentCard = ({ card }: { card: ContentCardData }) => {
+  const { user, item, remainingCount } = card;
+  const positionLabel = remainingCount > 1 ? `1 of ${remainingCount} unreviewed` : 'last unreviewed item';
+  return (
+    <div className="card-body">
+      <UserHeader user={user} subtitle={positionLabel} />
+      <div className="content-meta">
+        <span className="chip">{item.collectionName === 'Posts' ? 'Post' : 'Comment'}</span>
+        <span>{formatPostedAt(item.postedAt)}</span>
+        {item.baseScore !== null && <span>{item.baseScore} karma</span>}
+        <PangramBadge pangramScore={item.pangramScore} aiChoice={item.aiChoice} />
+      </div>
+      {item.collectionName === 'Posts' ? (
+        <h2 className="content-title">{item.title}</h2>
+      ) : (
+        item.postTitle && <div className="content-context">Comment on: {item.postTitle}</div>
+      )}
+      <div className="content-html" dangerouslySetInnerHTML={{ __html: item.html ?? '<p><em>(no content)</em></p>' }} />
+    </div>
+  );
+};
+
+export default ContentCard;

--- a/simplemod/src/components/ContextPanel.tsx
+++ b/simplemod/src/components/ContextPanel.tsx
@@ -1,0 +1,105 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+import classNames from 'classnames';
+import { fetchUserContext } from '../lib/api';
+import type { QueueUser, UserContentItem } from '../lib/types';
+import { formatPostedAt, PangramBadge } from './ContentCard';
+import HighlightedHtml from './HighlightedHtml';
+
+const statusLabels: Record<UserContentItem['status'], string> = {
+  approved: 'Approved',
+  unreviewed: 'Unreviewed',
+  rejected: 'Rejected',
+  draft: 'Draft',
+};
+
+const ContextHistoryItem = ({ item, isCurrent }: { item: UserContentItem; isCurrent: boolean }) => {
+  const [expanded, setExpanded] = useState(false);
+  return (
+    <div className={classNames('context-item', isCurrent && 'context-item-current')}>
+      <button type="button" className="context-item-header" onClick={() => setExpanded(!expanded)}>
+        <span className="context-item-title">
+          {item.collectionName === 'Posts'
+            ? (item.title ?? 'Untitled post')
+            : `Comment on: ${item.postTitle ?? 'unknown post'}`}
+        </span>
+        <span className="context-item-meta">
+          <span className={classNames('chip', `chip-status-${item.status}`)}>{statusLabels[item.status]}</span>
+          {isCurrent && <span className="chip chip-current">Reviewing now</span>}
+          <span>{formatPostedAt(item.postedAt)}</span>
+          {item.baseScore !== null && <span>{item.baseScore} karma</span>}
+          <PangramBadge pangramScore={item.pangramScore} aiChoice={item.aiChoice} />
+        </span>
+      </button>
+      {expanded && (
+        <HighlightedHtml
+          className="content-html context-item-body"
+          html={item.html}
+          windowScores={item.pangramWindowScores}
+        />
+      )}
+    </div>
+  );
+};
+
+const ContextPanel = ({ user, currentDocumentId, onClose }: {
+  user: QueueUser;
+  currentDocumentId: string | null;
+  onClose: () => void;
+}) => {
+  const [items, setItems] = useState<UserContentItem[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setItems(null);
+    setError(null);
+    fetchUserContext(user._id)
+      .then(response => {
+        if (!cancelled) setItems(response.items);
+      })
+      .catch(fetchError => {
+        if (!cancelled) setError(fetchError instanceof Error ? fetchError.message : String(fetchError));
+      });
+    return () => { cancelled = true; };
+  }, [user._id]);
+
+  return (
+    <aside className="context-panel">
+      <div className="context-panel-header">
+        <span className="context-panel-title">{user.displayName}</span>
+        <button type="button" className="context-panel-close" onClick={onClose} aria-label="Close context panel">
+          ✕
+        </button>
+      </div>
+      {user.htmlBio && (
+        <>
+          <div className="section-label">Bio</div>
+          <div className="content-html context-bio" dangerouslySetInnerHTML={{ __html: user.htmlBio }} />
+        </>
+      )}
+      {user.sunshineNotes && (
+        <>
+          <div className="section-label">Moderator notes</div>
+          <pre className="mod-notes">{user.sunshineNotes}</pre>
+        </>
+      )}
+      <div className="section-label">
+        {items ? `All content (${items.length})` : 'All content'}
+      </div>
+      {error && <div className="context-panel-error">{error}</div>}
+      {!items && !error && <div className="context-panel-loading">Loading…</div>}
+      {items && items.length === 0 && <div className="context-panel-loading">No posts or comments.</div>}
+      {items?.map(item => (
+        <ContextHistoryItem
+          key={`${item.collectionName}-${item.documentId}`}
+          item={item}
+          isCurrent={item.documentId === currentDocumentId}
+        />
+      ))}
+    </aside>
+  );
+};
+
+export default ContextPanel;

--- a/simplemod/src/components/HighlightedHtml.tsx
+++ b/simplemod/src/components/HighlightedHtml.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import React, { useMemo } from 'react';
+import { highlightHtmlWithPangramWindowScores } from '@/components/sunshineDashboard/helpers';
+import type { PangramWindowScore } from '../lib/types';
+
+const HighlightedHtml = ({ html, windowScores, className }: {
+  html: string | null;
+  windowScores: PangramWindowScore[] | null;
+  className?: string;
+}) => {
+  const rendered = useMemo(() => {
+    const safeHtml = html ?? '<p><em>(no content)</em></p>';
+    if (typeof window === 'undefined' || !windowScores?.length) {
+      return safeHtml;
+    }
+    return highlightHtmlWithPangramWindowScores(safeHtml, windowScores);
+  }, [html, windowScores]);
+
+  return <div className={className} dangerouslySetInnerHTML={{ __html: rendered }} />;
+};
+
+export default HighlightedHtml;

--- a/simplemod/src/components/HotkeyLegend.tsx
+++ b/simplemod/src/components/HotkeyLegend.tsx
@@ -35,7 +35,7 @@ function legendForCard(card: QueueCard): LegendEntry[] {
 const HotkeyLegend = ({ card }: { card: QueueCard }) => {
   return (
     <footer className="hotkey-legend">
-      {legendForCard(card).map(entry => (
+      {[...legendForCard(card), { keys: '⇥', label: 'Context' }].map(entry => (
         <span key={entry.keys} className="hotkey-legend-entry">
           <kbd>{entry.keys}</kbd> {entry.label}
         </span>

--- a/simplemod/src/components/HotkeyLegend.tsx
+++ b/simplemod/src/components/HotkeyLegend.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import React from 'react';
+import type { QueueCard } from '../lib/types';
+
+interface LegendEntry {
+  keys: string;
+  label: string;
+}
+
+function legendForCard(card: QueueCard): LegendEntry[] {
+  switch (card.type) {
+    case 'content':
+      return [
+        { keys: '→ / A', label: 'Approve' },
+        { keys: '← / R', label: 'Reject…' },
+        { keys: 'D', label: 'Approve + DM…' },
+        { keys: 'U', label: 'Approve user' },
+        { keys: 'S', label: 'Skip user' },
+      ];
+    case 'offboard':
+      return [
+        { keys: '← / R', label: 'Offboard…' },
+        { keys: '→ / A / U', label: 'Approve user' },
+        { keys: 'S', label: 'Skip user' },
+      ];
+    case 'wrapup':
+      return [
+        { keys: '→ / A / U', label: 'Approve user' },
+        { keys: '← / R / S', label: 'Skip user' },
+      ];
+  }
+}
+
+const HotkeyLegend = ({ card }: { card: QueueCard }) => {
+  return (
+    <footer className="hotkey-legend">
+      {legendForCard(card).map(entry => (
+        <span key={entry.keys} className="hotkey-legend-entry">
+          <kbd>{entry.keys}</kbd> {entry.label}
+        </span>
+      ))}
+    </footer>
+  );
+};
+
+export default HotkeyLegend;

--- a/simplemod/src/components/HotkeyLegend.tsx
+++ b/simplemod/src/components/HotkeyLegend.tsx
@@ -3,42 +3,50 @@
 import React from 'react';
 import type { QueueCard } from '../lib/types';
 
+export type LegendAction = 'approve' | 'rejectIntent' | 'dm' | 'approveUser' | 'skip' | 'context';
+
 interface LegendEntry {
   keys: string;
   label: string;
+  action: LegendAction;
 }
 
 function legendForCard(card: QueueCard): LegendEntry[] {
   switch (card.type) {
     case 'content':
       return [
-        { keys: '→ / A', label: 'Approve' },
-        { keys: '← / R', label: 'Reject…' },
-        { keys: 'D', label: 'Approve + DM…' },
-        { keys: 'U', label: 'Approve user' },
-        { keys: 'S', label: 'Skip user' },
+        { keys: '→ / A', label: 'Approve', action: 'approve' },
+        { keys: '← / R', label: 'Reject…', action: 'rejectIntent' },
+        { keys: 'D', label: 'Approve + DM…', action: 'dm' },
+        { keys: 'U', label: 'Approve user', action: 'approveUser' },
+        { keys: 'S', label: 'Skip user', action: 'skip' },
       ];
     case 'offboard':
       return [
-        { keys: '← / R', label: 'Offboard…' },
-        { keys: '→ / A / U', label: 'Approve user' },
-        { keys: 'S', label: 'Skip user' },
+        { keys: '← / R', label: 'Offboard…', action: 'rejectIntent' },
+        { keys: '→ / A / U', label: 'Approve user', action: 'approveUser' },
+        { keys: 'S', label: 'Skip user', action: 'skip' },
       ];
     case 'wrapup':
       return [
-        { keys: '→ / A / U', label: 'Approve user' },
-        { keys: '← / R / S', label: 'Skip user' },
+        { keys: '→ / A / U', label: 'Approve user', action: 'approveUser' },
+        { keys: '← / R / S', label: 'Skip user', action: 'skip' },
       ];
   }
 }
 
-const HotkeyLegend = ({ card }: { card: QueueCard }) => {
+const HotkeyLegend = ({ card, onAction }: { card: QueueCard; onAction: (action: LegendAction) => void }) => {
   return (
     <footer className="hotkey-legend">
-      {[...legendForCard(card), { keys: '⇥', label: 'Context' }].map(entry => (
-        <span key={entry.keys} className="hotkey-legend-entry">
+      {[...legendForCard(card), { keys: '⇥', label: 'Context', action: 'context' as const }].map(entry => (
+        <button
+          key={entry.action}
+          type="button"
+          className="hotkey-legend-entry"
+          onClick={() => onAction(entry.action)}
+        >
           <kbd>{entry.keys}</kbd> {entry.label}
-        </span>
+        </button>
       ))}
     </footer>
   );

--- a/simplemod/src/components/ModQueueApp.tsx
+++ b/simplemod/src/components/ModQueueApp.tsx
@@ -276,7 +276,19 @@ const ModQueueApp = () => {
   if (!cards) {
     return (
       <main className="queue-shell">
-        <div className="queue-message">Loading queue…</div>
+        <header className="queue-hud">
+          <span className="queue-hud-title">SimpleMod</span>
+          <span className="queue-hud-counts"><span>loading queue…</span></span>
+        </header>
+        <div className="card-stage">
+          <div className="skeleton-card">
+            <div className="skeleton-line skeleton-line-half" />
+            <div className="skeleton-line skeleton-line-wide" />
+            <div className="skeleton-line" />
+            <div className="skeleton-line" />
+            <div className="skeleton-line skeleton-line-half" />
+          </div>
+        </div>
       </main>
     );
   }
@@ -309,6 +321,7 @@ const ModQueueApp = () => {
               key={topKey}
               onSwipe={handleSwipe}
               disabled={busy || !!composer}
+              busy={busy}
               leftStamp={stamps.left}
               rightStamp={stamps.right}
             >

--- a/simplemod/src/components/ModQueueApp.tsx
+++ b/simplemod/src/components/ModQueueApp.tsx
@@ -12,15 +12,32 @@ import ContentCard, { type CheckState } from './ContentCard';
 import WrapupCard from './WrapupCard';
 import OffboardCard, { type OffboardSelection } from './OffboardCard';
 import Composer, { type ComposerResult } from './Composer';
-import HotkeyLegend from './HotkeyLegend';
+import HotkeyLegend, { type LegendAction } from './HotkeyLegend';
 import ContextPanel from './ContextPanel';
 
 const PANEL_OPEN_STORAGE_KEY = 'simplemod_contextPanelOpen';
+const USER_ACTION_GRACE_MS = 2000;
 
 type ComposerState =
   | { mode: 'reject'; card: ContentCardData }
   | { mode: 'dm'; card: ContentCardData }
   | { mode: 'offboard'; card: OffboardCardData };
+
+interface Toast {
+  text: string;
+  kind: 'info' | 'error';
+}
+
+interface ActionFlash {
+  label: string;
+  direction: SwipeDirection;
+  nonce: number;
+}
+
+interface PendingUserAction {
+  label: string;
+  timer: number;
+}
 
 function cardKey(card: QueueCard): string {
   return card.type === 'content'
@@ -36,6 +53,20 @@ function stampsForCard(card: QueueCard): { left: string; right: string } {
   }
 }
 
+function scrollTopCardBody(delta: number) {
+  document.querySelector('.swipe-card .card-body')?.scrollBy({ top: delta, behavior: 'smooth' });
+}
+
+function isTextEntryTarget(target: HTMLElement | null): boolean {
+  if (!target) return false;
+  if (target.tagName === 'TEXTAREA' || target.isContentEditable) return true;
+  if (target.tagName === 'INPUT') {
+    const type = (target as HTMLInputElement).type;
+    return type !== 'checkbox' && type !== 'radio' && type !== 'button';
+  }
+  return false;
+}
+
 const ModQueueApp = () => {
   const router = useRouter();
   const [cards, setCards] = useState<QueueCard[] | null>(null);
@@ -43,12 +74,18 @@ const ModQueueApp = () => {
   const [loadError, setLoadError] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
   const [exitDirection, setExitDirection] = useState<SwipeDirection>(1);
+  const [exitingKey, setExitingKey] = useState<string | null>(null);
   const [composer, setComposer] = useState<ComposerState | null>(null);
-  const [toast, setToast] = useState<string | null>(null);
+  const [toast, setToast] = useState<Toast | null>(null);
+  const [actionFlash, setActionFlash] = useState<ActionFlash | null>(null);
+  const [pendingUserAction, setPendingUserAction] = useState<PendingUserAction | null>(null);
+  const [decidedCount, setDecidedCount] = useState(0);
   const [offboardSelection, setOffboardSelection] = useState<OffboardSelection>({ selectedIds: [], removePermissions: true });
   const [panelOpen, setPanelOpen] = useState(false);
   const [checkState, setCheckState] = useState<CheckState>(null);
+  const [checkNonce, setCheckNonce] = useState(0);
   const checkAttemptedRef = useRef<Set<string>>(new Set());
+  const flashNonceRef = useRef(0);
 
   const topCard = cards?.[0] ?? null;
   const topKey = topCard ? cardKey(topCard) : null;
@@ -127,37 +164,53 @@ const ModQueueApp = () => {
         ) ?? previous);
       })
       .catch(() => setCheckState('failed'));
-  }, [topItemDocumentId, topItemCollectionName, topItemHasScore]);
+  }, [topItemDocumentId, topItemCollectionName, topItemHasScore, checkNonce]);
+
+  const retryCheck = useCallback(() => {
+    if (topItemDocumentId) {
+      checkAttemptedRef.current.delete(topItemDocumentId);
+      setCheckNonce(nonce => nonce + 1);
+    }
+  }, [topItemDocumentId]);
 
   useEffect(() => {
-    if (!toast) return;
+    if (!toast || toast.kind === 'error') return;
     const timeout = setTimeout(() => setToast(null), 4000);
     return () => clearTimeout(timeout);
   }, [toast]);
 
   const handleActionError = useCallback(async (error: unknown) => {
     if (error instanceof ConflictError) {
-      setToast('Someone else got there first — queue reloaded');
+      setToast({ text: 'Someone else got there first — queue reloaded', kind: 'info' });
     } else {
-      setToast(error instanceof Error ? error.message : String(error));
+      setToast({ text: error instanceof Error ? error.message : String(error), kind: 'error' });
     }
     await loadQueue();
   }, [loadQueue]);
 
-  const runAction = useCallback(async (direction: SwipeDirection, action: () => Promise<void>) => {
-    if (busy) return;
+  const flashAction = useCallback((label: string, direction: SwipeDirection) => {
+    flashNonceRef.current += 1;
+    setActionFlash({ label, direction, nonce: flashNonceRef.current });
+  }, []);
+
+  const runAction = useCallback(async (direction: SwipeDirection, flashLabel: string, action: () => Promise<void>) => {
+    if (busy || !topKey) return;
     setBusy(true);
     setExitDirection(direction);
+    setExitingKey(topKey);
+    flashAction(flashLabel, direction);
     try {
       await action();
     } catch (error) {
       await handleActionError(error);
     } finally {
+      setExitingKey(null);
       setBusy(false);
     }
-  }, [busy, handleActionError]);
+  }, [busy, topKey, flashAction, handleActionError]);
 
   const advanceContentCard = useCallback((card: ContentCardData, result: NextItemResponse) => {
+    setDecidedCount(count => count + 1);
     setCards(previous => {
       if (!previous) return previous;
       const key = cardKey(card);
@@ -173,11 +226,12 @@ const ModQueueApp = () => {
   }, []);
 
   const removeUserCards = useCallback((userId: string) => {
+    setDecidedCount(count => count + 1);
     setCards(previous => previous?.filter(entry => entry.user._id !== userId) ?? previous);
   }, []);
 
   const approveTop = useCallback((card: ContentCardData) =>
-    runAction(1, async () => {
+    runAction(1, 'Approved', async () => {
       const result = await api.approveItem({
         userId: card.user._id,
         collectionName: card.item.collectionName,
@@ -187,7 +241,7 @@ const ModQueueApp = () => {
     }), [runAction, advanceContentCard]);
 
   const rejectTop = useCallback((card: ContentCardData, rejectedReason: string) =>
-    runAction(-1, async () => {
+    runAction(-1, 'Rejected', async () => {
       const result = await api.rejectItem({
         userId: card.user._id,
         collectionName: card.item.collectionName,
@@ -198,7 +252,7 @@ const ModQueueApp = () => {
     }), [runAction, advanceContentCard]);
 
   const approveAndDmTop = useCallback((card: ContentCardData, messageHtml: string) =>
-    runAction(1, async () => {
+    runAction(1, 'Approved + DM sent', async () => {
       const result = await api.approveItemAndDm({
         userId: card.user._id,
         collectionName: card.item.collectionName,
@@ -208,20 +262,8 @@ const ModQueueApp = () => {
       advanceContentCard(card, result);
     }), [runAction, advanceContentCard]);
 
-  const approveUserTop = useCallback((card: QueueCard) =>
-    runAction(1, async () => {
-      await api.approveUser(card.user._id);
-      removeUserCards(card.user._id);
-    }), [runAction, removeUserCards]);
-
-  const skipTop = useCallback((card: QueueCard) =>
-    runAction(-1, async () => {
-      await api.skipUser(card.user._id);
-      removeUserCards(card.user._id);
-    }), [runAction, removeUserCards]);
-
   const offboardTop = useCallback((card: OffboardCardData, selection: OffboardSelection, result: ComposerResult) =>
-    runAction(-1, async () => {
+    runAction(-1, 'Offboarded', async () => {
       const rejectedReason = result.rejectedReason;
       const selectedItems = card.items.filter(item => selection.selectedIds.includes(item.documentId));
       await api.offboardUser({
@@ -239,13 +281,50 @@ const ModQueueApp = () => {
       removeUserCards(card.user._id);
     }), [runAction, removeUserCards]);
 
+  const cancelPendingUserAction = useCallback(() => {
+    setPendingUserAction(previous => {
+      if (previous) {
+        clearTimeout(previous.timer);
+      }
+      return null;
+    });
+  }, []);
+
+  // U (approve user) and S (skip user) are single-keystroke, user-level
+  // actions, so they get a short cancellable grace period instead of firing
+  // instantly.
+  const scheduleUserAction = useCallback((label: string, run: () => void) => {
+    cancelPendingUserAction();
+    const timer = window.setTimeout(() => {
+      setPendingUserAction(null);
+      run();
+    }, USER_ACTION_GRACE_MS);
+    setPendingUserAction({ label, timer });
+  }, [cancelPendingUserAction]);
+
+  const approveUserTop = useCallback((card: QueueCard) =>
+    scheduleUserAction(`Approving ${card.user.displayName} as a user`, () => {
+      void runAction(1, 'User approved', async () => {
+        await api.approveUser(card.user._id);
+        removeUserCards(card.user._id);
+      });
+    }), [scheduleUserAction, runAction, removeUserCards]);
+
+  const skipTop = useCallback((card: QueueCard) =>
+    scheduleUserAction(`Removing ${card.user.displayName} from the queue`, () => {
+      void runAction(-1, 'Skipped', async () => {
+        await api.skipUser(card.user._id);
+        removeUserCards(card.user._id);
+      });
+    }), [scheduleUserAction, runAction, removeUserCards]);
+
   const handleSwipe = useCallback((direction: SwipeDirection) => {
-    if (!topCard || busy || composer) return;
+    if (!topCard || busy || composer || pendingUserAction) return;
     if (direction === 1) {
       if (topCard.type === 'content') {
         void approveTop(topCard);
       } else {
-        void approveUserTop(topCard);
+        approveUserTop(topCard);
       }
     } else {
       if (topCard.type === 'content') {
@@ -253,22 +332,83 @@ const ModQueueApp = () => {
       } else if (topCard.type === 'offboard') {
         setComposer({ mode: 'offboard', card: topCard });
       } else {
-        void skipTop(topCard);
+        skipTop(topCard);
       }
     }
-  }, [topCard, busy, composer, approveTop, approveUserTop, skipTop]);
+  }, [topCard, busy, composer, pendingUserAction, approveTop, approveUserTop, skipTop]);
+
+  const handleLegendAction = useCallback((action: LegendAction) => {
+    if (!topCard) return;
+    switch (action) {
+      case 'approve':
+        if (topCard.type === 'content') handleSwipe(1);
+        break;
+      case 'rejectIntent':
+        handleSwipe(-1);
+        break;
+      case 'dm':
+        if (topCard.type === 'content' && !busy && !composer && !pendingUserAction) {
+          setComposer({ mode: 'dm', card: topCard });
+        }
+        break;
+      case 'approveUser':
+        if (!busy && !composer && !pendingUserAction) approveUserTop(topCard);
+        break;
+      case 'skip':
+        if (!busy && !composer && !pendingUserAction) skipTop(topCard);
+        break;
+      case 'context':
+        togglePanel();
+        break;
+    }
+  }, [topCard, busy, composer, pendingUserAction, handleSwipe, approveUserTop, skipTop, togglePanel]);
 
   useEffect(() => {
     const onKeyDown = (event: KeyboardEvent) => {
-      if (composer || busy || !topCard) return;
+      if (composer) return;
       if (event.metaKey || event.ctrlKey || event.altKey) return;
-      const target = event.target as HTMLElement | null;
-      if (target && (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable)) return;
+      if (isTextEntryTarget(event.target as HTMLElement | null)) return;
+
+      if (pendingUserAction) {
+        if (event.key.toLowerCase() === 'z' || event.key === 'Escape') {
+          event.preventDefault();
+          cancelPendingUserAction();
+        }
+        return;
+      }
+
       if (event.key === 'Tab') {
         event.preventDefault();
         togglePanel();
         return;
       }
+      if (event.key === 'Escape' && panelOpen) {
+        event.preventDefault();
+        togglePanel();
+        return;
+      }
+
+      switch (event.key) {
+        case 'ArrowDown':
+          event.preventDefault();
+          scrollTopCardBody(120);
+          return;
+        case 'ArrowUp':
+          event.preventDefault();
+          scrollTopCardBody(-120);
+          return;
+        case 'PageDown':
+        case ' ':
+          event.preventDefault();
+          scrollTopCardBody(480);
+          return;
+        case 'PageUp':
+          event.preventDefault();
+          scrollTopCardBody(-480);
+          return;
+      }
+
+      if (busy || !topCard) return;
       switch (event.key.toLowerCase()) {
         case 'arrowright':
         case 'a':
@@ -288,23 +428,26 @@ const ModQueueApp = () => {
           break;
         case 's':
           event.preventDefault();
-          void skipTop(topCard);
+          skipTop(topCard);
           break;
         case 'u':
           event.preventDefault();
-          void approveUserTop(topCard);
+          approveUserTop(topCard);
           break;
       }
     };
     window.addEventListener('keydown', onKeyDown);
     return () => window.removeEventListener('keydown', onKeyDown);
-  }, [composer, busy, topCard, handleSwipe, skipTop, approveUserTop, togglePanel]);
+  }, [composer, busy, topCard, panelOpen, pendingUserAction, handleSwipe, skipTop, approveUserTop, togglePanel, cancelPendingUserAction]);
 
   const counts = useMemo(() => {
-    const content = cards?.filter(card => card.type === 'content').length ?? 0;
+    const summed = (cards ?? []).reduce((total, card) => {
+      if (card.type === 'content') return total + card.remainingCount;
+      if (card.type === 'offboard') return total + Math.max(card.items.length, 1);
+      return total + 1;
+    }, 0);
     const offboard = cards?.filter(card => card.type === 'offboard').length ?? 0;
-    const wrapup = cards?.filter(card => card.type === 'wrapup').length ?? 0;
-    return { content, offboard, wrapup };
+    return { users: cards?.length ?? 0, items: summed, offboard };
   }, [cards]);
 
   const handleComposerSubmit = (result: ComposerResult) => {
@@ -355,16 +498,17 @@ const ModQueueApp = () => {
   }
 
   const stamps = topCard ? stampsForCard(topCard) : null;
+  const showTopCard = topCard && stamps && topKey !== exitingKey;
 
   return (
     <main className="queue-shell">
       <header className="queue-hud">
         <span className="queue-hud-title">SimpleMod</span>
         <span className="queue-hud-counts">
-          {counts.content > 0 && <span>{counts.content} content</span>}
+          {counts.items > 0 && <span>{counts.items} item{counts.items === 1 ? '' : 's'} · {counts.users} user{counts.users === 1 ? '' : 's'}</span>}
           {counts.offboard > 0 && <span className="hud-offboard">{counts.offboard} offboard</span>}
-          {counts.wrapup > 0 && <span>{counts.wrapup} wrap-up</span>}
           {cards.length === 0 && <span>queue clear</span>}
+          {decidedCount > 0 && <span className="hud-decided">✓ {decidedCount} this session</span>}
         </span>
         <button type="button" className="hud-context-toggle" onClick={togglePanel}>
           {panelOpen ? 'Hide context' : 'Context'} <kbd>⇥</kbd>
@@ -373,11 +517,14 @@ const ModQueueApp = () => {
       </header>
       <div className={classNames('stage-row', panelOpen && topCard && 'stage-row-with-panel')}>
         {panelOpen && topCard && (
-          <ContextPanel
-            user={topCard.user}
-            currentDocumentId={topCard.type === 'content' ? topCard.item.documentId : null}
-            onClose={togglePanel}
-          />
+          <>
+            <div className="context-scrim" onClick={togglePanel} />
+            <ContextPanel
+              user={topCard.user}
+              currentDocumentId={topCard.type === 'content' ? topCard.item.documentId : null}
+              onClose={togglePanel}
+            />
+          </>
         )}
         <div className="card-stage">
           {cards.slice(1, 3).map((card, index) => (
@@ -388,16 +535,18 @@ const ModQueueApp = () => {
             />
           ))}
           <AnimatePresence custom={exitDirection} initial={false}>
-            {topCard && stamps && (
+            {showTopCard && (
               <SwipeCard
                 key={topKey}
                 onSwipe={handleSwipe}
-                disabled={busy || !!composer}
+                disabled={busy || !!composer || !!pendingUserAction}
                 busy={busy}
                 leftStamp={stamps.left}
                 rightStamp={stamps.right}
               >
-                {topCard.type === 'content' && <ContentCard card={topCard} checkState={checkState} />}
+                {topCard.type === 'content' && (
+                  <ContentCard card={topCard} checkState={checkState} onRetryCheck={retryCheck} />
+                )}
                 {topCard.type === 'wrapup' && <WrapupCard card={topCard} />}
                 {topCard.type === 'offboard' && (
                   <OffboardCard
@@ -409,6 +558,15 @@ const ModQueueApp = () => {
               </SwipeCard>
             )}
           </AnimatePresence>
+          {actionFlash && (
+            <div
+              key={actionFlash.nonce}
+              className={classNames('action-flash', actionFlash.direction === 1 ? 'action-flash-right' : 'action-flash-left')}
+              onAnimationEnd={() => setActionFlash(null)}
+            >
+              {actionFlash.label}
+            </div>
+          )}
           {cards.length === 0 && (
             <div className="queue-message queue-done">
               <h2>All clear 🎉</h2>
@@ -418,10 +576,15 @@ const ModQueueApp = () => {
           )}
         </div>
       </div>
-      {topCard && <HotkeyLegend card={topCard} />}
+      {topCard && <HotkeyLegend card={topCard} onAction={handleLegendAction} />}
       {composer && (
         <Composer
           mode={composer.mode}
+          draftKey={
+            composer.mode === 'offboard'
+              ? `offboard-${composer.card.user._id}`
+              : `${composer.mode}-${composer.card.item.documentId}`
+          }
           title={
             composer.mode === 'reject'
               ? `Reject ${composer.card.item.collectionName === 'Posts' ? `"${composer.card.item.title}"` : 'this comment'}`
@@ -439,7 +602,22 @@ const ModQueueApp = () => {
           onCancel={() => setComposer(null)}
         />
       )}
-      {toast && <div className="toast">{toast}</div>}
+      {pendingUserAction && (
+        <div className="pending-action">
+          <span>{pendingUserAction.label}…</span>
+          <button type="button" className="button button-secondary" onClick={cancelPendingUserAction}>
+            Cancel <kbd>Z</kbd>
+          </button>
+        </div>
+      )}
+      {toast && (
+        <div className={classNames('toast', toast.kind === 'error' && 'toast-error')}>
+          {toast.text}
+          {toast.kind === 'error' && (
+            <button type="button" className="toast-close" onClick={() => setToast(null)} aria-label="Dismiss">✕</button>
+          )}
+        </div>
+      )}
     </main>
   );
 };

--- a/simplemod/src/components/ModQueueApp.tsx
+++ b/simplemod/src/components/ModQueueApp.tsx
@@ -117,7 +117,7 @@ const ModQueueApp = () => {
         if (removedUsersRef.current.has(card.user._id)) continue;
         if (card.type === 'content' && decidedDocsRef.current.has(card.item.documentId)) {
           const localCard = localByUser.get(card.user._id);
-          if (localCard?.type === 'content') merged.push(localCard);
+          if (localCard) merged.push(localCard);
           continue;
         }
         merged.push(card);
@@ -275,7 +275,7 @@ const ModQueueApp = () => {
   const advanceContentCard = useCallback((card: ContentCardData, result: NextItemResponse) => {
     setDecidedCount(count => count + 1);
     decidedDocsRef.current.add(card.item.documentId);
-    if (!result.nextItem) {
+    if (!result.nextItem && !result.offboardCard) {
       removedUsersRef.current.add(card.user._id);
     }
     api.invalidateUserContext(card.user._id);
@@ -288,6 +288,10 @@ const ModQueueApp = () => {
           ? { ...card, item: nextItem, remainingCount: result.remainingCount }
           : entry
         );
+      }
+      if (result.offboardCard) {
+        const offboardCard = result.offboardCard;
+        return previous.map(entry => cardKey(entry) === key ? offboardCard : entry);
       }
       return previous.filter(entry => cardKey(entry) !== key);
     });

--- a/simplemod/src/components/ModQueueApp.tsx
+++ b/simplemod/src/components/ModQueueApp.tsx
@@ -1,17 +1,21 @@
 'use client';
 
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useRouter } from 'next/navigation';
+import classNames from 'classnames';
 import { AnimatePresence } from 'framer-motion';
 import * as api from '../lib/api';
 import { ApiError, ConflictError } from '../lib/api';
 import type { ContentCardData, NextItemResponse, OffboardCardData, QueueCard } from '../lib/types';
 import SwipeCard, { type SwipeDirection } from './SwipeCard';
-import ContentCard from './ContentCard';
+import ContentCard, { type CheckState } from './ContentCard';
 import WrapupCard from './WrapupCard';
 import OffboardCard, { type OffboardSelection } from './OffboardCard';
 import Composer, { type ComposerResult } from './Composer';
 import HotkeyLegend from './HotkeyLegend';
+import ContextPanel from './ContextPanel';
+
+const PANEL_OPEN_STORAGE_KEY = 'simplemod_contextPanelOpen';
 
 type ComposerState =
   | { mode: 'reject'; card: ContentCardData }
@@ -42,9 +46,23 @@ const ModQueueApp = () => {
   const [composer, setComposer] = useState<ComposerState | null>(null);
   const [toast, setToast] = useState<string | null>(null);
   const [offboardSelection, setOffboardSelection] = useState<OffboardSelection>({ selectedIds: [], removePermissions: true });
+  const [panelOpen, setPanelOpen] = useState(false);
+  const [checkState, setCheckState] = useState<CheckState>(null);
+  const checkAttemptedRef = useRef<Set<string>>(new Set());
 
   const topCard = cards?.[0] ?? null;
   const topKey = topCard ? cardKey(topCard) : null;
+
+  useEffect(() => {
+    setPanelOpen(localStorage.getItem(PANEL_OPEN_STORAGE_KEY) === 'true');
+  }, []);
+
+  const togglePanel = useCallback(() => {
+    setPanelOpen(previous => {
+      localStorage.setItem(PANEL_OPEN_STORAGE_KEY, String(!previous));
+      return !previous;
+    });
+  }, []);
 
   const loadQueue = useCallback(async () => {
     try {
@@ -74,6 +92,42 @@ const ModQueueApp = () => {
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [topKey]);
+
+  const topItemDocumentId = topCard?.type === 'content' ? topCard.item.documentId : null;
+  const topItemCollectionName = topCard?.type === 'content' ? topCard.item.collectionName : null;
+  const topItemHasScore = topCard?.type === 'content' ? topCard.item.pangramScore !== null : true;
+
+  useEffect(() => {
+    if (!topItemDocumentId || !topItemCollectionName || topItemHasScore) {
+      setCheckState(null);
+      return;
+    }
+    if (checkAttemptedRef.current.has(topItemDocumentId)) {
+      setCheckState('failed');
+      return;
+    }
+    checkAttemptedRef.current.add(topItemDocumentId);
+    setCheckState('running');
+    api.runCheck({ collectionName: topItemCollectionName, documentId: topItemDocumentId })
+      .then(result => {
+        setCheckState(result.pangramScore === null ? 'failed' : null);
+        setCards(previous => previous?.map(entry =>
+          entry.type === 'content' && entry.item.documentId === topItemDocumentId
+            ? {
+                ...entry,
+                item: {
+                  ...entry.item,
+                  pangramScore: result.pangramScore,
+                  pangramFractionAi: result.pangramFractionAi,
+                  pangramPrediction: result.pangramPrediction,
+                  pangramWindowScores: result.pangramWindowScores,
+                },
+              }
+            : entry
+        ) ?? previous);
+      })
+      .catch(() => setCheckState('failed'));
+  }, [topItemDocumentId, topItemCollectionName, topItemHasScore]);
 
   useEffect(() => {
     if (!toast) return;
@@ -210,6 +264,11 @@ const ModQueueApp = () => {
       if (event.metaKey || event.ctrlKey || event.altKey) return;
       const target = event.target as HTMLElement | null;
       if (target && (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable)) return;
+      if (event.key === 'Tab') {
+        event.preventDefault();
+        togglePanel();
+        return;
+      }
       switch (event.key.toLowerCase()) {
         case 'arrowright':
         case 'a':
@@ -239,7 +298,7 @@ const ModQueueApp = () => {
     };
     window.addEventListener('keydown', onKeyDown);
     return () => window.removeEventListener('keydown', onKeyDown);
-  }, [composer, busy, topCard, handleSwipe, skipTop, approveUserTop]);
+  }, [composer, busy, topCard, handleSwipe, skipTop, approveUserTop, togglePanel]);
 
   const counts = useMemo(() => {
     const content = cards?.filter(card => card.type === 'content').length ?? 0;
@@ -280,13 +339,15 @@ const ModQueueApp = () => {
           <span className="queue-hud-title">SimpleMod</span>
           <span className="queue-hud-counts"><span>loading queue…</span></span>
         </header>
-        <div className="card-stage">
-          <div className="skeleton-card">
-            <div className="skeleton-line skeleton-line-half" />
-            <div className="skeleton-line skeleton-line-wide" />
-            <div className="skeleton-line" />
-            <div className="skeleton-line" />
-            <div className="skeleton-line skeleton-line-half" />
+        <div className="stage-row">
+          <div className="card-stage">
+            <div className="skeleton-card">
+              <div className="skeleton-line skeleton-line-half" />
+              <div className="skeleton-line skeleton-line-wide" />
+              <div className="skeleton-line" />
+              <div className="skeleton-line" />
+              <div className="skeleton-line skeleton-line-half" />
+            </div>
           </div>
         </div>
       </main>
@@ -305,45 +366,57 @@ const ModQueueApp = () => {
           {counts.wrapup > 0 && <span>{counts.wrapup} wrap-up</span>}
           {cards.length === 0 && <span>queue clear</span>}
         </span>
+        <button type="button" className="hud-context-toggle" onClick={togglePanel}>
+          {panelOpen ? 'Hide context' : 'Context'} <kbd>⇥</kbd>
+        </button>
         <span className="queue-hud-moderator">{moderatorName}</span>
       </header>
-      <div className="card-stage">
-        {cards.slice(1, 3).map((card, index) => (
-          <div
-            key={cardKey(card)}
-            className="peek-card"
-            style={{ transform: `scale(${0.96 - index * 0.03}) translateY(${(index + 1) * 14}px)` }}
+      <div className={classNames('stage-row', panelOpen && topCard && 'stage-row-with-panel')}>
+        {panelOpen && topCard && (
+          <ContextPanel
+            user={topCard.user}
+            currentDocumentId={topCard.type === 'content' ? topCard.item.documentId : null}
+            onClose={togglePanel}
           />
-        ))}
-        <AnimatePresence custom={exitDirection} initial={false}>
-          {topCard && stamps && (
-            <SwipeCard
-              key={topKey}
-              onSwipe={handleSwipe}
-              disabled={busy || !!composer}
-              busy={busy}
-              leftStamp={stamps.left}
-              rightStamp={stamps.right}
-            >
-              {topCard.type === 'content' && <ContentCard card={topCard} />}
-              {topCard.type === 'wrapup' && <WrapupCard card={topCard} />}
-              {topCard.type === 'offboard' && (
-                <OffboardCard
-                  card={topCard}
-                  selection={offboardSelection}
-                  onChangeSelection={setOffboardSelection}
-                />
-              )}
-            </SwipeCard>
-          )}
-        </AnimatePresence>
-        {cards.length === 0 && (
-          <div className="queue-message queue-done">
-            <h2>All clear 🎉</h2>
-            <p>No users waiting for review.</p>
-            <button className="button button-secondary" onClick={() => void loadQueue()}>Check again</button>
-          </div>
         )}
+        <div className="card-stage">
+          {cards.slice(1, 3).map((card, index) => (
+            <div
+              key={cardKey(card)}
+              className="peek-card"
+              style={{ transform: `scale(${0.96 - index * 0.03}) translateY(${(index + 1) * 14}px)` }}
+            />
+          ))}
+          <AnimatePresence custom={exitDirection} initial={false}>
+            {topCard && stamps && (
+              <SwipeCard
+                key={topKey}
+                onSwipe={handleSwipe}
+                disabled={busy || !!composer}
+                busy={busy}
+                leftStamp={stamps.left}
+                rightStamp={stamps.right}
+              >
+                {topCard.type === 'content' && <ContentCard card={topCard} checkState={checkState} />}
+                {topCard.type === 'wrapup' && <WrapupCard card={topCard} />}
+                {topCard.type === 'offboard' && (
+                  <OffboardCard
+                    card={topCard}
+                    selection={offboardSelection}
+                    onChangeSelection={setOffboardSelection}
+                  />
+                )}
+              </SwipeCard>
+            )}
+          </AnimatePresence>
+          {cards.length === 0 && (
+            <div className="queue-message queue-done">
+              <h2>All clear 🎉</h2>
+              <p>No users waiting for review.</p>
+              <button className="button button-secondary" onClick={() => void loadQueue()}>Check again</button>
+            </div>
+          )}
+        </div>
       </div>
       {topCard && <HotkeyLegend card={topCard} />}
       {composer && (

--- a/simplemod/src/components/ModQueueApp.tsx
+++ b/simplemod/src/components/ModQueueApp.tsx
@@ -85,6 +85,8 @@ const ModQueueApp = () => {
   const [checkState, setCheckState] = useState<CheckState>(null);
   const [checkNonce, setCheckNonce] = useState(0);
   const checkAttemptedRef = useRef<Set<string>>(new Set());
+  const checkDocumentIdRef = useRef<string | null>(null);
+  const busyRef = useRef(false);
   const flashNonceRef = useRef(0);
 
   const topCard = cards?.[0] ?? null;
@@ -133,6 +135,7 @@ const ModQueueApp = () => {
   const topItemDocumentId = topCard?.type === 'content' ? topCard.item.documentId : null;
   const topItemCollectionName = topCard?.type === 'content' ? topCard.item.collectionName : null;
   const topItemHasScore = topCard?.type === 'content' ? topCard.item.pangramScore !== null : true;
+  checkDocumentIdRef.current = topItemDocumentId;
 
   useEffect(() => {
     if (!topItemDocumentId || !topItemCollectionName || topItemHasScore) {
@@ -145,9 +148,12 @@ const ModQueueApp = () => {
     }
     checkAttemptedRef.current.add(topItemDocumentId);
     setCheckState('running');
+    const requestedDocumentId = topItemDocumentId;
     api.runCheck({ collectionName: topItemCollectionName, documentId: topItemDocumentId })
       .then(result => {
-        setCheckState(result.pangramScore === null ? 'failed' : null);
+        if (checkDocumentIdRef.current === requestedDocumentId) {
+          setCheckState(result.pangramScore === null ? 'failed' : null);
+        }
         setCards(previous => previous?.map(entry =>
           entry.type === 'content' && entry.item.documentId === topItemDocumentId
             ? {
@@ -163,7 +169,11 @@ const ModQueueApp = () => {
             : entry
         ) ?? previous);
       })
-      .catch(() => setCheckState('failed'));
+      .catch(() => {
+        if (checkDocumentIdRef.current === requestedDocumentId) {
+          setCheckState('failed');
+        }
+      });
   }, [topItemDocumentId, topItemCollectionName, topItemHasScore, checkNonce]);
 
   const retryCheck = useCallback(() => {
@@ -194,7 +204,8 @@ const ModQueueApp = () => {
   }, []);
 
   const runAction = useCallback(async (direction: SwipeDirection, flashLabel: string, action: () => Promise<void>) => {
-    if (busy || !topKey) return;
+    if (busyRef.current || !topKey) return;
+    busyRef.current = true;
     setBusy(true);
     setExitDirection(direction);
     setExitingKey(topKey);
@@ -205,9 +216,10 @@ const ModQueueApp = () => {
       await handleActionError(error);
     } finally {
       setExitingKey(null);
+      busyRef.current = false;
       setBusy(false);
     }
-  }, [busy, topKey, flashAction, handleActionError]);
+  }, [topKey, flashAction, handleActionError]);
 
   const advanceContentCard = useCallback((card: ContentCardData, result: NextItemResponse) => {
     setDecidedCount(count => count + 1);
@@ -580,6 +592,7 @@ const ModQueueApp = () => {
       {composer && (
         <Composer
           mode={composer.mode}
+          recipientDisplayName={composer.card.user.displayName}
           draftKey={
             composer.mode === 'offboard'
               ? `offboard-${composer.card.user._id}`

--- a/simplemod/src/components/ModQueueApp.tsx
+++ b/simplemod/src/components/ModQueueApp.tsx
@@ -1,0 +1,361 @@
+'use client';
+
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { AnimatePresence } from 'framer-motion';
+import * as api from '../lib/api';
+import { ApiError, ConflictError } from '../lib/api';
+import type { ContentCardData, NextItemResponse, OffboardCardData, QueueCard } from '../lib/types';
+import SwipeCard, { type SwipeDirection } from './SwipeCard';
+import ContentCard from './ContentCard';
+import WrapupCard from './WrapupCard';
+import OffboardCard, { type OffboardSelection } from './OffboardCard';
+import Composer, { type ComposerResult } from './Composer';
+import HotkeyLegend from './HotkeyLegend';
+
+type ComposerState =
+  | { mode: 'reject'; card: ContentCardData }
+  | { mode: 'dm'; card: ContentCardData }
+  | { mode: 'offboard'; card: OffboardCardData };
+
+function cardKey(card: QueueCard): string {
+  return card.type === 'content'
+    ? `content-${card.user._id}-${card.item.documentId}`
+    : `${card.type}-${card.user._id}`;
+}
+
+function stampsForCard(card: QueueCard): { left: string; right: string } {
+  switch (card.type) {
+    case 'content': return { left: 'REJECT…', right: 'APPROVE' };
+    case 'offboard': return { left: 'OFFBOARD…', right: 'APPROVE USER' };
+    case 'wrapup': return { left: 'SKIP', right: 'APPROVE USER' };
+  }
+}
+
+const ModQueueApp = () => {
+  const router = useRouter();
+  const [cards, setCards] = useState<QueueCard[] | null>(null);
+  const [moderatorName, setModeratorName] = useState('');
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [exitDirection, setExitDirection] = useState<SwipeDirection>(1);
+  const [composer, setComposer] = useState<ComposerState | null>(null);
+  const [toast, setToast] = useState<string | null>(null);
+  const [offboardSelection, setOffboardSelection] = useState<OffboardSelection>({ selectedIds: [], removePermissions: true });
+
+  const topCard = cards?.[0] ?? null;
+  const topKey = topCard ? cardKey(topCard) : null;
+
+  const loadQueue = useCallback(async () => {
+    try {
+      const response = await api.fetchQueue();
+      setCards(response.cards);
+      setModeratorName(response.moderator.displayName);
+      setLoadError(null);
+    } catch (error) {
+      if (error instanceof ApiError && (error.status === 401 || error.status === 403)) {
+        router.push('/login');
+        return;
+      }
+      setLoadError(error instanceof Error ? error.message : String(error));
+    }
+  }, [router]);
+
+  useEffect(() => {
+    void loadQueue();
+  }, [loadQueue]);
+
+  useEffect(() => {
+    if (topCard?.type === 'offboard') {
+      setOffboardSelection({
+        selectedIds: topCard.items.map(item => item.documentId),
+        removePermissions: true,
+      });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [topKey]);
+
+  useEffect(() => {
+    if (!toast) return;
+    const timeout = setTimeout(() => setToast(null), 4000);
+    return () => clearTimeout(timeout);
+  }, [toast]);
+
+  const handleActionError = useCallback(async (error: unknown) => {
+    if (error instanceof ConflictError) {
+      setToast('Someone else got there first — queue reloaded');
+    } else {
+      setToast(error instanceof Error ? error.message : String(error));
+    }
+    await loadQueue();
+  }, [loadQueue]);
+
+  const runAction = useCallback(async (direction: SwipeDirection, action: () => Promise<void>) => {
+    if (busy) return;
+    setBusy(true);
+    setExitDirection(direction);
+    try {
+      await action();
+    } catch (error) {
+      await handleActionError(error);
+    } finally {
+      setBusy(false);
+    }
+  }, [busy, handleActionError]);
+
+  const advanceContentCard = useCallback((card: ContentCardData, result: NextItemResponse) => {
+    setCards(previous => {
+      if (!previous) return previous;
+      const key = cardKey(card);
+      if (result.nextItem) {
+        const nextItem = result.nextItem;
+        return previous.map(entry => cardKey(entry) === key
+          ? { ...card, item: nextItem, remainingCount: result.remainingCount }
+          : entry
+        );
+      }
+      return previous.filter(entry => cardKey(entry) !== key);
+    });
+  }, []);
+
+  const removeUserCards = useCallback((userId: string) => {
+    setCards(previous => previous?.filter(entry => entry.user._id !== userId) ?? previous);
+  }, []);
+
+  const approveTop = useCallback((card: ContentCardData) =>
+    runAction(1, async () => {
+      const result = await api.approveItem({
+        userId: card.user._id,
+        collectionName: card.item.collectionName,
+        documentId: card.item.documentId,
+      });
+      advanceContentCard(card, result);
+    }), [runAction, advanceContentCard]);
+
+  const rejectTop = useCallback((card: ContentCardData, rejectedReason: string) =>
+    runAction(-1, async () => {
+      const result = await api.rejectItem({
+        userId: card.user._id,
+        collectionName: card.item.collectionName,
+        documentId: card.item.documentId,
+        rejectedReason,
+      });
+      advanceContentCard(card, result);
+    }), [runAction, advanceContentCard]);
+
+  const approveAndDmTop = useCallback((card: ContentCardData, messageHtml: string) =>
+    runAction(1, async () => {
+      const result = await api.approveItemAndDm({
+        userId: card.user._id,
+        collectionName: card.item.collectionName,
+        documentId: card.item.documentId,
+        messageHtml,
+      });
+      advanceContentCard(card, result);
+    }), [runAction, advanceContentCard]);
+
+  const approveUserTop = useCallback((card: QueueCard) =>
+    runAction(1, async () => {
+      await api.approveUser(card.user._id);
+      removeUserCards(card.user._id);
+    }), [runAction, removeUserCards]);
+
+  const skipTop = useCallback((card: QueueCard) =>
+    runAction(-1, async () => {
+      await api.skipUser(card.user._id);
+      removeUserCards(card.user._id);
+    }), [runAction, removeUserCards]);
+
+  const offboardTop = useCallback((card: OffboardCardData, selection: OffboardSelection, result: ComposerResult) =>
+    runAction(-1, async () => {
+      const rejectedReason = result.rejectedReason;
+      const selectedItems = card.items.filter(item => selection.selectedIds.includes(item.documentId));
+      await api.offboardUser({
+        userId: card.user._id,
+        rejections: rejectedReason
+          ? selectedItems.map(item => ({
+              collectionName: item.collectionName,
+              documentId: item.documentId,
+              rejectedReason,
+            }))
+          : [],
+        removePermissions: selection.removePermissions,
+        messageHtml: result.messageHtml,
+      });
+      removeUserCards(card.user._id);
+    }), [runAction, removeUserCards]);
+
+  const handleSwipe = useCallback((direction: SwipeDirection) => {
+    if (!topCard || busy || composer) return;
+    if (direction === 1) {
+      if (topCard.type === 'content') {
+        void approveTop(topCard);
+      } else {
+        void approveUserTop(topCard);
+      }
+    } else {
+      if (topCard.type === 'content') {
+        setComposer({ mode: 'reject', card: topCard });
+      } else if (topCard.type === 'offboard') {
+        setComposer({ mode: 'offboard', card: topCard });
+      } else {
+        void skipTop(topCard);
+      }
+    }
+  }, [topCard, busy, composer, approveTop, approveUserTop, skipTop]);
+
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (composer || busy || !topCard) return;
+      if (event.metaKey || event.ctrlKey || event.altKey) return;
+      const target = event.target as HTMLElement | null;
+      if (target && (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable)) return;
+      switch (event.key.toLowerCase()) {
+        case 'arrowright':
+        case 'a':
+          event.preventDefault();
+          handleSwipe(1);
+          break;
+        case 'arrowleft':
+        case 'r':
+          event.preventDefault();
+          handleSwipe(-1);
+          break;
+        case 'd':
+          if (topCard.type === 'content') {
+            event.preventDefault();
+            setComposer({ mode: 'dm', card: topCard });
+          }
+          break;
+        case 's':
+          event.preventDefault();
+          void skipTop(topCard);
+          break;
+        case 'u':
+          event.preventDefault();
+          void approveUserTop(topCard);
+          break;
+      }
+    };
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [composer, busy, topCard, handleSwipe, skipTop, approveUserTop]);
+
+  const counts = useMemo(() => {
+    const content = cards?.filter(card => card.type === 'content').length ?? 0;
+    const offboard = cards?.filter(card => card.type === 'offboard').length ?? 0;
+    const wrapup = cards?.filter(card => card.type === 'wrapup').length ?? 0;
+    return { content, offboard, wrapup };
+  }, [cards]);
+
+  const handleComposerSubmit = (result: ComposerResult) => {
+    if (!composer) return;
+    const activeComposer = composer;
+    setComposer(null);
+    if (activeComposer.mode === 'reject' && result.rejectedReason) {
+      void rejectTop(activeComposer.card, result.rejectedReason);
+    } else if (activeComposer.mode === 'dm' && result.messageHtml) {
+      void approveAndDmTop(activeComposer.card, result.messageHtml);
+    } else if (activeComposer.mode === 'offboard') {
+      void offboardTop(activeComposer.card, offboardSelection, result);
+    }
+  };
+
+  if (loadError) {
+    return (
+      <main className="queue-shell">
+        <div className="queue-message">
+          <h2>Couldn&apos;t load the queue</h2>
+          <p>{loadError}</p>
+          <button className="button button-primary" onClick={() => void loadQueue()}>Retry</button>
+        </div>
+      </main>
+    );
+  }
+
+  if (!cards) {
+    return (
+      <main className="queue-shell">
+        <div className="queue-message">Loading queue…</div>
+      </main>
+    );
+  }
+
+  const stamps = topCard ? stampsForCard(topCard) : null;
+
+  return (
+    <main className="queue-shell">
+      <header className="queue-hud">
+        <span className="queue-hud-title">SimpleMod</span>
+        <span className="queue-hud-counts">
+          {counts.content > 0 && <span>{counts.content} content</span>}
+          {counts.offboard > 0 && <span className="hud-offboard">{counts.offboard} offboard</span>}
+          {counts.wrapup > 0 && <span>{counts.wrapup} wrap-up</span>}
+          {cards.length === 0 && <span>queue clear</span>}
+        </span>
+        <span className="queue-hud-moderator">{moderatorName}</span>
+      </header>
+      <div className="card-stage">
+        {cards.slice(1, 3).map((card, index) => (
+          <div
+            key={cardKey(card)}
+            className="peek-card"
+            style={{ transform: `scale(${0.96 - index * 0.03}) translateY(${(index + 1) * 14}px)` }}
+          />
+        ))}
+        <AnimatePresence custom={exitDirection} initial={false}>
+          {topCard && stamps && (
+            <SwipeCard
+              key={topKey}
+              onSwipe={handleSwipe}
+              disabled={busy || !!composer}
+              leftStamp={stamps.left}
+              rightStamp={stamps.right}
+            >
+              {topCard.type === 'content' && <ContentCard card={topCard} />}
+              {topCard.type === 'wrapup' && <WrapupCard card={topCard} />}
+              {topCard.type === 'offboard' && (
+                <OffboardCard
+                  card={topCard}
+                  selection={offboardSelection}
+                  onChangeSelection={setOffboardSelection}
+                />
+              )}
+            </SwipeCard>
+          )}
+        </AnimatePresence>
+        {cards.length === 0 && (
+          <div className="queue-message queue-done">
+            <h2>All clear 🎉</h2>
+            <p>No users waiting for review.</p>
+            <button className="button button-secondary" onClick={() => void loadQueue()}>Check again</button>
+          </div>
+        )}
+      </div>
+      {topCard && <HotkeyLegend card={topCard} />}
+      {composer && (
+        <Composer
+          mode={composer.mode}
+          title={
+            composer.mode === 'reject'
+              ? `Reject ${composer.card.item.collectionName === 'Posts' ? `"${composer.card.item.title}"` : 'this comment'}`
+              : composer.mode === 'dm'
+                ? `Approve and message ${composer.card.user.displayName}`
+                : `Offboard ${composer.card.user.displayName}`
+          }
+          rejectionCount={composer.mode === 'offboard' ? offboardSelection.selectedIds.length : 1}
+          submitLabel={
+            composer.mode === 'reject' ? 'Reject'
+              : composer.mode === 'dm' ? 'Approve & send'
+                : 'Offboard'
+          }
+          onSubmit={handleComposerSubmit}
+          onCancel={() => setComposer(null)}
+        />
+      )}
+      {toast && <div className="toast">{toast}</div>}
+    </main>
+  );
+};
+
+export default ModQueueApp;

--- a/simplemod/src/components/ModQueueApp.tsx
+++ b/simplemod/src/components/ModQueueApp.tsx
@@ -88,6 +88,8 @@ const ModQueueApp = () => {
   const checkDocumentIdRef = useRef<string | null>(null);
   const busyRef = useRef(false);
   const flashNonceRef = useRef(0);
+  const removedUsersRef = useRef<Set<string>>(new Set());
+  const decidedDocsRef = useRef<Set<string>>(new Set());
 
   const topCard = cards?.[0] ?? null;
   const topKey = topCard ? cardKey(topCard) : null;
@@ -103,12 +105,39 @@ const ModQueueApp = () => {
     });
   }, []);
 
-  const loadQueue = useCallback(async () => {
+  // Full queue results merge over local state so decisions made while the
+  // request was in flight aren't resurrected: removed users stay gone and
+  // already-decided items keep the locally-advanced card.
+  const applyFullQueue = useCallback((fullCards: QueueCard[]) => {
+    setCards(local => {
+      if (!local) return fullCards;
+      const localByUser = new Map(local.map(card => [card.user._id, card] as const));
+      const merged: QueueCard[] = [];
+      for (const card of fullCards) {
+        if (removedUsersRef.current.has(card.user._id)) continue;
+        if (card.type === 'content' && decidedDocsRef.current.has(card.item.documentId)) {
+          const localCard = localByUser.get(card.user._id);
+          if (localCard?.type === 'content') merged.push(localCard);
+          continue;
+        }
+        merged.push(card);
+      }
+      return merged;
+    });
+  }, []);
+
+  const loadQueue = useCallback(async ({ merge = false }: { merge?: boolean } = {}) => {
     try {
       const response = await api.fetchQueue();
-      setCards(response.cards);
       setModeratorName(response.moderator.displayName);
       setLoadError(null);
+      if (merge) {
+        applyFullQueue(response.cards);
+      } else {
+        removedUsersRef.current.clear();
+        decidedDocsRef.current.clear();
+        setCards(response.cards);
+      }
     } catch (error) {
       if (error instanceof ApiError && (error.status === 401 || error.status === 403)) {
         router.push('/login');
@@ -116,11 +145,33 @@ const ModQueueApp = () => {
       }
       setLoadError(error instanceof Error ? error.message : String(error));
     }
-  }, [router]);
+  }, [router, applyFullQueue]);
 
   useEffect(() => {
-    void loadQueue();
+    let cancelled = false;
+    // Quick prefix (first ~3 cards) and full queue race in parallel; whichever
+    // lands first renders, and the full result merges in behind it.
+    api.fetchQueue(true)
+      .then(response => {
+        if (cancelled) return;
+        setModeratorName(response.moderator.displayName);
+        setCards(local => local ?? response.cards);
+      })
+      .catch(() => {});
+    void loadQueue({ merge: true });
+    return () => { cancelled = true; };
   }, [loadQueue]);
+
+  useEffect(() => {
+    api.prefetchComposerTemplates();
+  }, []);
+
+  const topUserId = topCard?.user._id ?? null;
+  useEffect(() => {
+    if (topUserId) {
+      api.fetchUserContext(topUserId).catch(() => {});
+    }
+  }, [topUserId]);
 
   useEffect(() => {
     if (topCard?.type === 'offboard') {
@@ -223,6 +274,11 @@ const ModQueueApp = () => {
 
   const advanceContentCard = useCallback((card: ContentCardData, result: NextItemResponse) => {
     setDecidedCount(count => count + 1);
+    decidedDocsRef.current.add(card.item.documentId);
+    if (!result.nextItem) {
+      removedUsersRef.current.add(card.user._id);
+    }
+    api.invalidateUserContext(card.user._id);
     setCards(previous => {
       if (!previous) return previous;
       const key = cardKey(card);
@@ -239,6 +295,8 @@ const ModQueueApp = () => {
 
   const removeUserCards = useCallback((userId: string) => {
     setDecidedCount(count => count + 1);
+    removedUsersRef.current.add(userId);
+    api.invalidateUserContext(userId);
     setCards(previous => previous?.filter(entry => entry.user._id !== userId) ?? previous);
   }, []);
 

--- a/simplemod/src/components/OffboardCard.tsx
+++ b/simplemod/src/components/OffboardCard.tsx
@@ -45,7 +45,7 @@ const OffboardCard = ({ card, selection, onChangeSelection }: {
       <div className="section-label">
         {items.length > 0
           ? `Remaining unreviewed content — check items to reject on offboard (${selection.selectedIds.length}/${items.length} selected)`
-          : 'No unreviewed content remaining'}
+          : 'All content decided — choose what happens to this user'}
       </div>
       <div className="offboard-items">
         {items.map(item => (

--- a/simplemod/src/components/OffboardCard.tsx
+++ b/simplemod/src/components/OffboardCard.tsx
@@ -1,0 +1,89 @@
+'use client';
+
+import React from 'react';
+import classNames from 'classnames';
+import type { OffboardCardData } from '../lib/types';
+import UserHeader from './UserHeader';
+import { formatPostedAt, PangramBadge } from './ContentCard';
+
+export interface OffboardSelection {
+  selectedIds: string[];
+  removePermissions: boolean;
+}
+
+const OffboardCard = ({ card, selection, onChangeSelection }: {
+  card: OffboardCardData;
+  selection: OffboardSelection;
+  onChangeSelection: (selection: OffboardSelection) => void;
+}) => {
+  const { user, items, rejectedPostCount, rejectedCommentCount } = card;
+  const rejectedSummary = [
+    rejectedPostCount > 0 ? `${rejectedPostCount} rejected post${rejectedPostCount === 1 ? '' : 's'}` : null,
+    rejectedCommentCount > 0 ? `${rejectedCommentCount} rejected comment${rejectedCommentCount === 1 ? '' : 's'}` : null,
+  ].filter(Boolean).join(', ');
+
+  const toggleItem = (documentId: string) => {
+    const selected = new Set(selection.selectedIds);
+    if (selected.has(documentId)) {
+      selected.delete(documentId);
+    } else {
+      selected.add(documentId);
+    }
+    onChangeSelection({ ...selection, selectedIds: [...selected] });
+  };
+
+  return (
+    <div className="card-body">
+      <UserHeader user={user} subtitle={rejectedSummary || undefined} />
+      {user.karma < 0 && <div className="offboard-reason">Negative karma ({user.karma})</div>}
+      {user.htmlBio && (
+        <>
+          <div className="section-label">Bio</div>
+          <div className="content-html content-html-compact" dangerouslySetInnerHTML={{ __html: user.htmlBio }} />
+        </>
+      )}
+      <div className="section-label">
+        {items.length > 0
+          ? `Remaining unreviewed content — check items to reject on offboard (${selection.selectedIds.length}/${items.length} selected)`
+          : 'No unreviewed content remaining'}
+      </div>
+      <div className="offboard-items">
+        {items.map(item => (
+          <label key={item.documentId} className={classNames('offboard-item', selection.selectedIds.includes(item.documentId) && 'offboard-item-selected')}>
+            <input
+              type="checkbox"
+              checked={selection.selectedIds.includes(item.documentId)}
+              onChange={() => toggleItem(item.documentId)}
+            />
+            <span className="offboard-item-info">
+              <span className="offboard-item-title">
+                {item.collectionName === 'Posts' ? (item.title ?? 'Untitled post') : `Comment on: ${item.postTitle ?? 'unknown post'}`}
+              </span>
+              <span className="offboard-item-meta">
+                {formatPostedAt(item.postedAt)}
+                <PangramBadge pangramScore={item.pangramScore} aiChoice={item.aiChoice} />
+              </span>
+              {item.html && <span className="offboard-item-excerpt" dangerouslySetInnerHTML={{ __html: item.html }} />}
+            </span>
+          </label>
+        ))}
+      </div>
+      <label className="offboard-permissions-toggle">
+        <input
+          type="checkbox"
+          checked={selection.removePermissions}
+          onChange={event => onChangeSelection({ ...selection, removePermissions: event.target.checked })}
+        />
+        Disable posting, commenting, and messaging on offboard
+      </label>
+      {user.sunshineNotes && (
+        <>
+          <div className="section-label">Moderator notes</div>
+          <pre className="mod-notes">{user.sunshineNotes}</pre>
+        </>
+      )}
+    </div>
+  );
+};
+
+export default OffboardCard;

--- a/simplemod/src/components/SwipeCard.tsx
+++ b/simplemod/src/components/SwipeCard.tsx
@@ -1,0 +1,66 @@
+'use client';
+
+import React from 'react';
+import { motion, useMotionValue, useTransform, type PanInfo, type Variants } from 'framer-motion';
+
+export type SwipeDirection = 1 | -1;
+
+const SWIPE_COMMIT_THRESHOLD = 140;
+
+export const cardVariants: Variants = {
+  enter: { scale: 0.96, y: 16, opacity: 0 },
+  center: { scale: 1, y: 0, x: 0, opacity: 1 },
+  exit: (direction: SwipeDirection) => ({
+    x: direction * 800,
+    rotate: direction * 18,
+    opacity: 0,
+    transition: { duration: 0.28, ease: 'easeIn' },
+  }),
+};
+
+const SwipeCard = ({ children, onSwipe, disabled = false, leftStamp, rightStamp }: {
+  children: React.ReactNode;
+  onSwipe: (direction: SwipeDirection) => void;
+  disabled?: boolean;
+  leftStamp: string;
+  rightStamp: string;
+}) => {
+  const x = useMotionValue(0);
+  const rotate = useTransform(x, [-300, 300], [-10, 10]);
+  const rightStampOpacity = useTransform(x, [40, SWIPE_COMMIT_THRESHOLD], [0, 1]);
+  const leftStampOpacity = useTransform(x, [-SWIPE_COMMIT_THRESHOLD, -40], [1, 0]);
+
+  const handleDragEnd = (_event: MouseEvent | TouchEvent | PointerEvent, info: PanInfo) => {
+    if (info.offset.x > SWIPE_COMMIT_THRESHOLD) {
+      onSwipe(1);
+    } else if (info.offset.x < -SWIPE_COMMIT_THRESHOLD) {
+      onSwipe(-1);
+    }
+  };
+
+  return (
+    <motion.div
+      className="swipe-card"
+      drag={disabled ? false : 'x'}
+      dragSnapToOrigin
+      dragElastic={0.9}
+      onDragEnd={handleDragEnd}
+      style={{ x, rotate }}
+      variants={cardVariants}
+      initial="enter"
+      animate="center"
+      exit="exit"
+      transition={{ duration: 0.22, ease: 'easeOut' }}
+    >
+      <motion.div className="swipe-stamp swipe-stamp-right" style={{ opacity: rightStampOpacity }}>
+        {rightStamp}
+      </motion.div>
+      <motion.div className="swipe-stamp swipe-stamp-left" style={{ opacity: leftStampOpacity }}>
+        {leftStamp}
+      </motion.div>
+      {children}
+    </motion.div>
+  );
+};
+
+export default SwipeCard;

--- a/simplemod/src/components/SwipeCard.tsx
+++ b/simplemod/src/components/SwipeCard.tsx
@@ -7,6 +7,11 @@ export type SwipeDirection = 1 | -1;
 
 const SWIPE_COMMIT_THRESHOLD = 140;
 
+// Regions where a pointer-drag means "select text / interact", not "swipe the
+// card". Drag still works from the header, edges, and blank space; keyboard is
+// the primary commit path.
+const NO_DRAG_SELECTOR = '.content-html, .mod-notes, .offboard-items, .context-item, .composer, button, input, textarea, select, a, kbd';
+
 export const cardVariants: Variants = {
   enter: { scale: 0.96, y: 16, opacity: 0 },
   center: { scale: 1, y: 0, x: 0, opacity: 1 },
@@ -17,6 +22,13 @@ export const cardVariants: Variants = {
     transition: { duration: 0.28, ease: 'easeIn' },
   }),
 };
+
+function stopDragFromTextRegions(event: React.PointerEvent) {
+  const target = event.target as HTMLElement | null;
+  if (target?.closest(NO_DRAG_SELECTOR)) {
+    event.stopPropagation();
+  }
+}
 
 const SwipeCard = ({ children, onSwipe, disabled = false, busy = false, leftStamp, rightStamp }: {
   children: React.ReactNode;
@@ -32,6 +44,9 @@ const SwipeCard = ({ children, onSwipe, disabled = false, busy = false, leftStam
   const leftStampOpacity = useTransform(x, [-SWIPE_COMMIT_THRESHOLD, -40], [1, 0]);
 
   const handleDragEnd = (_event: MouseEvent | TouchEvent | PointerEvent, info: PanInfo) => {
+    if (window.getSelection()?.toString()) {
+      return;
+    }
     if (info.offset.x > SWIPE_COMMIT_THRESHOLD) {
       onSwipe(1);
     } else if (info.offset.x < -SWIPE_COMMIT_THRESHOLD) {
@@ -59,7 +74,9 @@ const SwipeCard = ({ children, onSwipe, disabled = false, busy = false, leftStam
       <motion.div className="swipe-stamp swipe-stamp-left" style={{ opacity: leftStampOpacity }}>
         {leftStamp}
       </motion.div>
-      {children}
+      <div className="swipe-card-content" onPointerDownCapture={stopDragFromTextRegions}>
+        {children}
+      </div>
     </motion.div>
   );
 };

--- a/simplemod/src/components/SwipeCard.tsx
+++ b/simplemod/src/components/SwipeCard.tsx
@@ -18,10 +18,11 @@ export const cardVariants: Variants = {
   }),
 };
 
-const SwipeCard = ({ children, onSwipe, disabled = false, leftStamp, rightStamp }: {
+const SwipeCard = ({ children, onSwipe, disabled = false, busy = false, leftStamp, rightStamp }: {
   children: React.ReactNode;
   onSwipe: (direction: SwipeDirection) => void;
   disabled?: boolean;
+  busy?: boolean;
   leftStamp: string;
   rightStamp: string;
 }) => {
@@ -40,7 +41,7 @@ const SwipeCard = ({ children, onSwipe, disabled = false, leftStamp, rightStamp 
 
   return (
     <motion.div
-      className="swipe-card"
+      className={busy ? 'swipe-card swipe-card-busy' : 'swipe-card'}
       drag={disabled ? false : 'x'}
       dragSnapToOrigin
       dragElastic={0.9}

--- a/simplemod/src/components/UserHeader.tsx
+++ b/simplemod/src/components/UserHeader.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import React from 'react';
+import type { QueueUser } from '../lib/types';
+
+function accountAge(createdAt: string): string {
+  const days = Math.floor((Date.now() - new Date(createdAt).getTime()) / (24 * 60 * 60 * 1000));
+  if (days < 1) return 'today';
+  if (days < 30) return `${days}d old`;
+  if (days < 365) return `${Math.floor(days / 30)}mo old`;
+  return `${Math.floor(days / 365)}y old`;
+}
+
+const UserHeader = ({ user, subtitle }: { user: QueueUser; subtitle?: string }) => {
+  return (
+    <header className="user-header">
+      <div className="user-header-main">
+        <span className="user-name">{user.displayName}</span>
+        {user.sunshineFlagged && <span className="chip chip-flagged">Flagged</span>}
+        {user.reviewGroup === 'offboard' && <span className="chip chip-offboard">Offboard candidate</span>}
+      </div>
+      <div className="user-header-stats">
+        <span>{user.karma} karma</span>
+        <span>{accountAge(user.createdAt)}</span>
+        <span>{user.postCount} posts</span>
+        <span>{user.commentCount} comments</span>
+        {subtitle && <span className="user-header-subtitle">{subtitle}</span>}
+      </div>
+    </header>
+  );
+};
+
+export default UserHeader;

--- a/simplemod/src/components/UserHeader.tsx
+++ b/simplemod/src/components/UserHeader.tsx
@@ -11,19 +11,23 @@ function accountAge(createdAt: string): string {
   return `${Math.floor(days / 365)}y old`;
 }
 
+function pluralize(count: number, singular: string): string {
+  return `${count} ${singular}${count === 1 ? '' : 's'}`;
+}
+
 const UserHeader = ({ user, subtitle }: { user: QueueUser; subtitle?: string }) => {
   return (
     <header className="user-header">
       <div className="user-header-main">
-        <span className="user-name">{user.displayName}</span>
+        <a className="user-name" href={user.profileUrl} target="_blank" rel="noreferrer">{user.displayName}</a>
         {user.sunshineFlagged && <span className="chip chip-flagged">Flagged</span>}
         {user.reviewGroup === 'offboard' && <span className="chip chip-offboard">Offboard candidate</span>}
       </div>
       <div className="user-header-stats">
         <span>{user.karma} karma</span>
         <span>{accountAge(user.createdAt)}</span>
-        <span>{user.postCount} posts</span>
-        <span>{user.commentCount} comments</span>
+        <span>{pluralize(user.postCount, 'post')}</span>
+        <span>{pluralize(user.commentCount, 'comment')}</span>
         {subtitle && <span className="user-header-subtitle">{subtitle}</span>}
       </div>
     </header>

--- a/simplemod/src/components/WrapupCard.tsx
+++ b/simplemod/src/components/WrapupCard.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import React from 'react';
+import type { WrapupCardData } from '../lib/types';
+import UserHeader from './UserHeader';
+
+const WrapupCard = ({ card }: { card: WrapupCardData }) => {
+  const { user } = card;
+  return (
+    <div className="card-body">
+      <UserHeader user={user} />
+      <div className="wrapup-message">
+        <h2>Nothing left to review</h2>
+        <p>
+          All of this user&apos;s current content has been reviewed, rejected, or deleted, but they are
+          still in the review queue.
+        </p>
+        <p className="wrapup-hint">
+          Swipe right (or press <kbd>U</kbd>) to approve them as a user; swipe left (or press <kbd>S</kbd>)
+          to remove them from the queue without approving — their future content will be reviewed again.
+        </p>
+      </div>
+      {user.htmlBio && (
+        <>
+          <div className="section-label">Bio</div>
+          <div className="content-html" dangerouslySetInnerHTML={{ __html: user.htmlBio }} />
+        </>
+      )}
+      {user.sunshineNotes && (
+        <>
+          <div className="section-label">Moderator notes</div>
+          <pre className="mod-notes">{user.sunshineNotes}</pre>
+        </>
+      )}
+    </div>
+  );
+};
+
+export default WrapupCard;

--- a/simplemod/src/lib/api.ts
+++ b/simplemod/src/lib/api.ts
@@ -43,8 +43,22 @@ export function fetchQueue(): Promise<QueueResponse> {
   return request<QueueResponse>('/api/queue');
 }
 
-export function fetchTemplates(collection: 'Rejections' | 'Messages'): Promise<{ templates: ModerationTemplateData[]; rejectionIntroHtml: string }> {
-  return request(`/api/templates?collection=${collection}`);
+interface TemplatesResponse {
+  templates: ModerationTemplateData[];
+  rejectionIntroHtml: string;
+}
+
+const templateCache = new Map<string, Promise<TemplatesResponse>>();
+
+export function fetchTemplates(collection: 'Rejections' | 'Messages'): Promise<TemplatesResponse> {
+  const cached = templateCache.get(collection);
+  if (cached) {
+    return cached;
+  }
+  const fetched = request<TemplatesResponse>(`/api/templates?collection=${collection}`);
+  templateCache.set(collection, fetched);
+  fetched.catch(() => templateCache.delete(collection));
+  return fetched;
 }
 
 export function fetchUserContext(userId: string): Promise<UserContextResponse> {

--- a/simplemod/src/lib/api.ts
+++ b/simplemod/src/lib/api.ts
@@ -1,0 +1,83 @@
+import type { ModerationTemplateData, NextItemResponse, QueueItem, QueueResponse, ReviewCollectionName } from './types';
+
+export class ApiError extends Error {
+  status: number;
+
+  constructor(status: number, message: string) {
+    super(message);
+    this.status = status;
+  }
+}
+
+export class ConflictError extends ApiError {
+  currentEarliest: QueueItem | null;
+
+  constructor(message: string, currentEarliest: QueueItem | null) {
+    super(409, message);
+    this.currentEarliest = currentEarliest;
+  }
+}
+
+async function request<T>(path: string, init?: RequestInit): Promise<T> {
+  const response = await fetch(path, init);
+  const body = await response.json().catch(() => null);
+  if (!response.ok) {
+    const message = body?.error ?? `Request failed (${response.status})`;
+    if (response.status === 409) {
+      throw new ConflictError(message, body?.currentEarliest ?? null);
+    }
+    throw new ApiError(response.status, message);
+  }
+  return body as T;
+}
+
+function post<T>(path: string, body: Record<string, unknown>): Promise<T> {
+  return request<T>(path, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+export function fetchQueue(): Promise<QueueResponse> {
+  return request<QueueResponse>('/api/queue');
+}
+
+export function fetchTemplates(collection: 'Rejections' | 'Messages'): Promise<{ templates: ModerationTemplateData[]; rejectionIntroHtml: string }> {
+  return request(`/api/templates?collection=${collection}`);
+}
+
+export interface ItemActionInput {
+  userId: string;
+  collectionName: ReviewCollectionName;
+  documentId: string;
+}
+
+export function approveItem(input: ItemActionInput): Promise<NextItemResponse> {
+  return post('/api/actions/approve', { ...input });
+}
+
+export function rejectItem(input: ItemActionInput & { rejectedReason: string }): Promise<NextItemResponse> {
+  return post('/api/actions/reject', { ...input });
+}
+
+export function approveItemAndDm(input: ItemActionInput & { messageHtml: string }): Promise<NextItemResponse> {
+  return post('/api/actions/approve-and-dm', { ...input });
+}
+
+export function skipUser(userId: string): Promise<{ ok: true }> {
+  return post('/api/actions/skip', { userId });
+}
+
+export function approveUser(userId: string): Promise<{ ok: true }> {
+  return post('/api/actions/approve-user', { userId });
+}
+
+export function offboardUser(input: {
+  userId: string;
+  rejections: { collectionName: ReviewCollectionName; documentId: string; rejectedReason: string }[];
+  removePermissions: boolean;
+  messageHtml?: string;
+}): Promise<{ ok: true }> {
+  return post('/api/actions/offboard', { ...input });
+}

--- a/simplemod/src/lib/api.ts
+++ b/simplemod/src/lib/api.ts
@@ -1,4 +1,4 @@
-import type { ModerationTemplateData, NextItemResponse, QueueItem, QueueResponse, ReviewCollectionName } from './types';
+import type { ModerationTemplateData, NextItemResponse, QueueItem, QueueResponse, ReviewCollectionName, RunCheckResponse, UserContextResponse } from './types';
 
 export class ApiError extends Error {
   status: number;
@@ -45,6 +45,14 @@ export function fetchQueue(): Promise<QueueResponse> {
 
 export function fetchTemplates(collection: 'Rejections' | 'Messages'): Promise<{ templates: ModerationTemplateData[]; rejectionIntroHtml: string }> {
   return request(`/api/templates?collection=${collection}`);
+}
+
+export function fetchUserContext(userId: string): Promise<UserContextResponse> {
+  return request(`/api/user-context?userId=${encodeURIComponent(userId)}`);
+}
+
+export function runCheck(input: { collectionName: ReviewCollectionName; documentId: string }): Promise<RunCheckResponse> {
+  return post('/api/actions/run-check', { ...input });
 }
 
 export interface ItemActionInput {

--- a/simplemod/src/lib/api.ts
+++ b/simplemod/src/lib/api.ts
@@ -39,8 +39,8 @@ function post<T>(path: string, body: Record<string, unknown>): Promise<T> {
   });
 }
 
-export function fetchQueue(): Promise<QueueResponse> {
-  return request<QueueResponse>('/api/queue');
+export function fetchQueue(quick = false): Promise<QueueResponse> {
+  return request<QueueResponse>(quick ? '/api/queue?quick=1' : '/api/queue');
 }
 
 interface TemplatesResponse {
@@ -61,8 +61,26 @@ export function fetchTemplates(collection: 'Rejections' | 'Messages'): Promise<T
   return fetched;
 }
 
+const userContextCache = new Map<string, Promise<UserContextResponse>>();
+
 export function fetchUserContext(userId: string): Promise<UserContextResponse> {
-  return request(`/api/user-context?userId=${encodeURIComponent(userId)}`);
+  const cached = userContextCache.get(userId);
+  if (cached) {
+    return cached;
+  }
+  const fetched = request<UserContextResponse>(`/api/user-context?userId=${encodeURIComponent(userId)}`);
+  userContextCache.set(userId, fetched);
+  fetched.catch(() => userContextCache.delete(userId));
+  return fetched;
+}
+
+export function invalidateUserContext(userId: string): void {
+  userContextCache.delete(userId);
+}
+
+export function prefetchComposerTemplates(): void {
+  fetchTemplates('Rejections').catch(() => {});
+  fetchTemplates('Messages').catch(() => {});
 }
 
 export function runCheck(input: { collectionName: ReviewCollectionName; documentId: string }): Promise<RunCheckResponse> {

--- a/simplemod/src/lib/types.ts
+++ b/simplemod/src/lib/types.ts
@@ -1,0 +1,77 @@
+export type ReviewCollectionName = 'Posts' | 'Comments';
+
+export interface QueueItem {
+  documentId: string;
+  collectionName: ReviewCollectionName;
+  postedAt: string;
+  title: string | null;
+  postTitle: string | null;
+  postId: string | null;
+  html: string | null;
+  baseScore: number | null;
+  pangramScore: number | null;
+  pangramFractionAi: number | null;
+  aiChoice: string | null;
+  rejected: boolean;
+}
+
+export interface QueueUser {
+  _id: string;
+  displayName: string;
+  slug: string;
+  createdAt: string;
+  karma: number;
+  postCount: number;
+  commentCount: number;
+  htmlBio: string | null;
+  sunshineFlagged: boolean;
+  sunshineNotes: string;
+  reviewGroup: 'newContent' | 'offboard';
+  postingDisabled: boolean;
+  allCommentingDisabled: boolean;
+  conversationsDisabled: boolean;
+}
+
+export interface ContentCardData {
+  type: 'content';
+  user: QueueUser;
+  item: QueueItem;
+  remainingCount: number;
+}
+
+export interface OffboardCardData {
+  type: 'offboard';
+  user: QueueUser;
+  items: QueueItem[];
+  rejectedPostCount: number;
+  rejectedCommentCount: number;
+}
+
+export interface WrapupCardData {
+  type: 'wrapup';
+  user: QueueUser;
+}
+
+export type QueueCard = ContentCardData | OffboardCardData | WrapupCardData;
+
+export interface QueueResponse {
+  cards: QueueCard[];
+  moderator: { _id: string; displayName: string };
+}
+
+export interface ModerationTemplateData {
+  _id: string;
+  name: string;
+  collectionName: string;
+  html: string | null;
+}
+
+export interface NextItemResponse {
+  nextItem: QueueItem | null;
+  remainingCount: number;
+}
+
+export interface EarliestItemConflict {
+  error: string;
+  currentEarliest: QueueItem | null;
+}

--- a/simplemod/src/lib/types.ts
+++ b/simplemod/src/lib/types.ts
@@ -99,8 +99,3 @@ export interface NextItemResponse {
   nextItem: QueueItem | null;
   remainingCount: number;
 }
-
-export interface EarliestItemConflict {
-  error: string;
-  currentEarliest: QueueItem | null;
-}

--- a/simplemod/src/lib/types.ts
+++ b/simplemod/src/lib/types.ts
@@ -22,6 +22,9 @@ export interface QueueItem {
   pangramWindowScores: PangramWindowScore[] | null;
   aiChoice: string | null;
   rejected: boolean;
+  itemUrl: string;
+  parentCommentHtml: string | null;
+  parentCommentAuthor: string | null;
 }
 
 export interface UserContentItem extends QueueItem {
@@ -55,6 +58,7 @@ export interface QueueUser {
   postingDisabled: boolean;
   allCommentingDisabled: boolean;
   conversationsDisabled: boolean;
+  profileUrl: string;
 }
 
 export interface ContentCardData {

--- a/simplemod/src/lib/types.ts
+++ b/simplemod/src/lib/types.ts
@@ -1,5 +1,12 @@
 export type ReviewCollectionName = 'Posts' | 'Comments';
 
+export interface PangramWindowScore {
+  text: string;
+  score: number;
+  startIndex: number;
+  endIndex: number;
+}
+
 export interface QueueItem {
   documentId: string;
   collectionName: ReviewCollectionName;
@@ -11,8 +18,26 @@ export interface QueueItem {
   baseScore: number | null;
   pangramScore: number | null;
   pangramFractionAi: number | null;
+  pangramPrediction: string | null;
+  pangramWindowScores: PangramWindowScore[] | null;
   aiChoice: string | null;
   rejected: boolean;
+}
+
+export interface UserContentItem extends QueueItem {
+  status: 'approved' | 'unreviewed' | 'rejected' | 'draft';
+}
+
+export interface UserContextResponse {
+  items: UserContentItem[];
+}
+
+export interface RunCheckResponse {
+  pangramScore: number | null;
+  pangramFractionAi: number | null;
+  pangramPrediction: string | null;
+  pangramWindowScores: PangramWindowScore[] | null;
+  alreadyExisted: boolean;
 }
 
 export interface QueueUser {

--- a/simplemod/src/lib/types.ts
+++ b/simplemod/src/lib/types.ts
@@ -98,4 +98,5 @@ export interface ModerationTemplateData {
 export interface NextItemResponse {
   nextItem: QueueItem | null;
   remainingCount: number;
+  offboardCard?: OffboardCardData | null;
 }

--- a/simplemod/src/server/actionRoute.ts
+++ b/simplemod/src/server/actionRoute.ts
@@ -1,0 +1,48 @@
+import type { NextRequest } from 'next/server';
+import { NextResponse } from 'next/server';
+import { getModeratorSession, isErrorResponse, type ModeratorSession } from './fmAuth';
+import { EarliestItemConflictError } from './actions';
+import type { ReviewCollectionName } from '../lib/types';
+
+export async function handleActionRequest(
+  req: NextRequest,
+  handler: (session: ModeratorSession, body: Record<string, unknown>) => Promise<unknown>,
+): Promise<NextResponse> {
+  const session = await getModeratorSession(req);
+  if (isErrorResponse(session)) {
+    return session;
+  }
+  const body: unknown = await req.json().catch(() => null);
+  if (!body || typeof body !== 'object') {
+    return NextResponse.json({ error: 'Invalid request body' }, { status: 400 });
+  }
+  try {
+    const result = await handler(session, body as Record<string, unknown>);
+    return NextResponse.json(result ?? { ok: true });
+  } catch (error) {
+    if (error instanceof EarliestItemConflictError) {
+      return NextResponse.json(
+        { error: error.message, currentEarliest: error.currentEarliest },
+        { status: 409 },
+      );
+    }
+    const message = error instanceof Error ? error.message : String(error);
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}
+
+export function requireString(body: Record<string, unknown>, field: string): string {
+  const value = body[field];
+  if (typeof value !== 'string' || !value) {
+    throw new Error(`${field} is required`);
+  }
+  return value;
+}
+
+export function requireCollectionName(body: Record<string, unknown>): ReviewCollectionName {
+  const value = body.collectionName;
+  if (value !== 'Posts' && value !== 'Comments') {
+    throw new Error('collectionName must be Posts or Comments');
+  }
+  return value;
+}

--- a/simplemod/src/server/actionRoute.ts
+++ b/simplemod/src/server/actionRoute.ts
@@ -4,6 +4,8 @@ import { getModeratorSession, isErrorResponse, type ModeratorSession } from './f
 import { EarliestItemConflictError } from './actions';
 import type { ReviewCollectionName } from '../lib/types';
 
+export class ValidationError extends Error {}
+
 export async function handleActionRequest(
   req: NextRequest,
   handler: (session: ModeratorSession, body: Record<string, unknown>) => Promise<unknown>,
@@ -26,6 +28,9 @@ export async function handleActionRequest(
         { status: 409 },
       );
     }
+    if (error instanceof ValidationError) {
+      return NextResponse.json({ error: error.message }, { status: 400 });
+    }
     const message = error instanceof Error ? error.message : String(error);
     return NextResponse.json({ error: message }, { status: 500 });
   }
@@ -34,7 +39,7 @@ export async function handleActionRequest(
 export function requireString(body: Record<string, unknown>, field: string): string {
   const value = body[field];
   if (typeof value !== 'string' || !value) {
-    throw new Error(`${field} is required`);
+    throw new ValidationError(`${field} is required`);
   }
   return value;
 }
@@ -42,7 +47,7 @@ export function requireString(body: Record<string, unknown>, field: string): str
 export function requireCollectionName(body: Record<string, unknown>): ReviewCollectionName {
   const value = body.collectionName;
   if (value !== 'Posts' && value !== 'Comments') {
-    throw new Error('collectionName must be Posts or Comments');
+    throw new ValidationError('collectionName must be Posts or Comments');
   }
   return value;
 }

--- a/simplemod/src/server/actions.ts
+++ b/simplemod/src/server/actions.ts
@@ -1,0 +1,272 @@
+import { updatePost } from '@/server/collections/posts/mutations';
+import { updateComment } from '@/server/collections/comments/mutations';
+import { updateUser } from '@/server/collections/users/mutations';
+import { createConversation } from '@/server/collections/conversations/mutations';
+import { createMessage } from '@/server/collections/messages/mutations';
+import { createModeratorAction } from '@/server/collections/moderatorActions/mutations';
+import { VOTING_DISABLED } from '@/lib/collections/moderatorActions/constants';
+import { appendToSunshineNotes, getSignatureWithNote } from '@/lib/collections/users/helpers';
+import { approveUnreviewedSubmissions } from '@/server/callbacks/userCallbackFunctions';
+import { getEarliestUnreviewedItem } from './queue';
+import type { NextItemResponse, QueueItem, ReviewCollectionName } from '../lib/types';
+
+/**
+ * SimpleMod reviews content strictly earliest-first, so hotkey races must not
+ * be able to approve/reject a later item while an earlier one is still
+ * undecided. Actions for a given moderated user are serialized through a
+ * per-user promise chain, and the earliest-item check runs inside the critical
+ * section. This is sufficient for a single-instance internal tool; a
+ * multi-instance deployment would need pg_advisory_xact_lock around the
+ * check-and-write instead.
+ */
+const userLocks = new Map<string, Promise<unknown>>();
+
+export async function withUserLock<T>(userId: string, fn: () => Promise<T>): Promise<T> {
+  const previous = userLocks.get(userId) ?? Promise.resolve();
+  const run = previous.then(fn, fn);
+  const tail = run.then(() => {}, () => {});
+  userLocks.set(userId, tail);
+  try {
+    return await run;
+  } finally {
+    if (userLocks.get(userId) === tail) {
+      userLocks.delete(userId);
+    }
+  }
+}
+
+export class EarliestItemConflictError extends Error {
+  currentEarliest: QueueItem | null;
+
+  constructor(currentEarliest: QueueItem | null) {
+    super('Not the earliest unreviewed item for this user');
+    this.currentEarliest = currentEarliest;
+  }
+}
+
+interface ItemActionArgs {
+  userId: string;
+  collectionName: ReviewCollectionName;
+  documentId: string;
+}
+
+async function assertIsEarliestItem({ userId, collectionName, documentId }: ItemActionArgs): Promise<void> {
+  const { item } = await getEarliestUnreviewedItem(userId);
+  if (!item || item.collectionName !== collectionName || item.documentId !== documentId) {
+    throw new EarliestItemConflictError(item);
+  }
+}
+
+async function loadOwnedDocument(context: ResolverContext, { userId, collectionName, documentId }: ItemActionArgs): Promise<DbPost | DbComment> {
+  const document = collectionName === 'Posts'
+    ? await context.Posts.findOne(documentId)
+    : await context.Comments.findOne(documentId);
+  if (!document) {
+    throw new Error(`Invalid ${collectionName} ID`);
+  }
+  if (document.userId !== userId) {
+    throw new Error(`${collectionName} document does not belong to user`);
+  }
+  return document;
+}
+
+function itemDescription(collectionName: ReviewCollectionName, document: DbPost | DbComment): string {
+  if (collectionName === 'Posts') {
+    return `post "${(document as DbPost).title}"`;
+  }
+  return `comment ${document._id}`;
+}
+
+async function dequeueIfNoItemsRemain(context: ResolverContext, moderator: DbUser, userId: string): Promise<NextItemResponse> {
+  const { item, remainingCount } = await getEarliestUnreviewedItem(userId);
+  if (item) {
+    return { nextItem: item, remainingCount };
+  }
+  const user = await context.Users.findOne(userId);
+  if (user?.needsReview) {
+    await updateUser({
+      data: {
+        needsReview: false,
+        reviewedByUserId: null,
+        reviewedAt: user.reviewedAt ? new Date() : null,
+        sunshineNotes: getSignatureWithNote(moderator.displayName ?? moderator._id, 'SimpleMod: reviewed all current content individually') + (user.sunshineNotes ?? ''),
+      },
+      selector: { _id: userId },
+    }, context);
+  }
+  return { nextItem: null, remainingCount: 0 };
+}
+
+export async function approveItem(context: ResolverContext, moderator: DbUser, args: ItemActionArgs): Promise<NextItemResponse> {
+  return withUserLock(args.userId, async () => {
+    await assertIsEarliestItem(args);
+    const document = await loadOwnedDocument(context, args);
+    const data = { reviewedByUserId: moderator._id, authorIsUnreviewed: false };
+    if (args.collectionName === 'Posts') {
+      await updatePost({ data, selector: { _id: args.documentId } }, context);
+    } else {
+      await updateComment({ data, selector: { _id: args.documentId } }, context);
+    }
+    await appendToSunshineNotes({
+      moderatedUserId: args.userId,
+      adminName: moderator.displayName ?? moderator._id,
+      text: `SimpleMod: approved ${itemDescription(args.collectionName, document)}`,
+      context,
+    });
+    return dequeueIfNoItemsRemain(context, moderator, args.userId);
+  });
+}
+
+export async function rejectItem(context: ResolverContext, moderator: DbUser, args: ItemActionArgs & { rejectedReason: string }): Promise<NextItemResponse> {
+  return withUserLock(args.userId, async () => {
+    await assertIsEarliestItem(args);
+    await loadOwnedDocument(context, args);
+    const data = { rejected: true, rejectedReason: args.rejectedReason };
+    if (args.collectionName === 'Posts') {
+      await updatePost({ data, selector: { _id: args.documentId } }, context);
+    } else {
+      await updateComment({ data, selector: { _id: args.documentId } }, context);
+    }
+    return dequeueIfNoItemsRemain(context, moderator, args.userId);
+  });
+}
+
+export async function sendModeratorDm(context: ResolverContext, moderator: DbUser, { userId, title, messageHtml }: {
+  userId: string;
+  title: string;
+  messageHtml: string;
+}): Promise<void> {
+  const conversation = await createConversation({
+    data: {
+      participantIds: [userId, moderator._id],
+      title,
+      moderator: true,
+    },
+  }, context);
+  await createMessage({
+    data: {
+      userId: moderator._id,
+      contents: {
+        originalContents: {
+          type: 'html',
+          data: messageHtml,
+        },
+      },
+      conversationId: conversation._id,
+      noEmail: false,
+    },
+  }, context);
+}
+
+export async function approveItemAndDm(context: ResolverContext, moderator: DbUser, args: ItemActionArgs & { messageHtml: string }): Promise<NextItemResponse> {
+  const result = await approveItem(context, moderator, args);
+  await sendModeratorDm(context, moderator, {
+    userId: args.userId,
+    title: 'A note from the moderation team',
+    messageHtml: args.messageHtml,
+  });
+  await appendToSunshineNotes({
+    moderatedUserId: args.userId,
+    adminName: moderator.displayName ?? moderator._id,
+    text: 'SimpleMod: sent DM about approved content',
+    context,
+  });
+  return result;
+}
+
+export async function skipUser(context: ResolverContext, moderator: DbUser, userId: string): Promise<void> {
+  const user = await context.Users.findOne(userId);
+  if (!user) {
+    throw new Error('Invalid user ID');
+  }
+  if (!user.needsReview) {
+    return;
+  }
+  await updateUser({
+    data: {
+      needsReview: false,
+      reviewedByUserId: null,
+      reviewedAt: user.reviewedAt ? new Date() : null,
+      sunshineNotes: getSignatureWithNote(moderator.displayName ?? moderator._id, 'SimpleMod: removed from review queue') + (user.sunshineNotes ?? ''),
+    },
+    selector: { _id: userId },
+  }, context);
+}
+
+export async function approveUser(context: ResolverContext, moderator: DbUser, userId: string): Promise<void> {
+  const user = await context.Users.findOne(userId);
+  if (!user) {
+    throw new Error('Invalid user ID');
+  }
+  await updateUser({
+    data: {
+      sunshineFlagged: false,
+      reviewedByUserId: moderator._id,
+      reviewedAt: new Date(),
+      needsReview: false,
+      sunshineNotes: getSignatureWithNote(moderator.displayName ?? moderator._id, 'SimpleMod: approved user') + (user.sunshineNotes ?? ''),
+      snoozedUntilContentCount: null,
+    },
+    selector: { _id: userId },
+  }, context);
+}
+
+export async function offboardUser(context: ResolverContext, moderator: DbUser, { userId, rejections, removePermissions, messageHtml }: {
+  userId: string;
+  rejections: { collectionName: ReviewCollectionName; documentId: string; rejectedReason: string }[];
+  removePermissions: boolean;
+  messageHtml?: string;
+}): Promise<void> {
+  return withUserLock(userId, async () => {
+    const user = await context.Users.findOne(userId);
+    if (!user) {
+      throw new Error('Invalid user ID');
+    }
+    for (const rejection of rejections) {
+      await loadOwnedDocument(context, { userId, ...rejection });
+      const data = { rejected: true, rejectedReason: rejection.rejectedReason };
+      if (rejection.collectionName === 'Posts') {
+        await updatePost({ data, selector: { _id: rejection.documentId } }, context);
+      } else {
+        await updateComment({ data, selector: { _id: rejection.documentId } }, context);
+      }
+    }
+
+    const note = removePermissions
+      ? 'SimpleMod: offboarded (disabled posting, commenting, and messaging)'
+      : 'SimpleMod: removed from review queue (offboard review)';
+    const freshUser = await context.Users.findOne(userId);
+    await updateUser({
+      data: {
+        ...(removePermissions ? {
+          postingDisabled: true,
+          allCommentingDisabled: true,
+          conversationsDisabled: true,
+        } : {}),
+        needsReview: false,
+        reviewedByUserId: null,
+        reviewedAt: user.reviewedAt ? new Date() : null,
+        sunshineNotes: getSignatureWithNote(moderator.displayName ?? moderator._id, note) + (freshUser?.sunshineNotes ?? ''),
+      },
+      selector: { _id: userId },
+    }, context);
+
+    if (removePermissions) {
+      await createModeratorAction({
+        data: {
+          userId,
+          type: VOTING_DISABLED,
+          endedAt: null,
+        },
+      }, context);
+    }
+
+    if (messageHtml) {
+      await sendModeratorDm(context, moderator, {
+        userId,
+        title: removePermissions ? 'Your posting permissions have been restricted' : 'A note from the moderation team',
+        messageHtml,
+      });
+    }
+  });
+}

--- a/simplemod/src/server/actions.ts
+++ b/simplemod/src/server/actions.ts
@@ -6,8 +6,9 @@ import { createMessage } from '@/server/collections/messages/mutations';
 import { createModeratorAction } from '@/server/collections/moderatorActions/mutations';
 import { VOTING_DISABLED } from '@/lib/collections/moderatorActions/constants';
 import { getSignatureWithNote } from '@/lib/collections/users/helpers';
+import { getUserReviewGroup } from '@/lib/collections/users/newSchema';
 import { getSqlClientOrThrow } from '@/server/sql/sqlClient';
-import { getEarliestUnreviewedItem } from './queue';
+import { buildOffboardCard, getEarliestUnreviewedItem } from './queue';
 import type { NextItemResponse, QueueItem, ReviewCollectionName } from '../lib/types';
 
 /**
@@ -98,6 +99,12 @@ function itemDescription(collectionName: ReviewCollectionName, document: DbPost 
  * content is still created unreviewed. reviewedAt is set unconditionally
  * (matching approveUserCurrentContentOnly) so their next submission triggers
  * an "unreviewed content" action rather than a "first post" one.
+ *
+ * Offboard candidates are the exception: they stay queued and the response
+ * carries their user-level offboard decision card, so the moderator settles
+ * permissions/messaging explicitly. This is re-evaluated after every item
+ * decision, so a user who becomes an offboard candidate mid-review (e.g. via
+ * their second rejection) gets the offboard card too.
  */
 async function dequeueIfNoItemsRemain(context: ResolverContext, moderator: DbUser, userId: string): Promise<NextItemResponse> {
   const { item, remainingCount } = await getEarliestUnreviewedItem(userId);
@@ -105,19 +112,23 @@ async function dequeueIfNoItemsRemain(context: ResolverContext, moderator: DbUse
     return { nextItem: item, remainingCount };
   }
   const user = await context.Users.findOne(userId);
-  if (user?.needsReview) {
-    await updateUser({
-      data: {
-        needsReview: false,
-        reviewedByUserId: null,
-        reviewedAt: new Date(),
-        sunshineFlagged: false,
-        snoozedUntilContentCount: null,
-      },
-      selector: { _id: userId },
-    }, context);
-    await appendSunshineNote(moderator, userId, 'SimpleMod: reviewed all current content individually');
+  if (!user?.needsReview) {
+    return { nextItem: null, remainingCount: 0 };
   }
+  if (await getUserReviewGroup(context, user) === 'offboard') {
+    return { nextItem: null, remainingCount: 0, offboardCard: await buildOffboardCard(user) };
+  }
+  await updateUser({
+    data: {
+      needsReview: false,
+      reviewedByUserId: null,
+      reviewedAt: new Date(),
+      sunshineFlagged: false,
+      snoozedUntilContentCount: null,
+    },
+    selector: { _id: userId },
+  }, context);
+  await appendSunshineNote(moderator, userId, 'SimpleMod: reviewed all current content individually');
   return { nextItem: null, remainingCount: 0 };
 }
 

--- a/simplemod/src/server/actions.ts
+++ b/simplemod/src/server/actions.ts
@@ -5,8 +5,8 @@ import { createConversation } from '@/server/collections/conversations/mutations
 import { createMessage } from '@/server/collections/messages/mutations';
 import { createModeratorAction } from '@/server/collections/moderatorActions/mutations';
 import { VOTING_DISABLED } from '@/lib/collections/moderatorActions/constants';
-import { appendToSunshineNotes, getSignatureWithNote } from '@/lib/collections/users/helpers';
-import { approveUnreviewedSubmissions } from '@/server/callbacks/userCallbackFunctions';
+import { getSignatureWithNote } from '@/lib/collections/users/helpers';
+import { getSqlClientOrThrow } from '@/server/sql/sqlClient';
 import { getEarliestUnreviewedItem } from './queue';
 import type { NextItemResponse, QueueItem, ReviewCollectionName } from '../lib/types';
 
@@ -44,6 +44,21 @@ export class EarliestItemConflictError extends Error {
   }
 }
 
+/**
+ * Prepends a signed note without read-modify-write: FM callbacks (rejection
+ * moderator actions, DM logging) append to sunshineNotes from background tasks
+ * that run concurrently with our writes, so a findOne-then-set here would race
+ * them and silently drop audit entries.
+ */
+async function appendSunshineNote(moderator: DbUser, userId: string, text: string): Promise<void> {
+  const db = getSqlClientOrThrow();
+  await db.none(`
+    UPDATE "Users"
+    SET "sunshineNotes" = $(note) || COALESCE("sunshineNotes", '')
+    WHERE "_id" = $(userId)
+  `, { note: getSignatureWithNote(moderator.displayName ?? moderator._id, text), userId });
+}
+
 interface ItemActionArgs {
   userId: string;
   collectionName: ReviewCollectionName;
@@ -77,6 +92,13 @@ function itemDescription(collectionName: ReviewCollectionName, document: DbPost 
   return `comment ${document._id}`;
 }
 
+/**
+ * Once every current item has been individually decided, the user leaves the
+ * queue without a user-level approval: reviewedByUserId stays null so future
+ * content is still created unreviewed. reviewedAt is set unconditionally
+ * (matching approveUserCurrentContentOnly) so their next submission triggers
+ * an "unreviewed content" action rather than a "first post" one.
+ */
 async function dequeueIfNoItemsRemain(context: ResolverContext, moderator: DbUser, userId: string): Promise<NextItemResponse> {
   const { item, remainingCount } = await getEarliestUnreviewedItem(userId);
   if (item) {
@@ -88,11 +110,13 @@ async function dequeueIfNoItemsRemain(context: ResolverContext, moderator: DbUse
       data: {
         needsReview: false,
         reviewedByUserId: null,
-        reviewedAt: user.reviewedAt ? new Date() : null,
-        sunshineNotes: getSignatureWithNote(moderator.displayName ?? moderator._id, 'SimpleMod: reviewed all current content individually') + (user.sunshineNotes ?? ''),
+        reviewedAt: new Date(),
+        sunshineFlagged: false,
+        snoozedUntilContentCount: null,
       },
       selector: { _id: userId },
     }, context);
+    await appendSunshineNote(moderator, userId, 'SimpleMod: reviewed all current content individually');
   }
   return { nextItem: null, remainingCount: 0 };
 }
@@ -107,12 +131,7 @@ export async function approveItem(context: ResolverContext, moderator: DbUser, a
     } else {
       await updateComment({ data, selector: { _id: args.documentId } }, context);
     }
-    await appendToSunshineNotes({
-      moderatedUserId: args.userId,
-      adminName: moderator.displayName ?? moderator._id,
-      text: `SimpleMod: approved ${itemDescription(args.collectionName, document)}`,
-      context,
-    });
+    await appendSunshineNote(moderator, args.userId, `SimpleMod: approved ${itemDescription(args.collectionName, document)}`);
     return dequeueIfNoItemsRemain(context, moderator, args.userId);
   });
 }
@@ -165,50 +184,49 @@ export async function approveItemAndDm(context: ResolverContext, moderator: DbUs
     title: 'A note from the moderation team',
     messageHtml: args.messageHtml,
   });
-  await appendToSunshineNotes({
-    moderatedUserId: args.userId,
-    adminName: moderator.displayName ?? moderator._id,
-    text: 'SimpleMod: sent DM about approved content',
-    context,
-  });
+  await appendSunshineNote(moderator, args.userId, 'SimpleMod: sent DM about approved content');
   return result;
 }
 
 export async function skipUser(context: ResolverContext, moderator: DbUser, userId: string): Promise<void> {
-  const user = await context.Users.findOne(userId);
-  if (!user) {
-    throw new Error('Invalid user ID');
-  }
-  if (!user.needsReview) {
-    return;
-  }
-  await updateUser({
-    data: {
-      needsReview: false,
-      reviewedByUserId: null,
-      reviewedAt: user.reviewedAt ? new Date() : null,
-      sunshineNotes: getSignatureWithNote(moderator.displayName ?? moderator._id, 'SimpleMod: removed from review queue') + (user.sunshineNotes ?? ''),
-    },
-    selector: { _id: userId },
-  }, context);
+  return withUserLock(userId, async () => {
+    const user = await context.Users.findOne(userId);
+    if (!user) {
+      throw new Error('Invalid user ID');
+    }
+    if (!user.needsReview) {
+      return;
+    }
+    await updateUser({
+      data: {
+        needsReview: false,
+        reviewedByUserId: null,
+        reviewedAt: user.reviewedAt ? new Date() : null,
+      },
+      selector: { _id: userId },
+    }, context);
+    await appendSunshineNote(moderator, userId, 'SimpleMod: removed from review queue');
+  });
 }
 
 export async function approveUser(context: ResolverContext, moderator: DbUser, userId: string): Promise<void> {
-  const user = await context.Users.findOne(userId);
-  if (!user) {
-    throw new Error('Invalid user ID');
-  }
-  await updateUser({
-    data: {
-      sunshineFlagged: false,
-      reviewedByUserId: moderator._id,
-      reviewedAt: new Date(),
-      needsReview: false,
-      sunshineNotes: getSignatureWithNote(moderator.displayName ?? moderator._id, 'SimpleMod: approved user') + (user.sunshineNotes ?? ''),
-      snoozedUntilContentCount: null,
-    },
-    selector: { _id: userId },
-  }, context);
+  return withUserLock(userId, async () => {
+    const user = await context.Users.findOne(userId);
+    if (!user) {
+      throw new Error('Invalid user ID');
+    }
+    await updateUser({
+      data: {
+        sunshineFlagged: false,
+        reviewedByUserId: moderator._id,
+        reviewedAt: new Date(),
+        needsReview: false,
+        snoozedUntilContentCount: null,
+      },
+      selector: { _id: userId },
+    }, context);
+    await appendSunshineNote(moderator, userId, 'SimpleMod: approved user');
+  });
 }
 
 export async function offboardUser(context: ResolverContext, moderator: DbUser, { userId, rejections, removePermissions, messageHtml }: {
@@ -232,10 +250,6 @@ export async function offboardUser(context: ResolverContext, moderator: DbUser, 
       }
     }
 
-    const note = removePermissions
-      ? 'SimpleMod: offboarded (disabled posting, commenting, and messaging)'
-      : 'SimpleMod: removed from review queue (offboard review)';
-    const freshUser = await context.Users.findOne(userId);
     await updateUser({
       data: {
         ...(removePermissions ? {
@@ -246,10 +260,12 @@ export async function offboardUser(context: ResolverContext, moderator: DbUser, 
         needsReview: false,
         reviewedByUserId: null,
         reviewedAt: user.reviewedAt ? new Date() : null,
-        sunshineNotes: getSignatureWithNote(moderator.displayName ?? moderator._id, note) + (freshUser?.sunshineNotes ?? ''),
       },
       selector: { _id: userId },
     }, context);
+    await appendSunshineNote(moderator, userId, removePermissions
+      ? 'SimpleMod: offboarded (disabled posting, commenting, and messaging)'
+      : 'SimpleMod: removed from review queue (offboard review)');
 
     if (removePermissions) {
       await createModeratorAction({

--- a/simplemod/src/server/fmAuth.ts
+++ b/simplemod/src/server/fmAuth.ts
@@ -17,8 +17,17 @@ export interface ModeratorSession {
 }
 
 export async function getModeratorSession(req: NextRequest): Promise<ModeratorSession | NextResponse> {
-  await ensureSettingsLoaded();
-  const context = await getContextFromReqAndRes({ req });
+  let context: ResolverContext;
+  try {
+    await ensureSettingsLoaded();
+    context = await getContextFromReqAndRes({ req });
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error('SimpleMod session setup failed:', error);
+    settingsLoaded = null;
+    const message = error instanceof Error ? error.message : String(error);
+    return NextResponse.json({ error: `Session setup failed: ${message}` }, { status: 500 });
+  }
   const moderator = context.currentUser;
   if (!moderator) {
     return NextResponse.json({ error: 'Not logged in' }, { status: 401 });

--- a/simplemod/src/server/fmAuth.ts
+++ b/simplemod/src/server/fmAuth.ts
@@ -1,0 +1,34 @@
+import type { NextRequest } from 'next/server';
+import { NextResponse } from 'next/server';
+import { getContextFromReqAndRes } from '@/server/vulcan-lib/apollo-server/context';
+import { userIsAdminOrMod } from '@/lib/vulcan-users/permissions';
+import { refreshSettingsCaches } from '@/server/loadDatabaseSettings';
+
+let settingsLoaded: Promise<void> | null = null;
+
+function ensureSettingsLoaded(): Promise<void> {
+  settingsLoaded ??= refreshSettingsCaches().then(() => undefined);
+  return settingsLoaded;
+}
+
+export interface ModeratorSession {
+  context: ResolverContext;
+  moderator: DbUser;
+}
+
+export async function getModeratorSession(req: NextRequest): Promise<ModeratorSession | NextResponse> {
+  await ensureSettingsLoaded();
+  const context = await getContextFromReqAndRes({ req });
+  const moderator = context.currentUser;
+  if (!moderator) {
+    return NextResponse.json({ error: 'Not logged in' }, { status: 401 });
+  }
+  if (!userIsAdminOrMod(moderator)) {
+    return NextResponse.json({ error: 'Not a moderator' }, { status: 403 });
+  }
+  return { context, moderator };
+}
+
+export function isErrorResponse(session: ModeratorSession | NextResponse): session is NextResponse {
+  return session instanceof NextResponse;
+}

--- a/simplemod/src/server/queue.ts
+++ b/simplemod/src/server/queue.ts
@@ -1,7 +1,7 @@
 import { getSqlClientOrThrow } from '@/server/sql/sqlClient';
 import { spamRiskScoreThreshold } from '@/lib/collections/users/helpers';
 import { getUserReviewGroup } from '@/lib/collections/users/newSchema';
-import type { QueueCard, QueueItem, QueueUser, ReviewCollectionName } from '../lib/types';
+import type { PangramWindowScore, QueueCard, QueueItem, QueueUser, ReviewCollectionName } from '../lib/types';
 
 const QUEUE_USER_LIMIT = 100;
 
@@ -17,6 +17,8 @@ interface QueueItemRow {
   baseScore: number | null;
   pangramScore: number | null;
   pangramFractionAi: number | null;
+  pangramPrediction: string | null;
+  pangramWindowScores: PangramWindowScore[] | null;
   aiChoice: string | null;
   rejected: boolean | null;
 }
@@ -34,12 +36,14 @@ const liveUnreviewedItemsSql = `
     p."baseScore",
     ace."pangramScore",
     ace."pangramFractionAi",
+    ace."pangramPrediction",
+    ace."pangramWindowScores",
     ace."aiChoice",
     p."rejected"
   FROM "Posts" p
   LEFT JOIN "Revisions" r ON r."_id" = p."contents_latest"
   LEFT JOIN LATERAL (
-    SELECT a."pangramScore", a."pangramFractionAi", a."aiChoice"
+    SELECT a."pangramScore", a."pangramFractionAi", a."pangramPrediction", a."pangramWindowScores", a."aiChoice"
     FROM "AutomatedContentEvaluations" a
     WHERE a."revisionId" = p."contents_latest"
     ORDER BY a."createdAt" DESC
@@ -64,13 +68,15 @@ const liveUnreviewedItemsSql = `
     c."baseScore",
     ace."pangramScore",
     ace."pangramFractionAi",
+    ace."pangramPrediction",
+    ace."pangramWindowScores",
     ace."aiChoice",
     c."rejected"
   FROM "Comments" c
   LEFT JOIN "Posts" post ON post."_id" = c."postId"
   LEFT JOIN "Revisions" r ON r."_id" = c."contents_latest"
   LEFT JOIN LATERAL (
-    SELECT a."pangramScore", a."pangramFractionAi", a."aiChoice"
+    SELECT a."pangramScore", a."pangramFractionAi", a."pangramPrediction", a."pangramWindowScores", a."aiChoice"
     FROM "AutomatedContentEvaluations" a
     WHERE a."revisionId" = c."contents_latest"
     ORDER BY a."createdAt" DESC
@@ -96,6 +102,8 @@ function toQueueItem(row: QueueItemRow): QueueItem {
     baseScore: row.baseScore,
     pangramScore: row.pangramScore,
     pangramFractionAi: row.pangramFractionAi,
+    pangramPrediction: row.pangramPrediction,
+    pangramWindowScores: row.pangramWindowScores,
     aiChoice: row.aiChoice,
     rejected: row.rejected ?? false,
   };

--- a/simplemod/src/server/queue.ts
+++ b/simplemod/src/server/queue.ts
@@ -173,7 +173,13 @@ interface QueueUserRow extends DbUser {
   simplemodHtmlBio: string | null;
 }
 
-export async function computeQueue(context: ResolverContext): Promise<QueueCard[]> {
+export interface ComputeQueueOptions {
+  userLimit?: number;
+  cardLimit?: number;
+}
+
+export async function computeQueue(context: ResolverContext, options: ComputeQueueOptions = {}): Promise<QueueCard[]> {
+  const { userLimit = QUEUE_USER_LIMIT, cardLimit } = options;
   const db = getSqlClientOrThrow();
   const users = await db.any<QueueUserRow>(`
     SELECT u.*, bio."html" AS "simplemodHtmlBio"
@@ -185,23 +191,28 @@ export async function computeQueue(context: ResolverContext): Promise<QueueCard[
       AND (u."signUpReCaptchaRating" IS NULL OR u."signUpReCaptchaRating" > $(recaptchaThreshold))
     ORDER BY u."createdAt" ASC
     LIMIT $(limit)
-  `, { recaptchaThreshold: spamRiskScoreThreshold * 1.25, limit: QUEUE_USER_LIMIT });
+  `, { recaptchaThreshold: spamRiskScoreThreshold * 1.25, limit: userLimit });
 
-  const reviewGroups = await Promise.all(users.map(user => getUserReviewGroup(context, user)));
+  // Items and rejected counts don't depend on review groups, so all three
+  // computations run concurrently over the full candidate set.
+  const allUserIds = users.map(user => user._id);
+  const [reviewGroups, itemsByUser, rejectedCounts] = await Promise.all([
+    Promise.all(users.map(user => getUserReviewGroup(context, user))),
+    getLiveUnreviewedItems(allUserIds),
+    getRejectedContentCountsByCollection(allUserIds),
+  ]);
+
   const queueUsers = users
     .map((user, index) => ({ user, reviewGroup: reviewGroups[index] }))
     .filter((entry): entry is { user: QueueUserRow; reviewGroup: 'newContent' | 'offboard' } =>
       entry.reviewGroup === 'newContent' || entry.reviewGroup === 'offboard'
     );
 
-  const userIds = queueUsers.map(entry => entry.user._id);
-  const [itemsByUser, rejectedCounts] = await Promise.all([
-    getLiveUnreviewedItems(userIds),
-    getRejectedContentCountsByCollection(userIds),
-  ]);
-
   const cards: QueueCard[] = [];
   for (const { user, reviewGroup } of queueUsers) {
+    if (cardLimit !== undefined && cards.length >= cardLimit) {
+      break;
+    }
     const queueUser = toQueueUser(user, user.simplemodHtmlBio, reviewGroup);
     const items = itemsByUser.get(user._id) ?? [];
     if (reviewGroup === 'offboard') {

--- a/simplemod/src/server/queue.ts
+++ b/simplemod/src/server/queue.ts
@@ -1,7 +1,15 @@
 import { getSqlClientOrThrow } from '@/server/sql/sqlClient';
 import { spamRiskScoreThreshold } from '@/lib/collections/users/helpers';
 import { getUserReviewGroup } from '@/lib/collections/users/newSchema';
+import { getSiteUrl } from '@/lib/vulcan-lib/utils';
 import type { PangramWindowScore, QueueCard, QueueItem, QueueUser, ReviewCollectionName } from '../lib/types';
+
+export function getItemUrl(collectionName: ReviewCollectionName, documentId: string, postId: string | null): string {
+  if (collectionName === 'Posts') {
+    return `${getSiteUrl()}posts/${documentId}`;
+  }
+  return postId ? `${getSiteUrl()}posts/${postId}?commentId=${documentId}` : getSiteUrl();
+}
 
 const QUEUE_USER_LIMIT = 100;
 
@@ -21,6 +29,8 @@ interface QueueItemRow {
   pangramWindowScores: PangramWindowScore[] | null;
   aiChoice: string | null;
   rejected: boolean | null;
+  parentCommentHtml: string | null;
+  parentCommentAuthor: string | null;
 }
 
 const liveUnreviewedItemsSql = `
@@ -39,7 +49,9 @@ const liveUnreviewedItemsSql = `
     ace."pangramPrediction",
     ace."pangramWindowScores",
     ace."aiChoice",
-    p."rejected"
+    p."rejected",
+    NULL AS "parentCommentHtml",
+    NULL AS "parentCommentAuthor"
   FROM "Posts" p
   LEFT JOIN "Revisions" r ON r."_id" = p."contents_latest"
   LEFT JOIN LATERAL (
@@ -71,10 +83,15 @@ const liveUnreviewedItemsSql = `
     ace."pangramPrediction",
     ace."pangramWindowScores",
     ace."aiChoice",
-    c."rejected"
+    c."rejected",
+    pr."html" AS "parentCommentHtml",
+    pu."displayName" AS "parentCommentAuthor"
   FROM "Comments" c
   LEFT JOIN "Posts" post ON post."_id" = c."postId"
   LEFT JOIN "Revisions" r ON r."_id" = c."contents_latest"
+  LEFT JOIN "Comments" pc ON pc."_id" = c."parentCommentId"
+  LEFT JOIN "Revisions" pr ON pr."_id" = pc."contents_latest"
+  LEFT JOIN "Users" pu ON pu."_id" = pc."userId"
   LEFT JOIN LATERAL (
     SELECT a."pangramScore", a."pangramFractionAi", a."pangramPrediction", a."pangramWindowScores", a."aiChoice"
     FROM "AutomatedContentEvaluations" a
@@ -106,6 +123,9 @@ function toQueueItem(row: QueueItemRow): QueueItem {
     pangramWindowScores: row.pangramWindowScores,
     aiChoice: row.aiChoice,
     rejected: row.rejected ?? false,
+    itemUrl: getItemUrl(row.collectionName, row.documentId, row.postId),
+    parentCommentHtml: row.parentCommentHtml,
+    parentCommentAuthor: row.parentCommentAuthor,
   };
 }
 
@@ -144,6 +164,7 @@ function toQueueUser(user: DbUser, htmlBio: string | null, reviewGroup: 'newCont
     postingDisabled: !!user.postingDisabled,
     allCommentingDisabled: !!user.allCommentingDisabled,
     conversationsDisabled: !!user.conversationsDisabled,
+    profileUrl: `${getSiteUrl()}users/${user.slug ?? user._id}`,
   };
 }
 

--- a/simplemod/src/server/queue.ts
+++ b/simplemod/src/server/queue.ts
@@ -2,7 +2,7 @@ import { getSqlClientOrThrow } from '@/server/sql/sqlClient';
 import { spamRiskScoreThreshold } from '@/lib/collections/users/helpers';
 import { getUserReviewGroup } from '@/lib/collections/users/newSchema';
 import { getSiteUrl } from '@/lib/vulcan-lib/utils';
-import type { PangramWindowScore, QueueCard, QueueItem, QueueUser, ReviewCollectionName } from '../lib/types';
+import type { OffboardCardData, PangramWindowScore, QueueCard, QueueItem, QueueUser, ReviewCollectionName } from '../lib/types';
 
 export function getItemUrl(collectionName: ReviewCollectionName, documentId: string, postId: string | null): string {
   if (collectionName === 'Posts') {
@@ -208,6 +208,9 @@ export async function computeQueue(context: ResolverContext, options: ComputeQue
       entry.reviewGroup === 'newContent' || entry.reviewGroup === 'offboard'
     );
 
+  // User-level cards only ever appear once every item has been individually
+  // decided: offboard candidates with live unreviewed items get ordinary
+  // content cards first, and the offboard decision card comes at the end.
   const cards: QueueCard[] = [];
   for (const { user, reviewGroup } of queueUsers) {
     if (cardLimit !== undefined && cards.length >= cardLimit) {
@@ -215,22 +218,40 @@ export async function computeQueue(context: ResolverContext, options: ComputeQue
     }
     const queueUser = toQueueUser(user, user.simplemodHtmlBio, reviewGroup);
     const items = itemsByUser.get(user._id) ?? [];
-    if (reviewGroup === 'offboard') {
+    if (items.length > 0) {
+      cards.push({ type: 'content', user: queueUser, item: items[0], remainingCount: items.length });
+    } else if (reviewGroup === 'offboard') {
       const rejected = rejectedCounts.get(user._id) ?? { posts: 0, comments: 0 };
       cards.push({
         type: 'offboard',
         user: queueUser,
-        items,
+        items: [],
         rejectedPostCount: rejected.posts,
         rejectedCommentCount: rejected.comments,
       });
-    } else if (items.length > 0) {
-      cards.push({ type: 'content', user: queueUser, item: items[0], remainingCount: items.length });
     } else {
       cards.push({ type: 'wrapup', user: queueUser });
     }
   }
   return cards;
+}
+
+export async function buildOffboardCard(user: DbUser): Promise<OffboardCardData> {
+  const db = getSqlClientOrThrow();
+  const [bio, rejectedCounts] = await Promise.all([
+    user.biography_latest
+      ? db.oneOrNone<{ html: string | null }>(`SELECT "html" FROM "Revisions" WHERE "_id" = $(id)`, { id: user.biography_latest })
+      : null,
+    getRejectedContentCountsByCollection([user._id]),
+  ]);
+  const rejected = rejectedCounts.get(user._id) ?? { posts: 0, comments: 0 };
+  return {
+    type: 'offboard',
+    user: toQueueUser(user, bio?.html ?? null, 'offboard'),
+    items: [],
+    rejectedPostCount: rejected.posts,
+    rejectedCommentCount: rejected.comments,
+  };
 }
 
 async function getRejectedContentCountsByCollection(userIds: string[]): Promise<Map<string, { posts: number; comments: number }>> {

--- a/simplemod/src/server/queue.ts
+++ b/simplemod/src/server/queue.ts
@@ -1,0 +1,219 @@
+import { getSqlClientOrThrow } from '@/server/sql/sqlClient';
+import { spamRiskScoreThreshold } from '@/lib/collections/users/helpers';
+import { getUserReviewGroup } from '@/lib/collections/users/newSchema';
+import type { QueueCard, QueueItem, QueueUser, ReviewCollectionName } from '../lib/types';
+
+const QUEUE_USER_LIMIT = 100;
+
+interface QueueItemRow {
+  documentId: string;
+  collectionName: ReviewCollectionName;
+  userId: string;
+  postedAt: Date;
+  title: string | null;
+  postTitle: string | null;
+  postId: string | null;
+  html: string | null;
+  baseScore: number | null;
+  pangramScore: number | null;
+  pangramFractionAi: number | null;
+  aiChoice: string | null;
+  rejected: boolean | null;
+}
+
+const liveUnreviewedItemsSql = `
+  SELECT
+    p."_id" AS "documentId",
+    'Posts' AS "collectionName",
+    p."userId",
+    p."postedAt",
+    p."title",
+    NULL AS "postTitle",
+    NULL AS "postId",
+    r."html",
+    p."baseScore",
+    ace."pangramScore",
+    ace."pangramFractionAi",
+    ace."aiChoice",
+    p."rejected"
+  FROM "Posts" p
+  LEFT JOIN "Revisions" r ON r."_id" = p."contents_latest"
+  LEFT JOIN LATERAL (
+    SELECT a."pangramScore", a."pangramFractionAi", a."aiChoice"
+    FROM "AutomatedContentEvaluations" a
+    WHERE a."revisionId" = p."contents_latest"
+    ORDER BY a."createdAt" DESC
+    LIMIT 1
+  ) ace ON TRUE
+  WHERE p."userId" = ANY($(userIds)::text[])
+    AND p."authorIsUnreviewed" IS TRUE
+    AND p."rejected" IS NOT TRUE
+    AND p."reviewedByUserId" IS NULL
+    AND p."draft" IS NOT TRUE
+    AND p."deletedDraft" IS NOT TRUE
+  UNION ALL
+  SELECT
+    c."_id",
+    'Comments',
+    c."userId",
+    c."postedAt",
+    NULL,
+    post."title",
+    c."postId",
+    r."html",
+    c."baseScore",
+    ace."pangramScore",
+    ace."pangramFractionAi",
+    ace."aiChoice",
+    c."rejected"
+  FROM "Comments" c
+  LEFT JOIN "Posts" post ON post."_id" = c."postId"
+  LEFT JOIN "Revisions" r ON r."_id" = c."contents_latest"
+  LEFT JOIN LATERAL (
+    SELECT a."pangramScore", a."pangramFractionAi", a."aiChoice"
+    FROM "AutomatedContentEvaluations" a
+    WHERE a."revisionId" = c."contents_latest"
+    ORDER BY a."createdAt" DESC
+    LIMIT 1
+  ) ace ON TRUE
+  WHERE c."userId" = ANY($(userIds)::text[])
+    AND c."authorIsUnreviewed" IS TRUE
+    AND c."rejected" IS NOT TRUE
+    AND c."reviewedByUserId" IS NULL
+    AND c."deleted" IS NOT TRUE
+  ORDER BY "postedAt" ASC, "documentId" ASC
+`;
+
+function toQueueItem(row: QueueItemRow): QueueItem {
+  return {
+    documentId: row.documentId,
+    collectionName: row.collectionName,
+    postedAt: new Date(row.postedAt).toISOString(),
+    title: row.title,
+    postTitle: row.postTitle,
+    postId: row.postId,
+    html: row.html,
+    baseScore: row.baseScore,
+    pangramScore: row.pangramScore,
+    pangramFractionAi: row.pangramFractionAi,
+    aiChoice: row.aiChoice,
+    rejected: row.rejected ?? false,
+  };
+}
+
+export async function getLiveUnreviewedItems(userIds: string[]): Promise<Map<string, QueueItem[]>> {
+  const itemsByUser = new Map<string, QueueItem[]>(userIds.map(userId => [userId, []]));
+  if (!userIds.length) {
+    return itemsByUser;
+  }
+  const db = getSqlClientOrThrow();
+  const rows = await db.any<QueueItemRow>(liveUnreviewedItemsSql, { userIds });
+  for (const row of rows) {
+    itemsByUser.get(row.userId)?.push(toQueueItem(row));
+  }
+  return itemsByUser;
+}
+
+export async function getEarliestUnreviewedItem(userId: string): Promise<{ item: QueueItem | null; remainingCount: number }> {
+  const itemsByUser = await getLiveUnreviewedItems([userId]);
+  const items = itemsByUser.get(userId) ?? [];
+  return { item: items[0] ?? null, remainingCount: items.length };
+}
+
+function toQueueUser(user: DbUser, htmlBio: string | null, reviewGroup: 'newContent' | 'offboard'): QueueUser {
+  return {
+    _id: user._id,
+    displayName: user.displayName ?? user.username ?? user._id,
+    slug: user.slug ?? user._id,
+    createdAt: new Date(user.createdAt).toISOString(),
+    karma: user.karma,
+    postCount: user.postCount,
+    commentCount: user.commentCount,
+    htmlBio,
+    sunshineFlagged: !!user.sunshineFlagged,
+    sunshineNotes: user.sunshineNotes ?? '',
+    reviewGroup,
+    postingDisabled: !!user.postingDisabled,
+    allCommentingDisabled: !!user.allCommentingDisabled,
+    conversationsDisabled: !!user.conversationsDisabled,
+  };
+}
+
+interface QueueUserRow extends DbUser {
+  simplemodHtmlBio: string | null;
+}
+
+export async function computeQueue(context: ResolverContext): Promise<QueueCard[]> {
+  const db = getSqlClientOrThrow();
+  const users = await db.any<QueueUserRow>(`
+    SELECT u.*, bio."html" AS "simplemodHtmlBio"
+    FROM "Users" u
+    LEFT JOIN "Revisions" bio ON bio."_id" = u."biography_latest"
+    WHERE u."needsReview" IS TRUE
+      AND u."banned" IS NULL
+      AND u."reviewedByUserId" IS NULL
+      AND (u."signUpReCaptchaRating" IS NULL OR u."signUpReCaptchaRating" > $(recaptchaThreshold))
+    ORDER BY u."createdAt" ASC
+    LIMIT $(limit)
+  `, { recaptchaThreshold: spamRiskScoreThreshold * 1.25, limit: QUEUE_USER_LIMIT });
+
+  const reviewGroups = await Promise.all(users.map(user => getUserReviewGroup(context, user)));
+  const queueUsers = users
+    .map((user, index) => ({ user, reviewGroup: reviewGroups[index] }))
+    .filter((entry): entry is { user: QueueUserRow; reviewGroup: 'newContent' | 'offboard' } =>
+      entry.reviewGroup === 'newContent' || entry.reviewGroup === 'offboard'
+    );
+
+  const userIds = queueUsers.map(entry => entry.user._id);
+  const [itemsByUser, rejectedCounts] = await Promise.all([
+    getLiveUnreviewedItems(userIds),
+    getRejectedContentCountsByCollection(userIds),
+  ]);
+
+  const cards: QueueCard[] = [];
+  for (const { user, reviewGroup } of queueUsers) {
+    const queueUser = toQueueUser(user, user.simplemodHtmlBio, reviewGroup);
+    const items = itemsByUser.get(user._id) ?? [];
+    if (reviewGroup === 'offboard') {
+      const rejected = rejectedCounts.get(user._id) ?? { posts: 0, comments: 0 };
+      cards.push({
+        type: 'offboard',
+        user: queueUser,
+        items,
+        rejectedPostCount: rejected.posts,
+        rejectedCommentCount: rejected.comments,
+      });
+    } else if (items.length > 0) {
+      cards.push({ type: 'content', user: queueUser, item: items[0], remainingCount: items.length });
+    } else {
+      cards.push({ type: 'wrapup', user: queueUser });
+    }
+  }
+  return cards;
+}
+
+async function getRejectedContentCountsByCollection(userIds: string[]): Promise<Map<string, { posts: number; comments: number }>> {
+  const counts = new Map<string, { posts: number; comments: number }>();
+  if (!userIds.length) {
+    return counts;
+  }
+  const db = getSqlClientOrThrow();
+  const rows = await db.any<{ userId: string; postCount: number; commentCount: number }>(`
+    SELECT
+      "userId",
+      COUNT(*) FILTER (WHERE "collectionName" = 'Posts')::int AS "postCount",
+      COUNT(*) FILTER (WHERE "collectionName" = 'Comments')::int AS "commentCount"
+    FROM (
+      SELECT "userId", 'Posts' AS "collectionName" FROM "Posts"
+      WHERE "userId" = ANY($(userIds)::text[]) AND "rejected" IS TRUE
+      UNION ALL
+      SELECT "userId", 'Comments' FROM "Comments"
+      WHERE "userId" = ANY($(userIds)::text[]) AND "rejected" IS TRUE
+    ) "rejectedContent"
+    GROUP BY "userId"
+  `, { userIds });
+  for (const row of rows) {
+    counts.set(row.userId, { posts: row.postCount, comments: row.commentCount });
+  }
+  return counts;
+}

--- a/simplemod/src/server/queue.ts
+++ b/simplemod/src/server/queue.ts
@@ -104,6 +104,7 @@ const liveUnreviewedItemsSql = `
     AND c."rejected" IS NOT TRUE
     AND c."reviewedByUserId" IS NULL
     AND c."deleted" IS NOT TRUE
+    AND c."draft" IS NOT TRUE
   ORDER BY "postedAt" ASC, "documentId" ASC
 `;
 

--- a/simplemod/src/server/userContext.ts
+++ b/simplemod/src/server/userContext.ts
@@ -1,0 +1,116 @@
+import { getSqlClientOrThrow } from '@/server/sql/sqlClient';
+import type { PangramWindowScore, ReviewCollectionName, UserContentItem } from '../lib/types';
+
+interface UserContentRow {
+  documentId: string;
+  collectionName: ReviewCollectionName;
+  postedAt: Date;
+  title: string | null;
+  postTitle: string | null;
+  postId: string | null;
+  html: string | null;
+  baseScore: number | null;
+  pangramScore: number | null;
+  pangramFractionAi: number | null;
+  pangramPrediction: string | null;
+  pangramWindowScores: PangramWindowScore[] | null;
+  aiChoice: string | null;
+  rejected: boolean | null;
+  draft: boolean | null;
+  authorIsUnreviewed: boolean | null;
+  reviewedByUserId: string | null;
+}
+
+function rowStatus(row: UserContentRow): UserContentItem['status'] {
+  if (row.rejected) return 'rejected';
+  if (row.draft) return 'draft';
+  if (row.authorIsUnreviewed || !row.reviewedByUserId) return 'unreviewed';
+  return 'approved';
+}
+
+export async function getUserContentHistory(userId: string): Promise<UserContentItem[]> {
+  const db = getSqlClientOrThrow();
+  const rows = await db.any<UserContentRow>(`
+    SELECT
+      p."_id" AS "documentId",
+      'Posts' AS "collectionName",
+      p."postedAt",
+      p."title",
+      NULL AS "postTitle",
+      NULL AS "postId",
+      r."html",
+      p."baseScore",
+      ace."pangramScore",
+      ace."pangramFractionAi",
+      ace."pangramPrediction",
+      ace."pangramWindowScores",
+      ace."aiChoice",
+      p."rejected",
+      p."draft",
+      p."authorIsUnreviewed",
+      p."reviewedByUserId"
+    FROM "Posts" p
+    LEFT JOIN "Revisions" r ON r."_id" = p."contents_latest"
+    LEFT JOIN LATERAL (
+      SELECT a."pangramScore", a."pangramFractionAi", a."pangramPrediction", a."pangramWindowScores", a."aiChoice"
+      FROM "AutomatedContentEvaluations" a
+      WHERE a."revisionId" = p."contents_latest"
+      ORDER BY a."createdAt" DESC
+      LIMIT 1
+    ) ace ON TRUE
+    WHERE p."userId" = $(userId)
+      AND p."deletedDraft" IS NOT TRUE
+      AND (p."draft" IS NOT TRUE OR p."wasEverUndrafted" IS TRUE OR p."rejected" IS TRUE)
+    UNION ALL
+    SELECT
+      c."_id",
+      'Comments',
+      c."postedAt",
+      NULL,
+      post."title",
+      c."postId",
+      r."html",
+      c."baseScore",
+      ace."pangramScore",
+      ace."pangramFractionAi",
+      ace."pangramPrediction",
+      ace."pangramWindowScores",
+      ace."aiChoice",
+      c."rejected",
+      FALSE,
+      c."authorIsUnreviewed",
+      c."reviewedByUserId"
+    FROM "Comments" c
+    LEFT JOIN "Posts" post ON post."_id" = c."postId"
+    LEFT JOIN "Revisions" r ON r."_id" = c."contents_latest"
+    LEFT JOIN LATERAL (
+      SELECT a."pangramScore", a."pangramFractionAi", a."pangramPrediction", a."pangramWindowScores", a."aiChoice"
+      FROM "AutomatedContentEvaluations" a
+      WHERE a."revisionId" = c."contents_latest"
+      ORDER BY a."createdAt" DESC
+      LIMIT 1
+    ) ace ON TRUE
+    WHERE c."userId" = $(userId)
+      AND c."deleted" IS NOT TRUE
+    ORDER BY "postedAt" DESC
+    LIMIT 100
+  `, { userId });
+
+  return rows.map(row => ({
+    documentId: row.documentId,
+    collectionName: row.collectionName,
+    postedAt: new Date(row.postedAt).toISOString(),
+    title: row.title,
+    postTitle: row.postTitle,
+    postId: row.postId,
+    html: row.html,
+    baseScore: row.baseScore,
+    pangramScore: row.pangramScore,
+    pangramFractionAi: row.pangramFractionAi,
+    pangramPrediction: row.pangramPrediction,
+    pangramWindowScores: row.pangramWindowScores,
+    aiChoice: row.aiChoice,
+    rejected: row.rejected ?? false,
+    status: rowStatus(row),
+  }));
+}

--- a/simplemod/src/server/userContext.ts
+++ b/simplemod/src/server/userContext.ts
@@ -84,7 +84,7 @@ export async function getUserContentHistory(userId: string): Promise<UserContent
       c."rejected",
       pr."html",
       pu."displayName",
-      FALSE,
+      c."draft",
       c."authorIsUnreviewed",
       c."reviewedByUserId"
     FROM "Comments" c

--- a/simplemod/src/server/userContext.ts
+++ b/simplemod/src/server/userContext.ts
@@ -1,4 +1,5 @@
 import { getSqlClientOrThrow } from '@/server/sql/sqlClient';
+import { getItemUrl } from './queue';
 import type { PangramWindowScore, ReviewCollectionName, UserContentItem } from '../lib/types';
 
 interface UserContentRow {
@@ -16,6 +17,8 @@ interface UserContentRow {
   pangramWindowScores: PangramWindowScore[] | null;
   aiChoice: string | null;
   rejected: boolean | null;
+  parentCommentHtml: string | null;
+  parentCommentAuthor: string | null;
   draft: boolean | null;
   authorIsUnreviewed: boolean | null;
   reviewedByUserId: string | null;
@@ -46,6 +49,8 @@ export async function getUserContentHistory(userId: string): Promise<UserContent
       ace."pangramWindowScores",
       ace."aiChoice",
       p."rejected",
+      NULL AS "parentCommentHtml",
+      NULL AS "parentCommentAuthor",
       p."draft",
       p."authorIsUnreviewed",
       p."reviewedByUserId"
@@ -77,12 +82,17 @@ export async function getUserContentHistory(userId: string): Promise<UserContent
       ace."pangramWindowScores",
       ace."aiChoice",
       c."rejected",
+      pr."html",
+      pu."displayName",
       FALSE,
       c."authorIsUnreviewed",
       c."reviewedByUserId"
     FROM "Comments" c
     LEFT JOIN "Posts" post ON post."_id" = c."postId"
     LEFT JOIN "Revisions" r ON r."_id" = c."contents_latest"
+    LEFT JOIN "Comments" pc ON pc."_id" = c."parentCommentId"
+    LEFT JOIN "Revisions" pr ON pr."_id" = pc."contents_latest"
+    LEFT JOIN "Users" pu ON pu."_id" = pc."userId"
     LEFT JOIN LATERAL (
       SELECT a."pangramScore", a."pangramFractionAi", a."pangramPrediction", a."pangramWindowScores", a."aiChoice"
       FROM "AutomatedContentEvaluations" a
@@ -111,6 +121,9 @@ export async function getUserContentHistory(userId: string): Promise<UserContent
     pangramWindowScores: row.pangramWindowScores,
     aiChoice: row.aiChoice,
     rejected: row.rejected ?? false,
+    itemUrl: getItemUrl(row.collectionName, row.documentId, row.postId),
+    parentCommentHtml: row.parentCommentHtml,
+    parentCommentAuthor: row.parentCommentAuthor,
     status: rowStatus(row),
   }));
 }

--- a/simplemod/tsconfig.json
+++ b/simplemod/tsconfig.json
@@ -1,0 +1,39 @@
+{
+  "extends": "../tsconfig-shared.json",
+  "compilerOptions": {
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "paths": {
+      "*": ["../*"],
+      "@/*": ["../packages/lesswrong/*"],
+      "@lexical/react": ["../packages/lesswrong/lib/vendor/lexical-react"],
+      "@lexical/react/*": ["../packages/lesswrong/lib/vendor/lexical-react/*"],
+      "@lexical/yjs": ["../packages/lesswrong/lib/vendor/lexical-yjs"],
+      "@lexical/yjs/*": ["../packages/lesswrong/lib/vendor/lexical-yjs/*"],
+      "shared/invariant": ["../packages/lesswrong/lib/vendor/lexical-shared/invariant"],
+      "shared/simpleDiffWithCursor": ["../packages/lesswrong/lib/vendor/lexical-shared/simpleDiffWithCursor"],
+      "shared/warnOnlyOnce": ["../packages/lesswrong/lib/vendor/lexical-shared/warnOnlyOnce"],
+      "shared/reactPatches": ["../packages/lesswrong/lib/vendor/lexical-shared/reactPatches"],
+      "shared/useLayoutEffect": ["../packages/lesswrong/lib/vendor/lexical-shared/useLayoutEffect"],
+      "shared/canUseDOM": ["../packages/lesswrong/lib/vendor/lexical-shared/canUseDOM"],
+      "shared/environment": ["../packages/lesswrong/lib/vendor/lexical-shared/environment"],
+      "shared/devInvariant": ["../packages/lesswrong/lib/vendor/lexical-shared/devInvariant"]
+    }
+  },
+  "include": [
+    "app",
+    "src",
+    "next.config.ts",
+    "next-env.d.ts",
+    ".next/types/**/*.ts",
+    "../packages/lesswrong"
+  ],
+  "exclude": [
+    "../node_modules",
+    ".next",
+    "../packages/lesswrong/lib/vendor/@material-ui"
+  ]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -13570,6 +13570,15 @@ frame-ticker@1:
   dependencies:
     simplesignal "^2.1.6"
 
+framer-motion@^13.1.0:
+  version "13.1.0"
+  resolved "https://registry.yarnpkg.com/framer-motion/-/framer-motion-13.1.0.tgz#e9bb655cececea4bd4ceb7cd33311b74b53953e6"
+  integrity sha512-QSZrF0Id3QGuHJ+OL+9PSY9pk86C8ERFalwAGSchzTm65+ZoGH/RM26lmEARLljcHj2lqhv0jZOOks+EI3COOw==
+  dependencies:
+    motion-dom "^13.0.0"
+    motion-utils "^13.0.0"
+    tslib "^2.4.0"
+
 fresh@0.5.2:
   version "0.5.2"
   resolved "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz"
@@ -17832,6 +17841,18 @@ moo@^0.5.0:
   version "0.5.1"
   resolved "https://registry.npmjs.org/moo/-/moo-0.5.1.tgz"
   integrity sha512-I1mnb5xn4fO80BH9BLcF0yLypy2UKl+Cb01Fu0hJRkJjlCRtxZMWkTdAtDd5ZqCOxtCkhmRwyI57vWT+1iZ67w==
+
+motion-dom@^13.0.0:
+  version "13.0.0"
+  resolved "https://registry.yarnpkg.com/motion-dom/-/motion-dom-13.0.0.tgz#1fbca308aad5140b78fa6414e187d7db10ffdc9e"
+  integrity sha512-Xk+SJas70uMAUIApg+m3lZDShxI3LBFHq7mFGbBKoRXc2PVPDyAKmzN64Bbzt4CZdP/CItTiJxWtn4TA0v53Ng==
+  dependencies:
+    motion-utils "^13.0.0"
+
+motion-utils@^13.0.0:
+  version "13.0.0"
+  resolved "https://registry.yarnpkg.com/motion-utils/-/motion-utils-13.0.0.tgz#b2e4dbe21e5488032592f0b0d4e0b7b776466dfa"
+  integrity sha512-7DnN7TmbLcYXcG4RVadXIihWlyuM9afoUww8Y5Agg431kGKiuL2/OMyP4mJ5wLz+pvN3t5ySClLOaVXJ+wekRQ==
 
 mri@^1.1.5:
   version "1.1.6"


### PR DESCRIPTION
# SimpleMod

A standalone Next.js app in `simplemod/` that reviews moderation queue items **one at a time**, Tinder-style, instead of reviewing whole users. It shares ForumMagnum's packages, database, and `.env` credentials, but has its own UI, routes, and dev server (`yarn simplemod` → http://localhost:3030, self-bootstrapping its `.env.local` via `scripts/runSimplemod.sh`).

Design principle: the moderator only ever has **one thing to think about** — the current card — but all the context they might need (bio, karma, the user's full content history, mod notes) is one keystroke away, and the post itself is fully readable in place with Pangram AI-detection highlighting applied automatically. A user-level card never appears while that user still has unreviewed posts or comments.

## What it does

- **Content cards**: the user's *earliest* unreviewed post/comment, with author stats above the post, Pangram/auto-triage chips, parent-comment context for replies, and body text colored by `highlightHtmlWithPangramWindowScores` on the same green→red scale as the score chip. Swipe right (`→`/`A`) approves that item; swipe left (`←`/`R`) opens the reject composer (templated reasons + free text); `D` approves but DMs the author; `U` approves the user outright; `S` removes them from the queue (both with a 2s cancellable grace bar). Offboard candidates' items go through this same one-at-a-time flow, flagged with an "Offboard candidate" chip.
- **Earliest-item rule, enforced server-side**: every content action runs under a per-user lock and re-verifies inside the critical section that the target is still the earliest unreviewed item; a mismatch returns 409 with the actual earliest and the client re-syncs. Hotkey races can't strand unapproved items out of order. (Single-instance by design; documented upgrade path is `pg_advisory_xact_lock`.)
- **Per-item approval semantics**: approving marks only that item (`reviewedByUserId` + `authorIsUnreviewed: false`). When the last item is decided the server auto-dequeues via `updateUser` with `reviewedAt` set (matching `approveUserCurrentContentOnly` semantics) so future content re-triggers the correct review group.
- **Offboard decision cards**: when an offboard-group user's last item is decided, instead of dequeuing, the card flips to a user-level decision — rejected-content summary, bio, permissions-removal toggle, and message composer (offboarding disables posting/commenting/messaging, creates a `VOTING_DISABLED` action, and sends the DM). Group membership is re-evaluated after every decision, so users who cross the offboard threshold mid-review (e.g. a second rejection) get the decision card too, and candidates whose content is fully approved just dequeue.
- **Pangram auto-run**: when the displayed item has no score, an evaluation runs once on load via a `run-check` endpoint that never re-rolls an existing score; failures show a quiet retry affordance.
- **Context panel**: `Tab` slides out a left panel (slide-over with scrim on mobile) with bio, mod notes, and the user's complete content history — every item expandable to full text with status chips, the current item marked.
- **Wrap-up cards**: queued users with no live unreviewed content — approve or dequeue.
- All writes go through FM's mutation functions, so rejection PMs, `REJECTED_*` moderator actions, sunshine notes, and notifications fire exactly as in supermod. Templates are processed with `getDraftMessageHtml` (moderator-only preamble stripped, `{{displayName}}` substituted) like every other FM composer.

## Architecture

- `simplemod/` reuses the **root `node_modules`** (no second dependency tree). Its `next.config.ts` loads the root `.env.local` via `@next/env` and replicates the root Turbopack aliases (`@/*` → `../packages/lesswrong/*`, server/client stubs, Sentry stub).
- Auth: FM's `loginToken` cookie flow (`getContextFromReqAndRes` + `userIsAdminOrMod`); on localhost, a forum login on :3000 authenticates :3030. `/login` accepts a pasted `loginToken` otherwise.
- Queue: raw SQL mirroring `sunshineNewUsers` + an earliest-unreviewed-item UNION over posts and comments (drafts and deleted excluded, `postedAt`+`_id` tiebreak); review groups via `getUserReviewGroup`, extracted from the Users `reviewGroup` resolver. Sunshine-note writes use an atomic SQL prepend so FM's concurrent background note-appenders can't lose entries.
- Loading: the client fires a quick request (first ~3 cards) and the full queue in parallel, rendering the quick result immediately and merging the full list in behind it without resurrecting locally-decided cards; server queue stages run concurrently; templates and the top user's context prefetch in the background with per-user cache invalidation.
- UI: framer-motion drag cards (drag blocked over text so selection never triggers a swipe), optimistic exit animations with APPROVE/REJECT flashes, keyboard scrolling with scroll shadows, 68ch reading measure, dark mode, session progress counter, clickable hotkey legend that doubles as mobile buttons, composer drafts that survive Esc, cached templates.

## Review process

Built with an iterative subagent review loop: an adversarial code review (earliest-item invariant, SQL vs FM view semantics, mutation side effects, XSS/auth) and a UX review driving the real app with mocked APIs, findings fixed and re-verified per round (screenshots via Playwright), plus a final verification pass.

FM-core changes are minimal: `getUserReviewGroup` extraction in `users/newSchema.ts`, and `rerunLlmCheck` now updates the newest ACE when a revision has several (matching reader behavior).

## Verification

- `tsgo --noEmit` clean for root and `simplemod/`; eslint clean on touched FM files.
- Full UI exercised via Playwright with mocked API data (light/dark/mobile, all card types, composer, context panel, conflict and error states, offboard item→decision flow).
- Not yet verified against a real dev database in the dev container: end-to-end flag flips, rejection PM delivery, live 409 race test, real Pangram runs. Suggested local check: `yarn simplemod`, log into the forum on :3000 as an admin, seed a queue user via `yarn repl dev lw` (create an `UNREVIEWED_FIRST_POST` moderator action), then click/spam through the flows.

## Known limitations / flagged for product

- Users whose only remaining content is drafts surface as wrap-up cards.
- The shared `highlightHtmlWithPangramWindowScores` fuzzy word-anchor matcher can misplace a window on highly repetitive text (pre-existing FM behavior, shared with supermod's score dialog).
- Prod deployment concerns (cookie domain, multi-instance locking) are out of scope for v1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WjSXkC4MLTeHv3VMorbabD