### PR TITLE
Add light-mode fallbacks for light-dark() CSS on old Safari

### DIFF
--- a/packages/lesswrong/components/hooks/useStyles.tsx
+++ b/packages/lesswrong/components/hooks/useStyles.tsx
@@ -13,6 +13,7 @@ import jssPropsSort from 'jss-plugin-props-sort';
 import { isClient } from "@/lib/executionEnvironment";
 import { ThemeContext, ThemeContextType, useTheme } from '../themes/useTheme';
 import { maybeMinifyCSS } from "@/server/maybeMinifyCSS";
+import { addLightDarkFallbacks } from "@/lib/lightDarkFallbacks";
 import { type AbstractThemeOptions, abstractThemeToConcrete, themeOptionsAreConcrete } from "@/themes/themeNames";
 import { getForumTheme } from "@/themes/forumTheme";
 import { classNameProxy, defineStyles } from "./defineStyles";
@@ -310,7 +311,9 @@ function styleNodeToString(theme: ThemeType, styleDefinition: StyleDefinition): 
     }
   );
   sheets.add(sheet);
-  return maybeMinifyCSS(sheets.toString());
+  // Fallbacks must be added after minification: csso's restructuring would
+  // remove the "overridden" fallback declarations.
+  return addLightDarkFallbacks(maybeMinifyCSS(sheets.toString()));
 }
 
 

--- a/packages/lesswrong/lib/jssStyles.ts
+++ b/packages/lesswrong/lib/jssStyles.ts
@@ -1,4 +1,5 @@
 import type { StyleDefinition } from "@/server/styleGeneration";
+import { addLightDarkFallbacks } from "@/lib/lightDarkFallbacks";
 import { create as jssCreate, SheetsRegistry } from "jss";
 import jssCamelCase from "jss-plugin-camel-case";
 import jssDefaultUnit from "jss-plugin-default-unit";
@@ -115,5 +116,5 @@ export function styleNodeToString(theme: ThemeType, styleDefinition: StyleDefini
     }
   );
   sheets.add(sheet);
-  return sheets.toString();
+  return addLightDarkFallbacks(sheets.toString());
 }

--- a/packages/lesswrong/lib/lightDarkFallbacks.ts
+++ b/packages/lesswrong/lib/lightDarkFallbacks.ts
@@ -1,0 +1,71 @@
+const lightDarkStart = "light-dark(";
+
+/**
+ * Replace every `light-dark(lightColor, darkColor)` in the given CSS (or CSS
+ * fragment) with just `lightColor`. Used for email stylesheets (email clients
+ * don't support `light-dark()`) and for building fallback declarations for
+ * browsers that predate `light-dark()` support (Safari <17.5).
+ */
+export function replaceLightDarkWithLightModeColor(stylesheet: string): string {
+  let css = "";
+  let startIndex = 0;
+
+  while (true) {
+    const matchIndex = stylesheet.indexOf(lightDarkStart, startIndex);
+    if (matchIndex === -1) {
+      return css + stylesheet.slice(startIndex);
+    }
+
+    css += stylesheet.slice(startIndex, matchIndex);
+
+    let depth = 1;
+    let firstArgumentEnd = -1;
+    let endIndex = matchIndex + lightDarkStart.length;
+
+    for (; endIndex < stylesheet.length; endIndex++) {
+      const character = stylesheet[endIndex];
+
+      if (character === "(") {
+        depth += 1;
+      } else if (character === ")") {
+        depth -= 1;
+        if (depth === 0) {
+          break;
+        }
+      } else if (character === "," && depth === 1 && firstArgumentEnd === -1) {
+        firstArgumentEnd = endIndex;
+      }
+    }
+
+    if (depth !== 0 || firstArgumentEnd === -1) {
+      return css + stylesheet.slice(matchIndex);
+    }
+
+    css += stylesheet
+      .slice(matchIndex + lightDarkStart.length, firstArgumentEnd)
+      .trim();
+    startIndex = endIndex + 1;
+  }
+}
+
+// Matches a full `property: value` declaration whose value contains
+// `light-dark(`. The value can't contain `;`, `{`, or `}` (light-dark
+// arguments are colors, which never contain those characters), so scanning
+// with [^;{}] can't escape the declaration. The terminating `;` or `}` is
+// matched with a lookahead so it's left in place.
+const declarationWithLightDarkRegex = /[-\w]+\s*:[^;{}]*light-dark\([^;{}]*(?=[;}])/g;
+
+/**
+ * Browsers without `light-dark()` support (Safari <17.5) drop any declaration
+ * containing it, leaving e.g. backgrounds transparent. For each such
+ * declaration, insert a copy before it with the light-mode color, so old
+ * browsers get light-mode styling while modern browsers override it with the
+ * `light-dark()` version. Must be applied after minification: csso's
+ * restructuring would strip the "overridden" fallback declaration.
+ */
+export function addLightDarkFallbacks(css: string): string {
+  return css.replace(
+    declarationWithLightDarkRegex,
+    (declaration) => `${replaceLightDarkWithLightModeColor(declaration)};${declaration}`,
+  );
+}

--- a/packages/lesswrong/lib/styleHelpers.ts
+++ b/packages/lesswrong/lib/styleHelpers.ts
@@ -1,6 +1,7 @@
 import type { StyleDefinition } from "../server/styleGeneration";
 import sortBy from "lodash/sortBy";
 import { getJss } from "@/lib/jssStyles";
+import { replaceLightDarkWithLightModeColor } from "@/lib/lightDarkFallbacks";
 import { SheetsRegistry } from 'jss';
 import keyBy from "lodash/keyBy";
 
@@ -23,49 +24,6 @@ function stylesToStylesheet(allStyles: Record<string,StyleDefinition>, theme: Th
     sheetsRegistry.add(sheet);
   }).join("\n");
   return sheetsRegistry.toString();
-}
-
-function replaceLightDarkWithLightModeColor(stylesheet: string): string {
-  const lightDarkStart = "light-dark(";
-  let css = "";
-  let startIndex = 0;
-
-  while (true) {
-    const matchIndex = stylesheet.indexOf(lightDarkStart, startIndex);
-    if (matchIndex === -1) {
-      return css + stylesheet.slice(startIndex);
-    }
-
-    css += stylesheet.slice(startIndex, matchIndex);
-
-    let depth = 1;
-    let firstArgumentEnd = -1;
-    let endIndex = matchIndex + lightDarkStart.length;
-
-    for (; endIndex < stylesheet.length; endIndex++) {
-      const character = stylesheet[endIndex];
-
-      if (character === "(") {
-        depth += 1;
-      } else if (character === ")") {
-        depth -= 1;
-        if (depth === 0) {
-          break;
-        }
-      } else if (character === "," && depth === 1 && firstArgumentEnd === -1) {
-        firstArgumentEnd = endIndex;
-      }
-    }
-
-    if (depth !== 0 || firstArgumentEnd === -1) {
-      return css + stylesheet.slice(matchIndex);
-    }
-
-    css += stylesheet
-      .slice(matchIndex + lightDarkStart.length, firstArgumentEnd)
-      .trim();
-    startIndex = endIndex + 1;
-  }
 }
 
 export function generateEmailStylesheet({ stylesUsed, theme }: {

--- a/packages/lesswrong/unitTests/lightDarkFallbacks.tests.ts
+++ b/packages/lesswrong/unitTests/lightDarkFallbacks.tests.ts
@@ -1,0 +1,60 @@
+import { addLightDarkFallbacks, replaceLightDarkWithLightModeColor } from '../lib/lightDarkFallbacks';
+
+describe('replaceLightDarkWithLightModeColor', () => {
+  it('replaces light-dark with its first argument', () => {
+    expect(replaceLightDarkWithLightModeColor('color: light-dark(#333, #aaa);')).toBe(
+      'color: #333;',
+    );
+  });
+
+  it('handles nested parentheses in the arguments', () => {
+    expect(
+      replaceLightDarkWithLightModeColor('background: light-dark(rgba(0,0,0,0.1),rgba(255,255,255,0.1));'),
+    ).toBe('background: rgba(0,0,0,0.1);');
+  });
+
+  it('replaces multiple occurrences', () => {
+    expect(
+      replaceLightDarkWithLightModeColor('border: 1px solid light-dark(#000,#fff); color: light-dark(#333,#aaa);'),
+    ).toBe('border: 1px solid #000; color: #333;');
+  });
+});
+
+describe('addLightDarkFallbacks', () => {
+  it('inserts a light-mode fallback before a light-dark declaration', () => {
+    expect(addLightDarkFallbacks('.a-root {\n  background-color: light-dark(#fff, #000);\n}')).toBe(
+      '.a-root {\n  background-color: #fff;background-color: light-dark(#fff, #000);\n}',
+    );
+  });
+
+  it('handles minified declarations without a trailing semicolon', () => {
+    expect(addLightDarkFallbacks('.a{color:light-dark(#333,#aaa)}')).toBe(
+      '.a{color:#333;color:light-dark(#333,#aaa)}',
+    );
+  });
+
+  it('handles values with multiple light-dark calls and nested parentheses', () => {
+    expect(
+      addLightDarkFallbacks('.a{box-shadow:0 0 2px light-dark(rgba(0,0,0,0.2),rgba(255,255,255,0.2)),0 0 4px light-dark(#000,#fff)}'),
+    ).toBe(
+      '.a{box-shadow:0 0 2px rgba(0,0,0,0.2),0 0 4px #000;box-shadow:0 0 2px light-dark(rgba(0,0,0,0.2),rgba(255,255,255,0.2)),0 0 4px light-dark(#000,#fff)}',
+    );
+  });
+
+  it('preserves !important in the fallback', () => {
+    expect(addLightDarkFallbacks('.a{color:light-dark(#333,#aaa) !important}')).toBe(
+      '.a{color:#333 !important;color:light-dark(#333,#aaa) !important}',
+    );
+  });
+
+  it('leaves declarations without light-dark unchanged', () => {
+    const css = '.a{color:#333;background:url(data:image/png;base64,abc)}';
+    expect(addLightDarkFallbacks(css)).toBe(css);
+  });
+
+  it('only duplicates the declarations that use light-dark', () => {
+    expect(
+      addLightDarkFallbacks('.a{margin:8px;color:light-dark(#333,#aaa);padding:4px}'),
+    ).toBe('.a{margin:8px;color:#333;color:light-dark(#333,#aaa);padding:4px}');
+  });
+});


### PR DESCRIPTION
Safari before 17.5 doesn't support the `light-dark()` CSS function and drops any declaration containing it, which left elements like the user-menu dropdown with a transparent background since the entire greyscale palette is emitted as `light-dark()` values. This inserts a plain light-mode fallback declaration before each `light-dark()` declaration at CSS generation time, so old browsers get light-mode colors while modern browsers override the fallback with the `light-dark()` version. The transform is applied in both `styleNodeToString` implementations (covering SSR-embedded styles, server components, and client-side style mounting), after csso minification so the minifier can't strip the duplicate declarations. `replaceLightDarkWithLightModeColor` moves from `styleHelpers` to a shared `lightDarkFallbacks` module so the email path and the new fallback logic share the parsing logic, with unit tests covering nested `rgba()` args, multiple `light-dark()` calls per value, `!important`, and minified input.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1217527658055498) by [Unito](https://www.unito.io)
