### PR TITLE
Fix comment-on-selection button doing nothing when pressed

### DIFF
--- a/packages/lesswrong/components/comments/CommentOnSelection.tsx
+++ b/packages/lesswrong/components/comments/CommentOnSelection.tsx
@@ -12,16 +12,17 @@ const ReplyCommentDialog = dynamic(() => import("./ReplyCommentDialog"), { ssr: 
 const selectedTextToolbarStyles = defineStyles("CommentOnSelectionContentWrapper", (theme: ThemeType) => ({
   toolbarWrapper: {
     position: "absolute",
+    zIndex: theme.zIndexes.lwPopper,
   },
   toolbar: {
     display: "flex",
     borderRadius: 8,
     color: theme.palette.icon.dim,
-    zIndex: theme.zIndexes.lwPopper,
     padding: 8,
     paddingBottom: 6,
     cursor: "pointer",
-    
+    userSelect: "none",
+
     "&:hover": {
       background: theme.palette.panelBackground.darken08,
     },
@@ -33,9 +34,13 @@ const selectedTextToolbarStyles = defineStyles("CommentOnSelectionContentWrapper
   },
 }));
 
+type CommentOnSelectionHandler = (html: string) => void;
+
+const commentOnSelectionHandlers = new WeakMap<HTMLElement, CommentOnSelectionHandler>();
+
 type SelectedTextToolbarState =
     {open: false}
-  | {open: true, x: number, y: number}
+  | {open: true, x: number, y: number, wrapper: HTMLElement, ranges: Range[]}
 
 /**
  * CommentOnSelectionPageWrapper: Wrapper around the entire page (used in
@@ -48,7 +53,7 @@ type SelectedTextToolbarState =
  * opens a floating comment editor prepopulated with the blockquote.)
  *
  * The CommentOnSelectionWrapper is found by walking up the DOM until we find
- * an HTML element with onClickComment monkeypatched onto it. Placement of the
+ * an HTML element registered in commentOnSelectionHandlers. Placement of the
  * toolbar button is done with coordinate-math.
  *
  * Positioning might be brittle if the element that supports selection is nested
@@ -62,80 +67,80 @@ export const CommentOnSelectionPageWrapper = ({children}: {
   children: React.ReactNode
 }) => {
   const [toolbarState,setToolbarState] = useState<SelectedTextToolbarState>({open: false});
-  
+
   const closeToolbar = useCallback(() => {
     // When changing toolbarState, do it in a way where if this is {open: false}, we reuse the previous value to avoid triggering a rerender.
     setToolbarState((prevState) => prevState.open ? {open: false} : prevState);
   }, []);
- 
+
   useEffect(() => {
     const selectionChangedHandler = () => {
       const selection = document.getSelection();
       const selectionText = selection+"";
-      
+
       // Is this selection non-empty?
       if (!selection || !selectionText?.length) {
         closeToolbar();
         return;
       }
-      
+
       // Determine whether this selection is fully wrapped in a single CommentOnSelectionContentWrapper
       let commonWrapper: HTMLElement|null = null;
       let hasCommonWrapper = true;
+      const ranges: Range[] = [];
       for (let i=0; i<selection.rangeCount; i++) {
         const range = selection.getRangeAt(i);
-        const container = range.commonAncestorContainer;
-        const wrapper = findAncestorElementWithCommentOnSelectionWrapper(container);
+        ranges.push(range.cloneRange());
+        const wrapper = findAncestorElementWithCommentOnSelectionWrapper(range.commonAncestorContainer);
         if (commonWrapper) {
-          if (container !== commonWrapper) {
+          if (wrapper !== commonWrapper) {
             hasCommonWrapper = false;
           }
         } else {
           commonWrapper = wrapper;
         }
       }
-      
+
       if (!commonWrapper || !hasCommonWrapper) {
         closeToolbar();
         return;
       }
-      
+
       // Get the bounding box of the selection
-      const selectionBoundingRect = selection.getRangeAt(0).getBoundingClientRect();
+      const selectionBoundingRect = ranges[0].getBoundingClientRect();
       const wrapperBoundingRect = commonWrapper.getBoundingClientRect();
-      
+
       // Place the toolbar
       const x = window.scrollX + Math.max(
         selectionBoundingRect.x + selectionBoundingRect.width,
         wrapperBoundingRect.x + wrapperBoundingRect.width);
       const y = selectionBoundingRect.y + window.scrollY;
-      setToolbarState({open: true, x,y});
+      setToolbarState({open: true, x, y, wrapper: commonWrapper, ranges});
     };
     document.addEventListener('selectionchange', selectionChangedHandler);
-    
+
     return () => {
       document.removeEventListener('selectionchange', selectionChangedHandler);
     };
   }, [closeToolbar]);
-  
+
   useOnNavigate(() => {
     closeToolbar();
   });
-  
+
   const onClickComment = () => {
-    const firstSelectedNode = document.getSelection()?.anchorNode;
-    if (!firstSelectedNode) {
+    if (!toolbarState.open) {
       return;
     }
-    const contentWrapper = findAncestorElementWithCommentOnSelectionWrapper(firstSelectedNode);
-    if (!contentWrapper) {
+    const handler = commentOnSelectionHandlers.get(toolbarState.wrapper);
+    if (!handler) {
       return;
     }
-    const selectionHtml = selectionToBlockquoteHTML(document.getSelection());
     // This HTML is XSS-safe because it's copied from somewhere that was already in the page as HTML, and is copied in a way that is syntax-aware throughout.
-    (contentWrapper as any).onClickComment(selectionHtml);
+    handler(rangesToBlockquoteHTML(toolbarState.ranges));
+    closeToolbar();
   }
-  
+
   return <>
     {children}
     {toolbarState.open && <SelectedTextToolbar
@@ -150,12 +155,16 @@ export const CommentOnSelectionPageWrapper = ({children}: {
  * a post. Consists of just a comment button, which opens a floating comment
  * editor. Created as a dialog by CommentOnSelectionPageWrapper.
  *
- * onClickComment: Called when the comment button is clicked
+ * onClickComment: Called when the comment button is pressed. This fires on
+ *   mousedown (with the default prevented) rather than on click, because
+ *   pressing the mouse outside a text selection collapses the selection in
+ *   some browsers, and the resulting selectionchange would unmount this
+ *   toolbar before a click event could be delivered to it.
  * x, y: In the page coordinate system, ie, relative to the top-left corner when
  *   the page is scrolled to the top.
  */
 const SelectedTextToolbar = ({onClickComment, x, y}: {
-  onClickComment: (ev: React.MouseEvent) => void,
+  onClickComment: () => void,
   x: number, y: number,
 }) => {
   const classes = useStyles(selectedTextToolbarStyles);
@@ -163,12 +172,17 @@ const SelectedTextToolbar = ({onClickComment, x, y}: {
 
   return <div className={classes.toolbarWrapper} style={{left: x, top: y}}>
     <LWTooltip inlineBlock={false} title={<div><p>Click to comment on the selected text</p></div>}>
-      <div className={classes.toolbar}>
+      <div
+        className={classes.toolbar}
+        onMouseDown={(ev: React.MouseEvent) => {
+          ev.preventDefault();
+          ev.stopPropagation();
+          captureEvent("commentOnSelectionClicked");
+          onClickComment();
+        }}
+      >
         <AnalyticsContext pageElementContext="selectedTextToolbar">
-          <CommentIcon onClick={(ev: React.MouseEvent) => {
-            captureEvent("commentOnSelectionClicked");
-            onClickComment(ev);
-          }}/>
+          <CommentIcon/>
         </AnalyticsContext>
       </div>
     </LWTooltip>
@@ -190,7 +204,7 @@ export const CommentOnSelectionContentWrapper = ({post, children}: {
 }) => {
   const { openDialog } = useDialog();
   const wrapperDivRef = useRef<HTMLDivElement|null>(null);
-  
+
   const onClickComment = useCallback((html: string) => {
     openDialog({
       name: "ReplyCommentDialog",
@@ -205,16 +219,16 @@ export const CommentOnSelectionContentWrapper = ({post, children}: {
   }, [openDialog, post]);
 
   useEffect(() => {
-    if (wrapperDivRef.current) {
-      let modifiedDiv = (wrapperDivRef.current as any)
-      modifiedDiv.onClickComment = onClickComment;
-      
+    const wrapperDiv = wrapperDivRef.current;
+    if (wrapperDiv) {
+      commentOnSelectionHandlers.set(wrapperDiv, onClickComment);
+
       return () => {
-        modifiedDiv.onClickComment = null;
+        commentOnSelectionHandlers.delete(wrapperDiv);
       }
     }
   }, [onClickComment]);
-  
+
   return <div className="commentOnSelection" ref={wrapperDivRef}>
     {children}
   </div>
@@ -230,7 +244,7 @@ export const CommentOnSelectionContentWrapper = ({post, children}: {
 function nearestAncestorElementWith(start: Node|null, fn: (node: HTMLElement) => boolean): HTMLElement|null {
   if (!start)
     return null;
-  
+
   let pos: HTMLElement|null = start.parentElement;
   while(pos && !fn(pos)) {
     pos = pos.parentElement;
@@ -240,35 +254,34 @@ function nearestAncestorElementWith(start: Node|null, fn: (node: HTMLElement) =>
 
 /**
  * Starting from an HTML node, climb the tree until one is found which
- * corresponds to a CommentOnSelectionContentWrapper component, ie, one with an
- * onClickComment function attached.
+ * corresponds to a CommentOnSelectionContentWrapper component, ie, one with a
+ * registered comment handler.
  *
  * Client-side only.
  */
 function findAncestorElementWithCommentOnSelectionWrapper(start: Node): HTMLElement|null {
   return nearestAncestorElementWith(
     start,
-    n=>!!((n as any).onClickComment)
+    n => commentOnSelectionHandlers.has(n)
   );
 }
 
 /**
- * selectionToBlockquoteHTML: Given a selection (this is a browser API, returned
- * from document.getSelection()), return the selected content, wrapped in a
- * blockquote. The resulting HTML is XSS-safe because it was already present in
- * the document as HTML.
+ * rangesToBlockquoteHTML: Given the ranges of a selection (cloned from
+ * document.getSelection() at the time the toolbar was shown), return the
+ * selected content, wrapped in a blockquote. The resulting HTML is XSS-safe
+ * because it was already present in the document as HTML.
  *
  * Client-side only.
  */
-function selectionToBlockquoteHTML(selection: Selection|null): string {
-  if (!selection || !selection.rangeCount)
+function rangesToBlockquoteHTML(ranges: Range[]): string {
+  if (!ranges.length)
     return "";
-  
-  var container = document.createElement("div");
-  for (let i=0; i<selection.rangeCount; i++) {
-    container.appendChild(selection.getRangeAt(i).cloneContents());
+
+  const container = document.createElement("div");
+  for (const range of ranges) {
+    container.appendChild(range.cloneContents());
   }
   const selectedHTML = container.innerHTML;
   return `<blockquote>${selectedHTML}</blockquote><p></p>`;
 }
-

--- a/packages/lesswrong/components/comments/CommentOnSelection.tsx
+++ b/packages/lesswrong/components/comments/CommentOnSelection.tsx
@@ -27,7 +27,6 @@ const selectedTextToolbarStyles = defineStyles("CommentOnSelectionContentWrapper
       background: theme.palette.panelBackground.darken08,
     },
 
-    // Hide on mobile to avoid horizontal scrolling
     [theme.breakpoints.down('xs')]: {
       display: "none",
     },
@@ -42,80 +41,37 @@ type SelectedTextToolbarState =
     {open: false}
   | {open: true, x: number, y: number, wrapper: HTMLElement, ranges: Range[]}
 
-/**
- * CommentOnSelectionPageWrapper: Wrapper around the entire page (used in
- * Layout) which adds event handlers to text-selection. If the selected range is
- * entirely wrapped in a CommentOnSelectionWrapper (in practice: is a post-body
- * on a post-page), places a floating comment button in the margin to the right.
- * When clicked, takes the selected content (HTML), wraps it in <blockquote>,
- * and calls the onClickComment function that was passed to the
- * CommentOnSelectionWrapper. (That function, defined as part of PostsPage,
- * opens a floating comment editor prepopulated with the blockquote.)
- *
- * The CommentOnSelectionWrapper is found by walking up the DOM until we find
- * an HTML element registered in commentOnSelectionHandlers. Placement of the
- * toolbar button is done with coordinate-math.
- *
- * Positioning might be brittle if the element that supports selection is nested
- * with multiple scrollbars or certain complex positioning. Test each context
- * separately when adding `CommentOnSelectionContentWrapper`s.
- *
- * If there's no space in the right margin (eg on mobile), adding the button
- * might introduce horizontal scrolling.
- */
+interface PagePosition {
+  x: number
+  y: number
+}
+
 export const CommentOnSelectionPageWrapper = ({children}: {
   children: React.ReactNode
 }) => {
   const [toolbarState,setToolbarState] = useState<SelectedTextToolbarState>({open: false});
 
   const closeToolbar = useCallback(() => {
-    // When changing toolbarState, do it in a way where if this is {open: false}, we reuse the previous value to avoid triggering a rerender.
     setToolbarState((prevState) => prevState.open ? {open: false} : prevState);
   }, []);
 
   useEffect(() => {
     const selectionChangedHandler = () => {
       const selection = document.getSelection();
-      const selectionText = selection+"";
-
-      // Is this selection non-empty?
-      if (!selection || !selectionText?.length) {
+      if (!selection || !selection.toString().length) {
         closeToolbar();
         return;
       }
 
-      // Determine whether this selection is fully wrapped in a single CommentOnSelectionContentWrapper
-      let commonWrapper: HTMLElement|null = null;
-      let hasCommonWrapper = true;
-      const ranges: Range[] = [];
-      for (let i=0; i<selection.rangeCount; i++) {
-        const range = selection.getRangeAt(i);
-        ranges.push(range.cloneRange());
-        const wrapper = findAncestorElementWithCommentOnSelectionWrapper(range.commonAncestorContainer);
-        if (commonWrapper) {
-          if (wrapper !== commonWrapper) {
-            hasCommonWrapper = false;
-          }
-        } else {
-          commonWrapper = wrapper;
-        }
-      }
-
-      if (!commonWrapper || !hasCommonWrapper) {
+      const ranges = cloneSelectionRanges(selection);
+      const wrapper = findCommonCommentOnSelectionWrapper(ranges);
+      if (!wrapper) {
         closeToolbar();
         return;
       }
 
-      // Get the bounding box of the selection
-      const selectionBoundingRect = ranges[0].getBoundingClientRect();
-      const wrapperBoundingRect = commonWrapper.getBoundingClientRect();
-
-      // Place the toolbar
-      const x = window.scrollX + Math.max(
-        selectionBoundingRect.x + selectionBoundingRect.width,
-        wrapperBoundingRect.x + wrapperBoundingRect.width);
-      const y = selectionBoundingRect.y + window.scrollY;
-      setToolbarState({open: true, x, y, wrapper: commonWrapper, ranges});
+      const {x, y} = getToolbarPagePosition(ranges[0], wrapper);
+      setToolbarState({open: true, x, y, wrapper, ranges});
     };
     document.addEventListener('selectionchange', selectionChangedHandler);
 
@@ -136,7 +92,6 @@ export const CommentOnSelectionPageWrapper = ({children}: {
     if (!handler) {
       return;
     }
-    // This HTML is XSS-safe because it's copied from somewhere that was already in the page as HTML, and is copied in a way that is syntax-aware throughout.
     handler(rangesToBlockquoteHTML(toolbarState.ranges));
     closeToolbar();
   }
@@ -150,19 +105,6 @@ export const CommentOnSelectionPageWrapper = ({children}: {
   </>
 }
 
-/**
- * SelectedTextToolbar: The toolbar that pops up when you select content inside
- * a post. Consists of just a comment button, which opens a floating comment
- * editor. Created as a dialog by CommentOnSelectionPageWrapper.
- *
- * onClickComment: Called when the comment button is pressed. This fires on
- *   mousedown (with the default prevented) rather than on click, because
- *   pressing the mouse outside a text selection collapses the selection in
- *   some browsers, and the resulting selectionchange would unmount this
- *   toolbar before a click event could be delivered to it.
- * x, y: In the page coordinate system, ie, relative to the top-left corner when
- *   the page is scrolled to the top.
- */
 const SelectedTextToolbar = ({onClickComment, x, y}: {
   onClickComment: () => void,
   x: number, y: number,
@@ -170,17 +112,19 @@ const SelectedTextToolbar = ({onClickComment, x, y}: {
   const classes = useStyles(selectedTextToolbarStyles);
   const { captureEvent } = useTracking()
 
+  const openCommentEditorBeforeSelectionCanCollapse = (ev: React.MouseEvent) => {
+    if (ev.button !== 0) {
+      return;
+    }
+    ev.preventDefault();
+    ev.stopPropagation();
+    captureEvent("commentOnSelectionClicked");
+    onClickComment();
+  };
+
   return <div className={classes.toolbarWrapper} style={{left: x, top: y}}>
     <LWTooltip inlineBlock={false} title={<div><p>Click to comment on the selected text</p></div>}>
-      <div
-        className={classes.toolbar}
-        onMouseDown={(ev: React.MouseEvent) => {
-          ev.preventDefault();
-          ev.stopPropagation();
-          captureEvent("commentOnSelectionClicked");
-          onClickComment();
-        }}
-      >
+      <div className={classes.toolbar} onMouseDown={openCommentEditorBeforeSelectionCanCollapse}>
         <AnalyticsContext pageElementContext="selectedTextToolbar">
           <CommentIcon/>
         </AnalyticsContext>
@@ -189,15 +133,6 @@ const SelectedTextToolbar = ({onClickComment, x, y}: {
   </div>
 }
 
-
-/**
- * CommentOnSelectionContentWrapper: Marks the contents inside it so that when
- * you highlight text, a floating comment button appears in the right margin.
- * When that button is clicked, calls onClickComment with the selected content,
- * wrapped in <blockquote>.
- *
- * See CommentOnSelectionPageWrapper for notes on implementation details.
- */
 export const CommentOnSelectionContentWrapper = ({post, children}: {
   post: PostsListWithVotes
   children: React.ReactNode,
@@ -234,13 +169,6 @@ export const CommentOnSelectionContentWrapper = ({post, children}: {
   </div>
 }
 
-/**
- * Starting from an HTML node, climb the tree until one is found which matches
- * the given function. Returns the deepest matching element, or null if no
- * match.
- *
- * Client-side only.
- */
 function nearestAncestorElementWith(start: Node|null, fn: (node: HTMLElement) => boolean): HTMLElement|null {
   if (!start)
     return null;
@@ -252,13 +180,6 @@ function nearestAncestorElementWith(start: Node|null, fn: (node: HTMLElement) =>
   return pos;
 }
 
-/**
- * Starting from an HTML node, climb the tree until one is found which
- * corresponds to a CommentOnSelectionContentWrapper component, ie, one with a
- * registered comment handler.
- *
- * Client-side only.
- */
 function findAncestorElementWithCommentOnSelectionWrapper(start: Node): HTMLElement|null {
   return nearestAncestorElementWith(
     start,
@@ -266,14 +187,40 @@ function findAncestorElementWithCommentOnSelectionWrapper(start: Node): HTMLElem
   );
 }
 
-/**
- * rangesToBlockquoteHTML: Given the ranges of a selection (cloned from
- * document.getSelection() at the time the toolbar was shown), return the
- * selected content, wrapped in a blockquote. The resulting HTML is XSS-safe
- * because it was already present in the document as HTML.
- *
- * Client-side only.
- */
+function cloneSelectionRanges(selection: Selection): Range[] {
+  const ranges: Range[] = [];
+  for (let i=0; i<selection.rangeCount; i++) {
+    ranges.push(selection.getRangeAt(i).cloneRange());
+  }
+  return ranges;
+}
+
+function findCommonCommentOnSelectionWrapper(ranges: Range[]): HTMLElement|null {
+  if (!ranges.length) {
+    return null;
+  }
+  const commonWrapper = findAncestorElementWithCommentOnSelectionWrapper(ranges[0].commonAncestorContainer);
+  if (!commonWrapper) {
+    return null;
+  }
+  for (let i=1; i<ranges.length; i++) {
+    if (findAncestorElementWithCommentOnSelectionWrapper(ranges[i].commonAncestorContainer) !== commonWrapper) {
+      return null;
+    }
+  }
+  return commonWrapper;
+}
+
+function getToolbarPagePosition(selectionRange: Range, wrapper: HTMLElement): PagePosition {
+  const selectionBoundingRect = selectionRange.getBoundingClientRect();
+  const wrapperBoundingRect = wrapper.getBoundingClientRect();
+  const x = window.scrollX + Math.max(
+    selectionBoundingRect.x + selectionBoundingRect.width,
+    wrapperBoundingRect.x + wrapperBoundingRect.width);
+  const y = selectionBoundingRect.y + window.scrollY;
+  return {x, y};
+}
+
 function rangesToBlockquoteHTML(ranges: Range[]): string {
   if (!ranges.length)
     return "";

--- a/packages/lesswrong/components/comments/CommentOnSelection.tsx
+++ b/packages/lesswrong/components/comments/CommentOnSelection.tsx
@@ -27,6 +27,7 @@ const selectedTextToolbarStyles = defineStyles("CommentOnSelectionContentWrapper
       background: theme.palette.panelBackground.darken08,
     },
 
+    // Hide on mobile to avoid horizontal scrolling
     [theme.breakpoints.down('xs')]: {
       display: "none",
     },
@@ -46,23 +47,48 @@ interface PagePosition {
   y: number
 }
 
+/**
+ * CommentOnSelectionPageWrapper: Wrapper around the entire page (used in
+ * Layout) which adds event handlers to text-selection. If the selected range is
+ * entirely wrapped in a CommentOnSelectionWrapper (in practice: is a post-body
+ * on a post-page), places a floating comment button in the margin to the right.
+ * When clicked, takes the selected content (HTML), wraps it in <blockquote>,
+ * and calls the onClickComment function that was passed to the
+ * CommentOnSelectionWrapper. (That function, defined as part of PostsPage,
+ * opens a floating comment editor prepopulated with the blockquote.)
+ *
+ * The CommentOnSelectionWrapper is found by walking up the DOM until we find
+ * an HTML element registered in commentOnSelectionHandlers. Placement of the
+ * toolbar button is done with coordinate-math.
+ *
+ * Positioning might be brittle if the element that supports selection is nested
+ * with multiple scrollbars or certain complex positioning. Test each context
+ * separately when adding `CommentOnSelectionContentWrapper`s.
+ *
+ * If there's no space in the right margin (eg on mobile), adding the button
+ * might introduce horizontal scrolling.
+ */
 export const CommentOnSelectionPageWrapper = ({children}: {
   children: React.ReactNode
 }) => {
   const [toolbarState,setToolbarState] = useState<SelectedTextToolbarState>({open: false});
 
   const closeToolbar = useCallback(() => {
+    // When changing toolbarState, do it in a way where if this is {open: false}, we reuse the previous value to avoid triggering a rerender.
     setToolbarState((prevState) => prevState.open ? {open: false} : prevState);
   }, []);
 
   useEffect(() => {
     const selectionChangedHandler = () => {
       const selection = document.getSelection();
+
+      // Is this selection non-empty?
       if (!selection || !selection.toString().length) {
         closeToolbar();
         return;
       }
 
+      // Determine whether this selection is fully wrapped in a single CommentOnSelectionContentWrapper
       const ranges = cloneSelectionRanges(selection);
       const wrapper = findCommonCommentOnSelectionWrapper(ranges);
       if (!wrapper) {
@@ -70,6 +96,7 @@ export const CommentOnSelectionPageWrapper = ({children}: {
         return;
       }
 
+      // Place the toolbar
       const {x, y} = getToolbarPagePosition(ranges[0], wrapper);
       setToolbarState({open: true, x, y, wrapper, ranges});
     };
@@ -92,6 +119,7 @@ export const CommentOnSelectionPageWrapper = ({children}: {
     if (!handler) {
       return;
     }
+    // This HTML is XSS-safe because it's copied from somewhere that was already in the page as HTML, and is copied in a way that is syntax-aware throughout.
     handler(rangesToBlockquoteHTML(toolbarState.ranges));
     closeToolbar();
   }
@@ -105,6 +133,19 @@ export const CommentOnSelectionPageWrapper = ({children}: {
   </>
 }
 
+/**
+ * SelectedTextToolbar: The toolbar that pops up when you select content inside
+ * a post. Consists of just a comment button, which opens a floating comment
+ * editor. Created as a dialog by CommentOnSelectionPageWrapper.
+ *
+ * onClickComment: Called when the comment button is pressed. This fires on
+ *   mousedown (with the default prevented) rather than on click, because
+ *   pressing the mouse outside a text selection collapses the selection in
+ *   some browsers, and the resulting selectionchange would unmount this
+ *   toolbar before a click event could be delivered to it.
+ * x, y: In the page coordinate system, ie, relative to the top-left corner when
+ *   the page is scrolled to the top.
+ */
 const SelectedTextToolbar = ({onClickComment, x, y}: {
   onClickComment: () => void,
   x: number, y: number,
@@ -133,6 +174,14 @@ const SelectedTextToolbar = ({onClickComment, x, y}: {
   </div>
 }
 
+/**
+ * CommentOnSelectionContentWrapper: Marks the contents inside it so that when
+ * you highlight text, a floating comment button appears in the right margin.
+ * When that button is clicked, calls onClickComment with the selected content,
+ * wrapped in <blockquote>.
+ *
+ * See CommentOnSelectionPageWrapper for notes on implementation details.
+ */
 export const CommentOnSelectionContentWrapper = ({post, children}: {
   post: PostsListWithVotes
   children: React.ReactNode,
@@ -169,6 +218,13 @@ export const CommentOnSelectionContentWrapper = ({post, children}: {
   </div>
 }
 
+/**
+ * Starting from an HTML node, climb the tree until one is found which matches
+ * the given function. Returns the deepest matching element, or null if no
+ * match.
+ *
+ * Client-side only.
+ */
 function nearestAncestorElementWith(start: Node|null, fn: (node: HTMLElement) => boolean): HTMLElement|null {
   if (!start)
     return null;
@@ -180,6 +236,13 @@ function nearestAncestorElementWith(start: Node|null, fn: (node: HTMLElement) =>
   return pos;
 }
 
+/**
+ * Starting from an HTML node, climb the tree until one is found which
+ * corresponds to a CommentOnSelectionContentWrapper component, ie, one with a
+ * registered comment handler.
+ *
+ * Client-side only.
+ */
 function findAncestorElementWithCommentOnSelectionWrapper(start: Node): HTMLElement|null {
   return nearestAncestorElementWith(
     start,
@@ -211,6 +274,10 @@ function findCommonCommentOnSelectionWrapper(ranges: Range[]): HTMLElement|null 
   return commonWrapper;
 }
 
+/**
+ * Get the bounding box of the selection and compute where to place the toolbar:
+ * to the right of whichever is wider, the selection or its wrapper.
+ */
 function getToolbarPagePosition(selectionRange: Range, wrapper: HTMLElement): PagePosition {
   const selectionBoundingRect = selectionRange.getBoundingClientRect();
   const wrapperBoundingRect = wrapper.getBoundingClientRect();
@@ -221,6 +288,14 @@ function getToolbarPagePosition(selectionRange: Range, wrapper: HTMLElement): Pa
   return {x, y};
 }
 
+/**
+ * rangesToBlockquoteHTML: Given the ranges of a selection (cloned from
+ * document.getSelection() at the time the toolbar was shown), return the
+ * selected content, wrapped in a blockquote. The resulting HTML is XSS-safe
+ * because it was already present in the document as HTML.
+ *
+ * Client-side only.
+ */
 function rangesToBlockquoteHTML(ranges: Range[]): string {
   if (!ranges.length)
     return "";


### PR DESCRIPTION
## Summary
- The floating "comment on selected text" button activated on `click` and re-read `document.getSelection()` at that moment. Anything that collapses the selection on mouse-press (Safari natively; browser extensions and document-level handlers too) fires a `selectionchange` that unmounts the toolbar between `mousedown` and `mouseup`, so the click is never delivered and pressing the icon does nothing — the reported symptom.
- The toolbar now snapshots the selection's ranges when it appears, activates on `mousedown` with the default prevented (the same approach `AddInlineReactionButton` already uses for the same reason), and resolves its content wrapper through a `WeakMap` instead of a monkeypatched DOM property.
- The toolbar wrapper gets a real `z-index` (the old `zIndex` was on a non-positioned element and had no effect).
- Fixes the multi-range wrapper check, which compared a range container against the wrapper element instead of comparing wrappers.

## Verification
- Logged-out, Chromium, on a local dev server: drag-select in a post, press the icon → editor opens prefilled with the blockquote (formatting preserved).
- With a capture-phase `mousedown` handler that clears the selection (simulating the failure mode): production's current code shows the icon and does nothing on press; this branch still opens the editor with the correct quote.
- `yarn tsc` reports no errors in the changed file (remaining errors are pre-existing worktree-environment ones: missing `.next/types`, `fly/hocuspocus` deps).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1217749695831659) by [Unito](https://www.unito.io)
