### PR TITLE
Fix mobile overflow of author tooltip, link previews, and inline reacts

### DIFF
--- a/packages/lesswrong/components/common/LWPopper.tsx
+++ b/packages/lesswrong/components/common/LWPopper.tsx
@@ -46,7 +46,9 @@ const LWPopper = ({
   tooltip=false,
   allowOverflow,
   overflowPadding,
+  overflowAltAxis,
   flip,
+  fallbackPlacements,
   open,
   anchorEl,
   distance=0,
@@ -59,7 +61,15 @@ const LWPopper = ({
   tooltip?: boolean,
   allowOverflow?: boolean,
   overflowPadding?: number,
+  // By default, popper's preventOverflow only keeps the popper in the viewport
+  // along its slide axis (e.g. only vertically for left/right placements).
+  // This enables it on the other axis too, which can cause the popper to
+  // overlap its anchor rather than go off-screen.
+  overflowAltAxis?: boolean,
   flip?: boolean,
+  // Placements to try, in order, when the preferred placement doesn't fit in
+  // the viewport. Overrides popper's default of just the opposite placement.
+  fallbackPlacements?: PopperPlacementType[],
   open: boolean,
   placement?: PopperPlacementType,
   anchorEl: any,
@@ -77,13 +87,18 @@ const LWPopper = ({
       name: 'flip',
       enabled: false,
     }
-  ] : [];
+  ] : (fallbackPlacements ? [
+    {
+      name: 'flip',
+      options: {fallbackPlacements},
+    }
+  ] : []);
 
   const preventOverflowModifier = [
     {
       name: 'preventOverflow',
       enabled: !allowOverflow,
-      options: {padding: overflowPadding},
+      options: {padding: overflowPadding, altAxis: overflowAltAxis},
     }
   ];
 

--- a/packages/lesswrong/components/common/LWTooltip.tsx
+++ b/packages/lesswrong/components/common/LWTooltip.tsx
@@ -28,6 +28,10 @@ export type LWTooltipProps = {
   placement?: PopperPlacementType,
   tooltip?: boolean,
   flip?: boolean,
+  /** Keep the popper on-screen along both axes, not just its slide axis. See LWPopper. */
+  overflowAltAxis?: boolean,
+  /** Placements to try, in order, when `placement` doesn't fit in the viewport. See LWPopper. */
+  fallbackPlacements?: PopperPlacementType[],
   clickable?: boolean,
   inlineBlock?: boolean,
   As?: 'span' | 'div',
@@ -59,6 +63,8 @@ const LWTooltip = ({
   placement="bottom-start",
   tooltip=true,
   flip=true,
+  overflowAltAxis,
+  fallbackPlacements,
   clickable=false,
   inlineBlock=true,
   As="span",
@@ -143,6 +149,8 @@ const LWTooltip = ({
       anchorEl={anchorEl ?? defaultAnchorElRef.current}
       tooltip={tooltip}
       allowOverflow={!flip}
+      overflowAltAxis={overflowAltAxis}
+      fallbackPlacements={fallbackPlacements}
       distance={distance}
       clickable={delayedClickable}
       hideOnTouchScreens={hideOnTouchScreens}

--- a/packages/lesswrong/components/linkPreview/CrossSiteLinkPreview.tsx
+++ b/packages/lesswrong/components/linkPreview/CrossSiteLinkPreview.tsx
@@ -35,7 +35,7 @@ const styles = defineStyles("CrossSiteLinkPreview", (theme: ThemeType) => ({
   },
   bannerCard: {
     width: 360,
-    maxWidth: "min(360, 90vw)",
+    maxWidth: "min(360px, 90vw)",
     padding: 0,
     position: "relative",
   },

--- a/packages/lesswrong/components/linkPreview/PostLinkPreview.tsx
+++ b/packages/lesswrong/components/linkPreview/PostLinkPreview.tsx
@@ -439,7 +439,7 @@ const defaultPreviewStyles = defineStyles('DefaultPreview', (theme: ThemeType) =
     fontSize: "1.1rem",
     ...theme.typography.commentStyle,
     color: theme.palette.grey[600],
-    maxWidth: 500,
+    maxWidth: "min(500px, calc(100vw - 16px))",
     overflow: 'hidden',
     textOverflow: 'ellipsis',
     whiteSpace: 'nowrap'
@@ -714,7 +714,7 @@ const arbitalStyles = defineStyles('ArbitalPreview', (theme: ThemeType) => ({
     padding: 8,
     paddingLeft: 12,
     paddingRight: 12,
-    maxWidth: 500,
+    maxWidth: "min(500px, calc(100vw - 16px))",
     overflow: 'hidden',
     textOverflow: 'ellipsis',
     '& h2': {

--- a/packages/lesswrong/components/sequences/SequencesSummary.tsx
+++ b/packages/lesswrong/components/sequences/SequencesSummary.tsx
@@ -29,7 +29,7 @@ const ChaptersFragmentMultiQuery = gql(`
 const styles = defineStyles('SequencesSummary', (theme: ThemeType) => ({
   root: {
     padding: 16,
-    width: 450,
+    width: "min(450px, calc(100vw - 16px))",
   },
   title: {
     ...theme.typography.body1,

--- a/packages/lesswrong/components/users/LWUserTooltipContent.tsx
+++ b/packages/lesswrong/components/users/LWUserTooltipContent.tsx
@@ -38,7 +38,7 @@ const styles = defineStyles('LWUserTooltipContent', (theme: ThemeType) => ({
   root: {
     display: "flex",
     flexDirection: "column",
-    width: 350,
+    width: "min(350px, calc(100vw - 16px))",
     maxWidth: "unset",
     fontSize: 14,
     fontWeight: 450,

--- a/packages/lesswrong/components/users/UserTooltip.tsx
+++ b/packages/lesswrong/components/users/UserTooltip.tsx
@@ -34,6 +34,8 @@ const UserTooltip = ({user, placement, inlineBlock, hideFollowButton, disabled, 
       inlineBlock={inlineBlock}
       popperClassName={classes.root}
       titleClassName={classes.overrideTooltip}
+      overflowAltAxis
+      fallbackPlacements={["bottom-start", "top-start"]}
       clickable
       disabled={disabled}
     >

--- a/packages/lesswrong/components/votes/ReactionsPalette.tsx
+++ b/packages/lesswrong/components/votes/ReactionsPalette.tsx
@@ -99,7 +99,7 @@ const styles = defineStyles('ReactionsPalette', (theme: ThemeType) => ({
     borderRadius: 6
   },
   reactionPaletteScrollRegion: {
-    width: 350,
+    width: "min(350px, calc(100vw - 16px))",
     maxHeight: 305,
     overflowY: "scroll",
     marginTop: 12,

--- a/packages/lesswrong/components/votes/lwReactions/AddInlineReactionButton.tsx
+++ b/packages/lesswrong/components/votes/lwReactions/AddInlineReactionButton.tsx
@@ -9,6 +9,8 @@ import ReactionsPalette from "../ReactionsPalette";
 import { defineStyles } from '@/components/hooks/defineStyles';
 import { useStyles } from '@/components/hooks/useStyles';
 
+const PALETTE_WIDTH = 350;
+
 const styles = defineStyles('AddInlineReactionButton', (theme: ThemeType) => ({
   container: {
     position: "relative",
@@ -17,6 +19,7 @@ const styles = defineStyles('AddInlineReactionButton', (theme: ThemeType) => ({
     height: 38,
   },
   icon: {
+    color: theme.palette.grey[600],
     borderRadius: 8,
     padding: '7px 8px',
     "&:hover": {
@@ -35,10 +38,19 @@ const styles = defineStyles('AddInlineReactionButton', (theme: ThemeType) => ({
     backgroundColor: theme.palette.background.pageActiveAreaBackground,
     boxShadow: theme.shadows[2],
     paddingTop: 12,
-    maxWidth: 350,
+    maxWidth: `min(${PALETTE_WIDTH}px, calc(100vw - 16px))`,
     position: "absolute",
     left: 0,
     top: -30,
+  },
+  // Used when there isn't room for the palette to extend rightwards from the
+  // button (e.g. on phones, where the button is clamped to the viewport
+  // edge). -40 (the icon width) aligns the palette's right edge with the
+  // icon's right edge; the container's own inline box ends at the icon's
+  // left edge.
+  paletteOpenToLeft: {
+    left: "auto",
+    right: -40,
   }
 }))
 
@@ -52,13 +64,16 @@ const AddInlineReactionButton = ({voteProps, quote, disabled, wrapperClassName, 
 }) => {
   const classes = useStyles(styles);
   const [open,setOpen] = useState(false);
+  const [openToLeft,setOpenToLeft] = useState(false);
   const buttonRef = useRef<HTMLElement|null>(null);
   const { getCurrentUserReactionVote, toggleReaction } = useNamesAttachedReactionsVoting(voteProps);
-  
+
   const handleOpen = (e: React.MouseEvent) => {
     e.stopPropagation();
     e.preventDefault();
     if (!disabled) {
+      const buttonRect = buttonRef.current?.getBoundingClientRect();
+      setOpenToLeft(!!buttonRect && buttonRect.left + PALETTE_WIDTH > window.innerWidth)
       setOpen(true)
     }
   }
@@ -86,7 +101,7 @@ const AddInlineReactionButton = ({voteProps, quote, disabled, wrapperClassName, 
         {!open && <ForumIcon icon="AddReaction" onMouseDown={handleOpen} className={classNames(classes.icon, { [classes.disabled]: disabled }, iconClassName)}/>}
       </span>
     </LWTooltip>
-    {open && <div className={classNames(classes.palette, paletteClassName)}>
+    {open && <div className={classNames(classes.palette, openToLeft && classes.paletteOpenToLeft, paletteClassName)}>
       <ReactionsPalette
         getCurrentUserReactionVote={getCurrentUserReactionVote}
         toggleReaction={handleToggleReaction}

--- a/packages/lesswrong/components/votes/lwReactions/InlineReactSelectionWrapper.tsx
+++ b/packages/lesswrong/components/votes/lwReactions/InlineReactSelectionWrapper.tsx
@@ -22,7 +22,7 @@ type Styling = "comment"|"post"|"tag"|"messageRight"|"messageLeft";
 function getButtonOffsetLeft(styling: Styling, contentRef?: React.RefObject<ContentItemBodyImperative | null> | null): number {
   switch (styling) {
     case "comment":
-      return 12;
+      return clampButtonOffsetToViewport(12, contentRef);
     // messageLeft is for messages by the current user, and indicates the inline react button should be to the left of the message item (since the message is right-aligned)
     // messageRight is for messages by other users, and indicates the inline react button should be to the right of the message item (since the message is left-aligned)
     // The messageLeft and messageRight values were chosen empirically to avoid overlap between the button background and the message container.
@@ -33,8 +33,20 @@ function getButtonOffsetLeft(styling: Styling, contentRef?: React.RefObject<Cont
       return 0;
     case "post":
     case "tag":
-      return 30;
+      return clampButtonOffsetToViewport(30, contentRef);
   }
+}
+
+// The button is normally rendered `offset` px into the right margin of the
+// content (in addition to the 12px from the button class's `left`). On narrow
+// screens the content runs nearly to the viewport edge and there is no right
+// margin, so reduce the offset (possibly to a negative value, pulling the
+// button over the content) enough to keep the ~40px-wide button on-screen.
+// 56 = 12 (button class `left`) + 40 (button width) + 4 (gap to the edge).
+function clampButtonOffsetToViewport(offset: number, contentRef?: React.RefObject<ContentItemBodyImperative | null> | null): number {
+  const anchorRight = contentRef?.current?.getAnchorEl()?.getBoundingClientRect().right;
+  if (anchorRight === undefined) return offset;
+  return Math.min(offset, window.innerWidth - anchorRight - 56);
 }
 
 function getButtonOffsetTop(styling: Styling): number {


### PR DESCRIPTION
On phone-width viewports, the author-name popup, several link previews, and the inline-react button/palette all extended past the screen edge. The author tooltip's width is now capped to the viewport, LWPopper/LWTooltip gained opt-in `overflowAltAxis` and `fallbackPlacements` options, and the user tooltip uses them to stay on-screen and open below the name when the byline's left placement doesn't fit. Link previews (DefaultPreview, ArbitalPreview, SequencesSummary, ReactionsPalette) get viewport-relative width caps, including fixing a missing `px` unit in CrossSiteLinkPreview that silently dropped its cap. The inline-react button's right-margin offset is now clamped to the viewport, the reactions palette opens leftwards when there's no room to extend right, and the button icon is explicitly grey so it stays legible over text. Verified with Playwright at 390px/650px/1440px widths: button, palette, and tooltips all render fully on-screen, with desktop behavior unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1217521116817999) by [Unito](https://www.unito.io)
