### PR TITLE
Scroll to the comment when re-clicking a notification for the page you're on

### DIFF
--- a/packages/lesswrong/components/notifications/NotificationsItem.tsx
+++ b/packages/lesswrong/components/notifications/NotificationsItem.tsx
@@ -1,5 +1,4 @@
 import { registerComponent } from '../../lib/vulcan-lib/components';
-import { getSiteUrl } from '../../lib/vulcan-lib/utils';
 import classNames from 'classnames';
 import React, { FC, ReactNode, useCallback, useState } from 'react';
 import { Card } from "@/components/widgets/Paper";
@@ -8,7 +7,6 @@ import withErrorBoundary from '../common/withErrorBoundary';
 import { parseRouteWithErrors } from '@/lib/routeChecks/parseRouteWithErrors';
 import { useTracking } from '../../lib/analyticsEvents';
 import { useNavigate } from '../../lib/routeUtil';
-import { getUrlClass } from '@/server/utils/getUrlClass';
 import LWTooltip from "../common/LWTooltip";
 import PostsTooltip from "../posts/PostsPreviewTooltip/PostsTooltip";
 import ConversationPreview from "../messaging/ConversationPreview";
@@ -16,6 +14,7 @@ import PostNominatedNotification from "../review/PostNominatedNotification";
 import TagRelNotificationItem from "./TagRelNotificationItem";
 import { onsiteHoverViewComponents } from '@/lib/notificationTypeComponents';
 import { getNotificationIconByNotificationName } from './notificationIcons';
+import { scrollToNotificationTarget } from './notificationScroll';
 import { defineStyles } from '@/components/hooks/defineStyles';
 import { useStyles } from '@/components/hooks/useStyles';
 
@@ -235,15 +234,8 @@ const NotificationsItem = ({notification, lastNotificationsCheck}: {
           navigate(notificationLink)
 
           setClicked(true);
-          
-          // we also check whether it's a relative link, and if so, scroll to the item
-          const UrlClass = getUrlClass()
-          const url = new UrlClass(notificationLink, getSiteUrl())
-          const hash = url.hash
-          if (hash) {
-            const element = document.getElementById(hash.substr(1))
-            if (element) element.scrollIntoView({behavior: "smooth"});
-          }
+
+          scrollToNotificationTarget(notificationLink);
         }}
       >
         {notification.type ? getNotificationIconByNotificationName(notification.type) : null}

--- a/packages/lesswrong/components/notifications/NotificationsItem.tsx
+++ b/packages/lesswrong/components/notifications/NotificationsItem.tsx
@@ -231,11 +231,10 @@ const NotificationsItem = ({notification, lastNotificationsCheck}: {
           
           // Do manual navigation since we also want to do a bunch of other stuff
           ev.preventDefault()
+          scrollToNotificationTarget(notificationLink);
           navigate(notificationLink)
 
           setClicked(true);
-
-          scrollToNotificationTarget(notificationLink);
         }}
       >
         {notification.type ? getNotificationIconByNotificationName(notification.type) : null}

--- a/packages/lesswrong/components/notifications/NotificationsPageItem.tsx
+++ b/packages/lesswrong/components/notifications/NotificationsPageItem.tsx
@@ -315,10 +315,9 @@ const NotificationsPageItem = ({notification, lastNotificationsCheck}: {
             });
 
             ev.preventDefault();
+            scrollToNotificationTarget(notificationLink);
             navigate(notificationLink);
             setClicked(true);
-
-            scrollToNotificationTarget(notificationLink);
           }}
         >
           <span className={classes.iconWrapper}>

--- a/packages/lesswrong/components/notifications/NotificationsPageItem.tsx
+++ b/packages/lesswrong/components/notifications/NotificationsPageItem.tsx
@@ -1,4 +1,3 @@
-import { getSiteUrl } from '../../lib/vulcan-lib/utils';
 import classNames from 'classnames';
 import React, { FC, ReactNode, useCallback, useState } from 'react';
 import { Card } from "@/components/widgets/Paper";
@@ -6,12 +5,12 @@ import { getNotificationTypeByName, isNotificationTypeName } from '../../lib/not
 import { parseRouteWithErrors } from '@/lib/routeChecks/parseRouteWithErrors';
 import { useTracking } from '../../lib/analyticsEvents';
 import { useNavigate } from '../../lib/routeUtil';
-import { getUrlClass } from '@/server/utils/getUrlClass';
 import LWTooltip from "../common/LWTooltip";
 import PostsTooltip from "../posts/PostsPreviewTooltip/PostsTooltip";
 import ConversationPreview from "../messaging/ConversationPreview";
 import PostNominatedNotification from "../review/PostNominatedNotification";
 import TagRelNotificationItem from "./TagRelNotificationItem";
+import { scrollToNotificationTarget } from './notificationScroll';
 import { onsiteHoverViewComponents } from '@/lib/notificationTypeComponents';
 import FormatDate from '../common/FormatDate';
 import { defineStyles } from '@/components/hooks/defineStyles';
@@ -319,13 +318,7 @@ const NotificationsPageItem = ({notification, lastNotificationsCheck}: {
             navigate(notificationLink);
             setClicked(true);
 
-            const UrlClass = getUrlClass();
-            const url = new UrlClass(notificationLink, getSiteUrl());
-            const hash = url.hash;
-            if (hash) {
-              const element = document.getElementById(hash.substring(1));
-              if (element) element.scrollIntoView({ behavior: "smooth" });
-            }
+            scrollToNotificationTarget(notificationLink);
           }}
         >
           <span className={classes.iconWrapper}>

--- a/packages/lesswrong/components/notifications/notificationScroll.ts
+++ b/packages/lesswrong/components/notifications/notificationScroll.ts
@@ -1,27 +1,21 @@
 import { getSiteUrl } from '../../lib/vulcan-lib/utils';
-import { getUrlClass } from '@/server/utils/getUrlClass';
 import { scrollFocusOnElement } from '@/lib/scrollUtils';
 
-/**
- * Scroll to the comment a notification points at, in the cases where following
- * the link doesn't do it by itself: clicking a notification for the page you're
- * already on is a no-op navigation, and a `#hash` link doesn't scroll on its own
- * either. On a real navigation to a different page, the page-load scripts in
- * `scrollUtils` handle the scrolling instead.
- */
+// Call before navigating. Handles the cases where navigating won't scroll by itself:
+// a #hash link, or re-clicking a notification for the page you're already on
+// (navigate() no-ops when the URL is unchanged, so nothing else would react).
 export function scrollToNotificationTarget(notificationLink: string) {
-  const UrlClass = getUrlClass();
-  const url = new UrlClass(notificationLink, getSiteUrl());
+  const url = new URL(notificationLink, getSiteUrl());
   const targetId = url.hash ? url.hash.substring(1) : url.searchParams.get("commentId");
   if (!targetId) return;
 
-  const currentTargetId = window.location.hash
-    ? window.location.hash.substring(1)
-    : new UrlClass(window.location.href).searchParams.get("commentId");
-  const alreadyOnTargetLocation =
-    url.pathname === window.location.pathname && currentTargetId === targetId;
+  const currentLocation = new URL(window.location.href);
+  const wasAlreadyOnTarget = url.pathname === currentLocation.pathname && (
+    currentLocation.hash.substring(1) === targetId ||
+    currentLocation.searchParams.get("commentId") === targetId
+  );
 
-  if (url.hash || alreadyOnTargetLocation) {
+  if (url.hash || wasAlreadyOnTarget) {
     scrollFocusOnElement({ id: targetId, options: { behavior: "smooth" } });
   }
 }

--- a/packages/lesswrong/components/notifications/notificationScroll.ts
+++ b/packages/lesswrong/components/notifications/notificationScroll.ts
@@ -1,0 +1,27 @@
+import { getSiteUrl } from '../../lib/vulcan-lib/utils';
+import { getUrlClass } from '@/server/utils/getUrlClass';
+import { scrollFocusOnElement } from '@/lib/scrollUtils';
+
+/**
+ * Scroll to the comment a notification points at, in the cases where following
+ * the link doesn't do it by itself: clicking a notification for the page you're
+ * already on is a no-op navigation, and a `#hash` link doesn't scroll on its own
+ * either. On a real navigation to a different page, the page-load scripts in
+ * `scrollUtils` handle the scrolling instead.
+ */
+export function scrollToNotificationTarget(notificationLink: string) {
+  const UrlClass = getUrlClass();
+  const url = new UrlClass(notificationLink, getSiteUrl());
+  const targetId = url.hash ? url.hash.substring(1) : url.searchParams.get("commentId");
+  if (!targetId) return;
+
+  const currentTargetId = window.location.hash
+    ? window.location.hash.substring(1)
+    : new UrlClass(window.location.href).searchParams.get("commentId");
+  const alreadyOnTargetLocation =
+    url.pathname === window.location.pathname && currentTargetId === targetId;
+
+  if (url.hash || alreadyOnTargetLocation) {
+    scrollFocusOnElement({ id: targetId, options: { behavior: "smooth" } });
+  }
+}


### PR DESCRIPTION
## Problem

If you're already on `/posts/:id/:slug?commentId=X` (arrived via a notification), scroll far down the page, then open your notifications and click that same notification again, nothing happens — the page doesn't move to the comment.

Comment notification links are permalinks of the form `...?commentId=X`, with no `#hash`. Navigating to the URL you're already on is a no-op, so none of the usual scroll machinery re-fires:

- the server-injected `preloadScrollToCommentScript` only runs on a fresh page load;
- `CommentsNode`'s scroll effects key off `linkedCommentId` / `scrollToCommentId`, which don't change.

Both notification click handlers already had a scroll fallback, but it only fired for `#hash` links.

## Fix

Extract the fallback into a shared `scrollToNotificationTarget` helper used by both the drawer item and the `/notifications` page item. It scrolls when the link has a hash (as before) **or** when you're already on the same pathname with the same comment already targeted — i.e. exactly the no-op-navigation case.

It uses `scrollFocusOnElement` from `lib/scrollUtils`, which applies the standard comment offset, no-ops safely if the element isn't in the DOM, and re-scrolls through the layout shift that follows until the user interacts.

Deliberately narrow: on a real cross-page navigation nothing new fires, so this can't race `CommentsNode`'s `window.scrollTo({top: 0})` effect that runs under LW's default `commentPermalinkStyle: 'top'`.

## Testing

`yarn tsc` clean for the touched files. Not exercised in a running app — verifying it needs a logged-in account with real notifications, so worth a manual pass on the preview: scroll deep into a post you reached via a notification, reopen the notifications drawer, click the same notification. Also worth spot-checking that clicking a notification for a *different* comment on the same post still behaves as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1217749409910813) by [Unito](https://www.unito.io)
