### PR TITLE
Halve max height of moderator notes list

### DIFF
--- a/packages/lesswrong/components/sunshineDashboard/supermod/ModeratorNotes.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/supermod/ModeratorNotes.tsx
@@ -52,7 +52,7 @@ const styles = defineStyles('ModeratorNotes', (theme: ThemeType) => ({
     alignItems: 'baseline',
     columnGap: 8,
     rowGap: 8,
-    maxHeight: 300,
+    maxHeight: 150,
     overflowY: 'auto',
     ...prettyScrollbars(theme),
   },


### PR DESCRIPTION
Reduces the scrollable moderator notes list in `ModeratorNotes.tsx` from `maxHeight: 300` to `maxHeight: 150`, so the notes section takes up half as much vertical space in the moderation user info column.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VbbqjDJUjXXvUFJWtR5TpS)_

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1217662637900289) by [Unito](https://www.unito.io)
