### PR TITLE
Add a "~Ban for ~6 months" supermod action

### DIFF
--- a/packages/lesswrong/components/sunshineDashboard/supermod/ModerationActionButtons.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/supermod/ModerationActionButtons.tsx
@@ -118,9 +118,9 @@ const ModerationActionButtons = ({user, currentUser, addToUndoQueue, dispatch}: 
         onClick: handlePurge,
       },
       {
-        label: '1 Month Ban, 3 Month Rate Limit',
+        label: '~Ban for ~6 months',
         keystroke: 'Shift+B',
-        tooltip: "Bans this user for 1 month, blocks posting and commenting on other people's posts for 4 weeks, then allows 1 post and 3 comments per 4 weeks until week 12. Removes them from the review queue.",
+        tooltip: "Roughly a 6 month ban: bans this user for 3 months, then rate limits them to 1 post and 3 comments (on other people's posts) per 4 weeks until 6 months out. Removes them from the review queue. Asks for confirmation first, and signs a '3 month ban, 6 month rate limit' note in their moderator notes.",
         onClick: handleBanAndRateLimit,
       },
       {

--- a/packages/lesswrong/components/sunshineDashboard/supermod/ModerationActionButtons.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/supermod/ModerationActionButtons.tsx
@@ -63,6 +63,7 @@ const ModerationActionButtons = ({user, currentUser, addToUndoQueue, dispatch}: 
     handleSnoozeCustom,
     handleRemoveNeedsReview,
     handlePurge,
+    handleBanAndRateLimit,
   } = useModerationUserActions({ selectedUser: user, currentUser, addToUndoQueue });
 
   const { toggleAllPermissions } = useUserContentPermissions(user, dispatch);
@@ -115,6 +116,12 @@ const ModerationActionButtons = ({user, currentUser, addToUndoQueue, dispatch}: 
         keystroke: 'P',
         tooltip: "Deletes all of this user's posts, comments, sequences, and votes, bans them for 1000 years, and removes them from the review queue. Asks for confirmation first, and signs a 'Purge' note in their moderator notes.",
         onClick: handlePurge,
+      },
+      {
+        label: '1 Month Ban, 3 Month Rate Limit',
+        keystroke: 'Shift+B',
+        tooltip: "Bans this user for 1 month, blocks posting and commenting on other people's posts for 4 weeks, then allows 1 post and 3 comments per 4 weeks until week 12. Removes them from the review queue.",
+        onClick: handleBanAndRateLimit,
       },
       {
         label: allPermissionsDisabled ? 'Enable Permissions' : 'Disable Permissions',

--- a/packages/lesswrong/components/sunshineDashboard/supermod/ModerationUserKeyboardHandler.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/supermod/ModerationUserKeyboardHandler.tsx
@@ -210,7 +210,7 @@ const ModerationUserKeyboardHandler = ({
   }), [selectedUser, handleBan]);
 
   const banAndRateLimitCommand: CommandPaletteItem = useMemo(() => ({
-    label: '1 Month Ban, 3 Month Rate Limit',
+    label: '~Ban for ~6 months',
     keystroke: 'Shift+B',
     isDisabled: () => !selectedUser,
     execute: handleBanAndRateLimit,

--- a/packages/lesswrong/components/sunshineDashboard/supermod/ModerationUserKeyboardHandler.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/supermod/ModerationUserKeyboardHandler.tsx
@@ -63,6 +63,7 @@ const ModerationUserKeyboardHandler = ({
     handleRestrictAndNotify,
     handleRemoveNeedsReview,
     handlePurge,
+    handleBanAndRateLimit,
     updateUserWith,
     getModSignatureWithNote,
     posts,
@@ -207,6 +208,13 @@ const ModerationUserKeyboardHandler = ({
     isDisabled: () => !selectedUser,
     execute: handleBan,
   }), [selectedUser, handleBan]);
+
+  const banAndRateLimitCommand: CommandPaletteItem = useMemo(() => ({
+    label: '1 Month Ban, 3 Month Rate Limit',
+    keystroke: 'Shift+B',
+    isDisabled: () => !selectedUser,
+    execute: handleBanAndRateLimit,
+  }), [selectedUser, handleBanAndRateLimit]);
 
   const purgeCommand: CommandPaletteItem = useMemo(() => ({
     label: 'Purge',
@@ -355,8 +363,8 @@ const ModerationUserKeyboardHandler = ({
     disablePostingCommand, disableCommentingCommand, disableMessagingCommand, disableVotingCommand, toggleAllPermissionsCommand,
     nextContentOrUserCommand, previousContentOrUserCommand, nextUserOrTabCommand, previousUserOrTabCommand,
     openOrCloseDetailViewCommand, undoMostRecentActionCommand,
-    ban3moCommand,
-  ], [rerunLlmCheckCommand, approveCommand, approveCurrentOnlyCommand, snooze10Command, snoozeCustomCommand, removeCommand, ban3moCommand, purgeCommand, flagCommand, copyUserIdCommand, rejectOrUnrejectCommand, rejectLatestAndRemoveCommand, restrictAndNotifyCommand, disablePostingCommand, disableCommentingCommand, disableMessagingCommand, disableVotingCommand, toggleAllPermissionsCommand, nextContentOrUserCommand, previousContentOrUserCommand, nextUserOrTabCommand, previousUserOrTabCommand, openOrCloseDetailViewCommand, undoMostRecentActionCommand]);
+    ban3moCommand, banAndRateLimitCommand,
+  ], [rerunLlmCheckCommand, approveCommand, approveCurrentOnlyCommand, snooze10Command, snoozeCustomCommand, removeCommand, ban3moCommand, banAndRateLimitCommand, purgeCommand, flagCommand, copyUserIdCommand, rejectOrUnrejectCommand, rejectLatestAndRemoveCommand, restrictAndNotifyCommand, disablePostingCommand, disableCommentingCommand, disableMessagingCommand, disableVotingCommand, toggleAllPermissionsCommand, nextContentOrUserCommand, previousContentOrUserCommand, nextUserOrTabCommand, previousUserOrTabCommand, openOrCloseDetailViewCommand, undoMostRecentActionCommand]);
 
   useSupermodKeyboardCommands({
     commands,

--- a/packages/lesswrong/components/sunshineDashboard/supermod/useModerationUserActions.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/supermod/useModerationUserActions.tsx
@@ -43,10 +43,10 @@ const CreateUserRateLimitMutation = gql(`
   }
 `);
 
-// The hard and tapered limits overlap, so the taper ends 12 weeks out, not 16.
+// The hard and tapered limits overlap, so the taper ends 6 months out, not 9.
 function getBanAndRateLimitInputs(userId: string): CreateUserRateLimitDataInput[] {
-  const hardEndedAt = moment().add(4, 'weeks').toDate();
-  const taperedEndedAt = moment().add(12, 'weeks').toDate();
+  const hardEndedAt = moment().add(3, 'months').toDate();
+  const taperedEndedAt = moment().add(6, 'months').toDate();
   // 0 actions per interval blocks outright until endedAt, so the interval is only filler
   // for the non-null columns (the taper rows are what size the lookback window).
   return [
@@ -206,15 +206,15 @@ export function useModerationUserActions({
 
   const handleBanAndRateLimit = useCallback(() => {
     if (!selectedUser) return;
-    if (!confirm(`Ban ${selectedUser.displayName} for 1 month and rate limit them for 3 months?`)) return;
+    if (!confirm(`Ban ${selectedUser.displayName} for 3 months and rate limit them for 6 months?`)) return;
 
     const notes = selectedUser.sunshineNotes || '';
-    const newNotes = getModSignatureWithNote('1 month ban, 3 month rate limit') + notes;
+    const newNotes = getModSignatureWithNote('3 month ban, 6 month rate limit') + notes;
     const rateLimits = getBanAndRateLimitInputs(selectedUser._id);
     // Anchored to the click, like the rate limits, rather than to the end of the undo window.
-    const bannedUntil = moment().add(1, 'months').toDate();
+    const bannedUntil = moment().add(3, 'months').toDate();
 
-    handleAction('Banned 1mo & rate limited 3mo', async () => {
+    handleAction('Banned 3mo & rate limited 6mo', async () => {
       await Promise.all(rateLimits.map(data => createUserRateLimit({ variables: { data } })));
       await updateUser({
         variables: {

--- a/packages/lesswrong/components/sunshineDashboard/supermod/useModerationUserActions.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/supermod/useModerationUserActions.tsx
@@ -33,6 +33,30 @@ const ApproveCurrentContentOnlyMutation = gql(`
   }
 `);
 
+const CreateUserRateLimitMutation = gql(`
+  mutation createUserRateLimitModerationUserActions($data: CreateUserRateLimitDataInput!) {
+    createUserRateLimit(data: $data) {
+      data {
+        _id
+      }
+    }
+  }
+`);
+
+// The hard and tapered limits overlap, so the taper ends 12 weeks out, not 16.
+function getBanAndRateLimitInputs(userId: string): CreateUserRateLimitDataInput[] {
+  const hardEndedAt = moment().add(4, 'weeks').toDate();
+  const taperedEndedAt = moment().add(12, 'weeks').toDate();
+  // 0 actions per interval blocks outright until endedAt, so the interval is only filler
+  // for the non-null columns (the taper rows are what size the lookback window).
+  return [
+    { userId, type: 'allPosts', intervalUnit: 'weeks', intervalLength: 1, actionsPerInterval: 0, endedAt: hardEndedAt },
+    { userId, type: 'allComments', intervalUnit: 'weeks', intervalLength: 1, actionsPerInterval: 0, endedAt: hardEndedAt },
+    { userId, type: 'allPosts', intervalUnit: 'weeks', intervalLength: 4, actionsPerInterval: 1, endedAt: taperedEndedAt },
+    { userId, type: 'allComments', intervalUnit: 'weeks', intervalLength: 4, actionsPerInterval: 3, endedAt: taperedEndedAt },
+  ];
+}
+
 function getMostRecentUnapprovedContent(posts: SunshinePostsList[], comments: CommentsListWithParentMetadata[]) {
   const allContent = [
     ...(posts || []).map(p => ({ _id: p._id, postedAt: p.postedAt, rejected: p.rejected, authorIsUnreviewed: p.authorIsUnreviewed, collectionName: 'Posts' as const })),
@@ -69,6 +93,7 @@ export function useModerationUserActions({
   const [updateUser] = useMutation(SunshineUsersListUpdateMutation);
   const [rejectContentAndRemoveFromQueue] = useMutation(RejectContentAndRemoveFromQueueMutation);
   const [approveCurrentContentOnly] = useMutation(ApproveCurrentContentOnlyMutation);
+  const [createUserRateLimit] = useMutation(CreateUserRateLimitMutation);
 
   const { posts, comments } = useModeratedUserContents(selectedUser?._id ?? '', 20);
 
@@ -179,6 +204,34 @@ export function useModerationUserActions({
     }, 'Purged');
   }, [selectedUser, currentUser, getModSignatureWithNote, updateUserWith]);
 
+  const handleBanAndRateLimit = useCallback(() => {
+    if (!selectedUser) return;
+    if (!confirm(`Ban ${selectedUser.displayName} for 1 month and rate limit them for 3 months?`)) return;
+
+    const notes = selectedUser.sunshineNotes || '';
+    const newNotes = getModSignatureWithNote('1 month ban, 3 month rate limit') + notes;
+    const rateLimits = getBanAndRateLimitInputs(selectedUser._id);
+    // Anchored to the click, like the rate limits, rather than to the end of the undo window.
+    const bannedUntil = moment().add(1, 'months').toDate();
+
+    handleAction('Banned 1mo & rate limited 3mo', async () => {
+      await Promise.all(rateLimits.map(data => createUserRateLimit({ variables: { data } })));
+      await updateUser({
+        variables: {
+          selector: { _id: selectedUser._id },
+          data: {
+            sunshineFlagged: false,
+            reviewedByUserId: currentUser._id,
+            needsReview: false,
+            reviewedAt: new Date(),
+            banned: bannedUntil,
+            sunshineNotes: newNotes,
+          },
+        },
+      });
+    });
+  }, [selectedUser, currentUser, getModSignatureWithNote, handleAction, createUserRateLimit, updateUser]);
+
   const handleRestrictAndNotify = useCallback(() => {
     if (!selectedUser) return;
     
@@ -268,6 +321,7 @@ export function useModerationUserActions({
     handleRestrictAndNotify,
     handleRemoveNeedsReview,
     handlePurge,
+    handleBanAndRateLimit,
     updateUserWith,
     getModSignatureWithNote,
     posts,

--- a/packages/lesswrong/lib/generated/gql-codegen/gql.ts
+++ b/packages/lesswrong/lib/generated/gql-codegen/gql.ts
@@ -533,6 +533,7 @@ type Documents = {
     "\n  mutation updateUserModerationKeyboard($selector: SelectorInput!, $data: UpdateUserDataInput!) {\n    updateUser(selector: $selector, data: $data) {\n      data {\n        ...SunshineUsersList\n      }\n    }\n  }\n": typeof types.updateUserModerationKeyboardDocument,
     "\n  mutation rejectContentAndRemoveFromQueueModerationKeyboard($userId: String!, $documentId: String!, $collectionName: ContentCollectionName!, $rejectedReason: String!) {\n    rejectContentAndRemoveUserFromQueue(userId: $userId, documentId: $documentId, collectionName: $collectionName, rejectedReason: $rejectedReason)\n  }\n": typeof types.rejectContentAndRemoveFromQueueModerationKeyboardDocument,
     "\n  mutation approveCurrentContentOnlyModerationKeyboard($userId: String!) {\n    approveUserCurrentContentOnly(userId: $userId)\n  }\n": typeof types.approveCurrentContentOnlyModerationKeyboardDocument,
+    "\n  mutation createUserRateLimitModerationUserActions($data: CreateUserRateLimitDataInput!) {\n    createUserRateLimit(data: $data) {\n      data {\n        _id\n      }\n    }\n  }\n": typeof types.createUserRateLimitModerationUserActionsDocument,
     "\n  mutation updatePostPostReviewActions($selector: SelectorInput!, $data: UpdatePostDataInput!) {\n    updatePost(selector: $selector, data: $data) {\n      data {\n        ...PostsList\n      }\n    }\n  }\n": typeof types.updatePostPostReviewActionsDocument,
     "\n  mutation createModeratorActionPostReviewActions($data: CreateModeratorActionDataInput!) {\n    createModeratorAction(data: $data) {\n      data {\n        _id\n      }\n    }\n  }\n": typeof types.createModeratorActionPostReviewActionsDocument,
     "\n  mutation RerunLlmCheckHook($documentId: String!, $collectionName: ContentCollectionName!) {\n    rerunLlmCheck(documentId: $documentId, collectionName: $collectionName) {\n      ...AutomatedContentEvaluationsFragment\n    }\n  }\n": typeof types.RerunLlmCheckHookDocument,
@@ -1420,6 +1421,7 @@ const documents: Documents = {
     "\n  mutation updateUserModerationKeyboard($selector: SelectorInput!, $data: UpdateUserDataInput!) {\n    updateUser(selector: $selector, data: $data) {\n      data {\n        ...SunshineUsersList\n      }\n    }\n  }\n": types.updateUserModerationKeyboardDocument,
     "\n  mutation rejectContentAndRemoveFromQueueModerationKeyboard($userId: String!, $documentId: String!, $collectionName: ContentCollectionName!, $rejectedReason: String!) {\n    rejectContentAndRemoveUserFromQueue(userId: $userId, documentId: $documentId, collectionName: $collectionName, rejectedReason: $rejectedReason)\n  }\n": types.rejectContentAndRemoveFromQueueModerationKeyboardDocument,
     "\n  mutation approveCurrentContentOnlyModerationKeyboard($userId: String!) {\n    approveUserCurrentContentOnly(userId: $userId)\n  }\n": types.approveCurrentContentOnlyModerationKeyboardDocument,
+    "\n  mutation createUserRateLimitModerationUserActions($data: CreateUserRateLimitDataInput!) {\n    createUserRateLimit(data: $data) {\n      data {\n        _id\n      }\n    }\n  }\n": types.createUserRateLimitModerationUserActionsDocument,
     "\n  mutation updatePostPostReviewActions($selector: SelectorInput!, $data: UpdatePostDataInput!) {\n    updatePost(selector: $selector, data: $data) {\n      data {\n        ...PostsList\n      }\n    }\n  }\n": types.updatePostPostReviewActionsDocument,
     "\n  mutation createModeratorActionPostReviewActions($data: CreateModeratorActionDataInput!) {\n    createModeratorAction(data: $data) {\n      data {\n        _id\n      }\n    }\n  }\n": types.createModeratorActionPostReviewActionsDocument,
     "\n  mutation RerunLlmCheckHook($documentId: String!, $collectionName: ContentCollectionName!) {\n    rerunLlmCheck(documentId: $documentId, collectionName: $collectionName) {\n      ...AutomatedContentEvaluationsFragment\n    }\n  }\n": types.RerunLlmCheckHookDocument,
@@ -3878,6 +3880,10 @@ export function gql(source: "\n  mutation rejectContentAndRemoveFromQueueModerat
  * The gql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */
 export function gql(source: "\n  mutation approveCurrentContentOnlyModerationKeyboard($userId: String!) {\n    approveUserCurrentContentOnly(userId: $userId)\n  }\n"): (typeof documents)["\n  mutation approveCurrentContentOnlyModerationKeyboard($userId: String!) {\n    approveUserCurrentContentOnly(userId: $userId)\n  }\n"];
+/**
+ * The gql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ */
+export function gql(source: "\n  mutation createUserRateLimitModerationUserActions($data: CreateUserRateLimitDataInput!) {\n    createUserRateLimit(data: $data) {\n      data {\n        _id\n      }\n    }\n  }\n"): (typeof documents)["\n  mutation createUserRateLimitModerationUserActions($data: CreateUserRateLimitDataInput!) {\n    createUserRateLimit(data: $data) {\n      data {\n        _id\n      }\n    }\n  }\n"];
 /**
  * The gql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */

--- a/packages/lesswrong/lib/generated/gql-codegen/graphql.ts
+++ b/packages/lesswrong/lib/generated/gql-codegen/graphql.ts
@@ -19675,6 +19675,13 @@ export type approveCurrentContentOnlyModerationKeyboardMutationVariables = Exact
 
 export type approveCurrentContentOnlyModerationKeyboardMutation = { __typename?: 'Mutation', approveUserCurrentContentOnly: boolean };
 
+export type createUserRateLimitModerationUserActionsMutationVariables = Exact<{
+  data: CreateUserRateLimitDataInput;
+}>;
+
+
+export type createUserRateLimitModerationUserActionsMutation = { __typename?: 'Mutation', createUserRateLimit: { __typename?: 'UserRateLimitOutput', data: { __typename?: 'UserRateLimit', _id: string } | null } | null };
+
 export type updatePostPostReviewActionsMutationVariables = Exact<{
   selector: SelectorInput;
   data: UpdatePostDataInput;
@@ -23418,6 +23425,7 @@ export const updateModeratorActionSupermodDocument = _o1(_1,[_o11(_987,_988,_o3(
 export const updateUserModerationKeyboardDocument = _o1(_1,[_o11(_987,_988,_o3(_3,"updateUserModerationKeyboard"),_1196,_1746),_61,_622,_663,_682]) as unknown as DocumentNode<updateUserModerationKeyboardMutation, updateUserModerationKeyboardMutationVariables>;
 export const rejectContentAndRemoveFromQueueModerationKeyboardDocument = _o1(_1,[_o11(_987,_988,_o3(_3,"rejectContentAndRemoveFromQueueModerationKeyboard"),[_1077,_998,_1747,_1798],_o5(_7,[_o10(_8,_1801,[_1111,_1093,_1092,_1802])]))]) as unknown as DocumentNode<rejectContentAndRemoveFromQueueModerationKeyboardMutation, rejectContentAndRemoveFromQueueModerationKeyboardMutationVariables>;
 export const approveCurrentContentOnlyModerationKeyboardDocument = _o1(_1,[_o11(_987,_988,_o3(_3,"approveCurrentContentOnlyModerationKeyboard"),_1641,_o5(_7,[_o10(_8,_o3(_3,"approveUserCurrentContentOnly"),_1803)]))]) as unknown as DocumentNode<approveCurrentContentOnlyModerationKeyboardMutation, approveCurrentContentOnlyModerationKeyboardMutationVariables>;
+export const createUserRateLimitModerationUserActionsDocument = _o1(_1,[_o11(_987,_988,_o3(_3,"createUserRateLimitModerationUserActions"),_1777,_o5(_7,[_o7(_8,_1778,_1146,_1766)]))]) as unknown as DocumentNode<createUserRateLimitModerationUserActionsMutation, createUserRateLimitModerationUserActionsMutationVariables>;
 export const updatePostPostReviewActionsDocument = _o1(_1,[_o11(_987,_988,_o3(_3,"updatePostPostReviewActions"),_1147,_1149),_23,_127,_61,_136,_146,_158,_184,_192,_198]) as unknown as DocumentNode<updatePostPostReviewActionsMutation, updatePostPostReviewActionsMutationVariables>;
 export const createModeratorActionPostReviewActionsDocument = _o1(_1,[_o11(_987,_988,_o3(_3,"createModeratorActionPostReviewActions"),_1754,_1767)]) as unknown as DocumentNode<createModeratorActionPostReviewActionsMutation, createModeratorActionPostReviewActionsMutationVariables>;
 export const RerunLlmCheckHookDocument = _o1(_1,[_o11(_987,_988,_o3(_3,"RerunLlmCheckHook"),_1748,_o5(_7,[_o7(_8,_o3(_3,"rerunLlmCheck"),_1749,_338)])),_335]) as unknown as DocumentNode<RerunLlmCheckHookMutation, RerunLlmCheckHookMutationVariables>;

--- a/packages/lesswrong/lib/generated/graphqlCodegenTypes.d.ts
+++ b/packages/lesswrong/lib/generated/graphqlCodegenTypes.d.ts
@@ -21334,6 +21334,20 @@ type approveCurrentContentOnlyModerationKeyboardMutationVariables = Exact<{
 
 type approveCurrentContentOnlyModerationKeyboardMutation = approveCurrentContentOnlyModerationKeyboardMutation_Mutation;
 
+type createUserRateLimitModerationUserActionsMutation_createUserRateLimit_UserRateLimitOutput_data_UserRateLimit = { __typename?: 'UserRateLimit', _id: string };
+
+type createUserRateLimitModerationUserActionsMutation_createUserRateLimit_UserRateLimitOutput = { __typename?: 'UserRateLimitOutput', data: createUserRateLimitModerationUserActionsMutation_createUserRateLimit_UserRateLimitOutput_data_UserRateLimit | null };
+
+type createUserRateLimitModerationUserActionsMutation_Mutation = { __typename?: 'Mutation', createUserRateLimit: createUserRateLimitModerationUserActionsMutation_createUserRateLimit_UserRateLimitOutput | null };
+
+
+type createUserRateLimitModerationUserActionsMutationVariables = Exact<{
+  data: CreateUserRateLimitDataInput;
+}>;
+
+
+type createUserRateLimitModerationUserActionsMutation = createUserRateLimitModerationUserActionsMutation_Mutation;
+
 type updatePostPostReviewActionsMutation_updatePost_PostOutput_data_Post = (
   { __typename?: 'Post' }
   & PostsList


### PR DESCRIPTION
Adds a button to the supermod **Moderator Actions** sidebar, `~Ban for ~6 months` (`Shift+B`, also in the command palette). After a confirmation prompt it:

- bans the user for 3 months
- creates four `UserRateLimits`:
  - 0 posts per week and 0 comments per week, until month 3
  - 1 post per 4 weeks and 3 comments per 4 weeks, until month 6
- signs a `3 month ban, 6 month rate limit` note in the moderator notes
- removes the user from the review queue, via the undo queue (like Purge), so it can be taken back

The four rows overlap rather than running in sequence — manual limits of a type all apply at once and the strictest wins, so the hard block governs until it expires at month 3 and the taper carries through to month 6. Rows with `actionsPerInterval: 0` are already handled: `getManualRateLimitInfo` short-circuits them to "blocked until `endedAt`".

Note that manual comment rate limits are skipped on the user's own posts (`getCommentRateLimitInfos` returns `[]` when `userIsAuthor`), so the taper only constrains commenting on other people's posts. The tooltip says so.

### Screenshots

_Cropped to the sidebar panel; the dev database holds real user data._

SCREENSHOT_PLACEHOLDER

🤖 Generated with [Claude Code](https://claude.com/claude-code)