### PR TITLE
Copy markdown directly to clipboard instead of opening a new tab

### DIFF
--- a/packages/lesswrong/components/dropdowns/CopyMarkdownDropdownItem.tsx
+++ b/packages/lesswrong/components/dropdowns/CopyMarkdownDropdownItem.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import DropdownItem from './DropdownItem';
 import { useMessages } from '../common/withMessages';
 
@@ -6,23 +6,24 @@ const CopyMarkdownDropdownItem = ({path}: {
   path: string,
 }) => {
   const { flash } = useMessages();
+  const [loading, setLoading] = useState(false);
 
   const copyMarkdown = () => {
-    // Start synchronously, while doc still has focus and user activation - opening new tab takes focus away
+    // Pass the fetch promise into ClipboardItem rather than awaiting it first,
+    // so the clipboard write still counts as user-activated in Safari
+    setLoading(true);
     const markdownBlob = fetch(path).then(async (response) => {
       if (!response.ok) {
         throw new Error(`Failed to fetch markdown: ${response.status}`);
       }
       return new Blob([await response.text()], {type: "text/plain"});
     });
-    const clipboardWrite = navigator.clipboard.write([
+    navigator.clipboard.write([
       new ClipboardItem({"text/plain": markdownBlob}),
-    ]);
-    window.open(path, "_blank");
-    clipboardWrite.then(
+    ]).then(
       () => flash("Markdown copied to clipboard"),
       () => flash("Failed to copy markdown"),
-    );
+    ).finally(() => setLoading(false));
   };
 
   return (
@@ -30,6 +31,7 @@ const CopyMarkdownDropdownItem = ({path}: {
       title="Copy Markdown"
       icon="ClipboardDocument"
       onClick={copyMarkdown}
+      loading={loading}
     />
   );
 };


### PR DESCRIPTION
"Copy Markdown" (in the post/comment triple-dot menus) previously opened the markdown API endpoint in a new tab in addition to copying to the clipboard. This removes the `window.open` so it just copies directly.

While the markdown is being fetched, the menu item shows a loading spinner (via `DropdownItem`'s existing `loading` prop, which is documented for exactly this case). The fetch promise is still passed into `ClipboardItem` rather than awaited beforehand, so the clipboard write remains within the user-activation window in Safari.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1217616266663686) by [Unito](https://www.unito.io)
