### PR TITLE
Only reuse untitled conversations when starting a DM

### DIFF
--- a/packages/lesswrong/server/resolvers/conversationResolvers.ts
+++ b/packages/lesswrong/server/resolvers/conversationResolvers.ts
@@ -116,6 +116,11 @@ export const conversationGqlMutations = {
 
     return true;
   },
+  /**
+   * Returns the existing *untitled* conversation between exactly these participants if there
+   * is one, otherwise creates a new conversation. Titled conversations are never reused, so
+   * starting a conversation with someone you only have titled threads with gives you a fresh one.
+   */
   async initiateConversation (_: void, { participantIds, moderator }: { participantIds: string[], moderator: boolean | null }, context: ResolverContext): Promise<(Partial<DbConversation> & { [ACCESS_FILTERED]: true }) | null> {
     const { currentUser, Conversations } = context;
 
@@ -131,8 +136,9 @@ export const conversationGqlMutations = {
       participantIds: participantIds?.length
         ? { $size: participantIds.length, $all: participantIds }
         : currentUser._id,
-        ...afField,
-        ...moderatorField,
+      $or: [{ title: null }, { title: "" }],
+      ...afField,
+      ...moderatorField,
     };
 
     const existingConversation = await Conversations.findOne(selector, { sort: { moderator: 1 }});

--- a/packages/lesswrong/server/resolvers/conversationResolvers.ts
+++ b/packages/lesswrong/server/resolvers/conversationResolvers.ts
@@ -116,11 +116,6 @@ export const conversationGqlMutations = {
 
     return true;
   },
-  /**
-   * Returns the existing *untitled* conversation between exactly these participants if there
-   * is one, otherwise creates a new conversation. Titled conversations are never reused, so
-   * starting a conversation with someone you only have titled threads with gives you a fresh one.
-   */
   async initiateConversation (_: void, { participantIds, moderator }: { participantIds: string[], moderator: boolean | null }, context: ResolverContext): Promise<(Partial<DbConversation> & { [ACCESS_FILTERED]: true }) | null> {
     const { currentUser, Conversations } = context;
 


### PR DESCRIPTION
## Summary

Starting a DM with someone you already have conversations with silently redirected you into the first matching existing conversation, titled or not. This narrows that so **only an existing untitled conversation is reused**; if every conversation with those participants has a title, a fresh one is created.

This is the behaviour `useInitiateConversation`'s doc comment and the `userGroupUntitledConversations` view already describe ("first conversation between these users with no title"); the mutation just wasn't filtering on title.

Smaller alternative to #12794 (which adds a dropdown of existing conversations plus an explicit "start new" button). Either can land independently.

## Changes

- `initiateConversation` resolver: add `$or: [{title: null}, {title: ""}]` to the existing-conversation lookup (empty string included because clearing the title in the conversation-options form can save `""`). Nothing else changes: same participant-set match, same AF/moderator filters, same preference for non-moderator conversations.

## Scope note

The mutation is shared by the inbox "New conversation" dialog, the profile "Message" button, `/message/:slug` magic links, and the moderator inbox, so all of them now skip titled threads. In particular, starting a mod DM with a user who only has automated titled mod threads now creates a new (untitled) mod conversation instead of landing in one of the old ones, and subsequent attempts reuse that untitled one.

## Verification

- `yarn tsc` and eslint clean; no schema/codegen changes.
- Throwaway repl script against the dev DB (not committed): for a pair whose 110 conversations are all titled, the new lookup finds nothing (→ would create); for a pair with 43 titled + 1 untitled, it finds exactly the untitled one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1217746302636946) by [Unito](https://www.unito.io)
