### PR TITLE
Add index for topShortform so old AllPosts time blocks load

### DIFF
--- a/packages/lesswrong/server/databaseIndexes/commentsDbIndexes.ts
+++ b/packages/lesswrong/server/databaseIndexes/commentsDbIndexes.ts
@@ -68,7 +68,20 @@ export function getDbIndexesOnComments() {
   
   // Will be used for experimental shortform display on AllPosts page
   indexSet.addIndex("Comments", { topLevelCommentId: 1, postedAt: 1, baseScore:1});
-  
+
+  // Serves the topShortform view, used by the shortform section of each time
+  // block on the AllPosts page. The shortform index above sorts by
+  // lastSubthreadActivity and so can't restrict on a postedAt range, which
+  // meant a time block covering a period with no shortform comments (ie
+  // anything before 2018) had to scan every comment posted in that range. That
+  // was slowest for the years with the most comments and no shortform at all:
+  // a 2013 time block took ~34s cold, which blocked the whole AllPosts year
+  // from rendering.
+  indexSet.addIndex("Comments",
+    augmentForDefaultView({ shortform: 1, parentCommentId: 1, deleted: 1, postedAt: -1, baseScore: -1 }),
+    { name: "comments.top_shortform" }
+  );
+
   // Filtering comments down to ones that include "nominated for Review" so further sort indexes not necessary
   indexSet.addIndex("Comments",
     augmentForDefaultView({ nominatedForReview: 1, userId: 1, postId: 1 }),

--- a/packages/lesswrong/server/databaseIndexes/commentsDbIndexes.ts
+++ b/packages/lesswrong/server/databaseIndexes/commentsDbIndexes.ts
@@ -69,17 +69,15 @@ export function getDbIndexesOnComments() {
   // Will be used for experimental shortform display on AllPosts page
   indexSet.addIndex("Comments", { topLevelCommentId: 1, postedAt: 1, baseScore:1});
 
-  // Serves the topShortform view, used by the shortform section of each time
-  // block on the AllPosts page. The shortform index above sorts by
-  // lastSubthreadActivity and so can't restrict on a postedAt range, which
-  // meant a time block covering a period with no shortform comments (ie
-  // anything before 2018) had to scan every comment posted in that range. That
-  // was slowest for the years with the most comments and no shortform at all:
-  // a 2013 time block took ~34s cold, which blocked the whole AllPosts year
-  // from rendering.
+  // Serves topShortform, the shortform section of each AllPosts time block.
+  // The {shortform, topLevelCommentId, ...} index above keeps postedAt too
+  // late in the key to restrict on a date range, so blocks from before
+  // shortform existed scanned every comment in range: 2013 took ~34s cold,
+  // which blocked the whole year from rendering. Partial because `shortform`
+  // is nullable, so an unfiltered index would cover every comment ever made.
   indexSet.addIndex("Comments",
-    augmentForDefaultView({ shortform: 1, parentCommentId: 1, deleted: 1, postedAt: -1, baseScore: -1 }),
-    { name: "comments.top_shortform" }
+    augmentForDefaultView({ shortform:1, parentCommentId:1, deleted:1, postedAt:-1, baseScore:-1 }),
+    { name: "comments.top_shortform", partialFilterExpression: { shortform: true }, concurrently: true }
   );
 
   // Filtering comments down to ones that include "nominated for Review" so further sort indexes not necessary

--- a/packages/lesswrong/server/databaseIndexes/commentsDbIndexes.ts
+++ b/packages/lesswrong/server/databaseIndexes/commentsDbIndexes.ts
@@ -69,12 +69,7 @@ export function getDbIndexesOnComments() {
   // Will be used for experimental shortform display on AllPosts page
   indexSet.addIndex("Comments", { topLevelCommentId: 1, postedAt: 1, baseScore:1});
 
-  // Serves topShortform, the shortform section of each AllPosts time block.
-  // The {shortform, topLevelCommentId, ...} index above keeps postedAt too
-  // late in the key to restrict on a date range, so blocks from before
-  // shortform existed scanned every comment in range: 2013 took ~34s cold,
-  // which blocked the whole year from rendering. Partial because `shortform`
-  // is nullable, so an unfiltered index would cover every comment ever made.
+  // Serves topShortform; the 2013 AllPosts block took ~34s cold without it.
   indexSet.addIndex("Comments",
     augmentForDefaultView({ shortform:1, parentCommentId:1, deleted:1, postedAt:-1, baseScore:-1 }),
     { name: "comments.top_shortform", partialFilterExpression: { shortform: true }, concurrently: true }

--- a/packages/lesswrong/server/migrations/20260819T120000.add_Comments_topShortform_index.ts
+++ b/packages/lesswrong/server/migrations/20260819T120000.add_Comments_topShortform_index.ts
@@ -1,0 +1,10 @@
+import Comments from "../collections/comments/collection";
+import { updateIndexes } from "./meta/utils";
+
+export const up = async ({db}: MigrationContext) => {
+  await updateIndexes(Comments);
+};
+
+export const down = async ({db}: MigrationContext) => {
+  // Dropping the index is not required; it is only additive.
+};

--- a/schema/accepted_schema.sql
+++ b/schema/accepted_schema.sql
@@ -490,6 +490,21 @@ CREATE INDEX IF NOT EXISTS "idx_Comments_shortform_topLevelCommentId_lastSubthre
 -- Index "idx_Comments_topLevelCommentId_postedAt_baseScore"
 CREATE INDEX IF NOT EXISTS "idx_Comments_topLevelCommentId_postedAt_baseScore" ON "Comments" USING btree ("topLevelCommentId", "postedAt", "baseScore");
 
+-- Index "idx_comments_top_shortform"
+CREATE INDEX IF NOT EXISTS "idx_comments_top_shortform" ON "Comments" USING btree (
+  "shortform",
+  "parentCommentId",
+  "deleted",
+  "postedAt",
+  "baseScore",
+  "authorIsUnreviewed",
+  "deletedPublic",
+  "hideAuthor",
+  "userId",
+  "af",
+  "debateResponse"
+);
+
 -- Index "idx_comments_nominations2018"
 CREATE INDEX IF NOT EXISTS "idx_comments_nominations2018" ON "Comments" USING btree (
   "nominatedForReview",

--- a/schema/accepted_schema.sql
+++ b/schema/accepted_schema.sql
@@ -503,7 +503,9 @@ CREATE INDEX IF NOT EXISTS "idx_comments_top_shortform" ON "Comments" USING btre
   "userId",
   "af",
   "debateResponse"
-);
+)
+WHERE
+  "shortform" IS TRUE;
 
 -- Index "idx_comments_nominations2018"
 CREATE INDEX IF NOT EXISTS "idx_comments_nominations2018" ON "Comments" USING btree (


### PR DESCRIPTION
## The bug

`/allPosts?after=2013-01-01&before=2014-01-01&limit=100` renders the `2013` heading and then nothing — no posts, no "No posts for this year", no divider. Recent years are fine. The posts do eventually appear after ~30-40s, long after anyone has given up.

## Root cause

Not the posts query — that's fine (100 results, `totalCount: 1973`, ~600ms). It's the `ShortformTimeBlock` rendered alongside it.

`topShortform` filters on `shortform` / `parentCommentId` / `deleted` plus a `postedAt` range, and sorts by `baseScore`. Nothing indexed that. The existing shortform index leads with `(shortform, topLevelCommentId, lastSubthreadActivity)`, so it can't restrict on a `postedAt` range, and the query degenerated into scanning every comment posted in the range. Cost scaled with comment volume in the block, so it was worst for periods with lots of comments and no shortform at all — anything before 2018.

Measured against prod, one-year block:

| Year | cold | warm |
|---|---|---|
| **2013** | **34,336 ms** | 1,474 ms |
| 2016 | 121 ms | 116 ms |
| 2020 | 144 ms | 142 ms |

The shortform query is batched into the same `/api/streamGraphql` request as the post list. `StreamingGraphqlHttpLink` is written to deliver each operation as its `{index,result}` line arrives, and the route handler does execute the batch in parallel and stream each result — but in production the response is buffered rather than flushed incrementally, so the posts result can't land until the slow shortform op finishes. Confirmed in the browser: one `streamGraphql` request, `duration: 28212ms`, and the 100 posts appeared only on its completion.

## The fix

Adds a covering index so the `postedAt` range is restricted up front, plus a migration that calls `updateIndexes(Comments)`.

## Verification

- Query timings above measured directly against prod with the real selector.
- `yarn tsc` reports no errors in the changed files (the remaining errors are pre-existing in this worktree: missing `.next/types` and uninstalled `fly/` deps).
- `schema/accepted_schema.sql` regenerated via the codegen entrypoint.

## Left undone

The batching/buffering coupling is the deeper issue — any slow query batched with the post list will block it, and there's no timeout or error state, so a stalled block is indistinguishable from a loading one. Worth a separate look. Also noted while debugging: `/allPosts` never finishes rendering in a background tab until the tab is actually painted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1217664872461282) by [Unito](https://www.unito.io)
