### PR TITLE
Show comments deleted without trace on the moderation log

### DIFF
--- a/app/moderation/ModerationPageContent.tsx
+++ b/app/moderation/ModerationPageContent.tsx
@@ -373,14 +373,6 @@ const styles = defineStyles("ModerationPageContent", (theme: ThemeType) => ({
       }
     }
   },
-  hiddenContentNote: {
-    padding: '12px',
-    background: theme.palette.panelBackground.default,
-    borderTop: `1px solid ${theme.palette.border.grey300}`,
-    fontSize: '12px',
-    fontStyle: 'italic',
-    color: theme.palette.text.dim,
-  },
   userList: {
     display: 'flex',
     flexWrap: 'wrap',
@@ -1133,11 +1125,7 @@ export default function ModerationPageContent(props: Props) {
                   </tr>
                   {expandedRows.has(comment._id) && (
                     <tr>
-                      <td colSpan={6}>
-                        {comment.deletedPublic
-                          ? renderContent(comment.contents)
-                          : <div className={classes.hiddenContentNote}>Contents are not shown for comments deleted without trace.</div>}
-                      </td>
+                      <td colSpan={6}>{renderContent(comment.contents)}</td>
                     </tr>
                   )}
                 </React.Fragment>

--- a/app/moderation/ModerationPageContent.tsx
+++ b/app/moderation/ModerationPageContent.tsx
@@ -373,6 +373,14 @@ const styles = defineStyles("ModerationPageContent", (theme: ThemeType) => ({
       }
     }
   },
+  hiddenContentNote: {
+    padding: '12px',
+    background: theme.palette.panelBackground.default,
+    borderTop: `1px solid ${theme.palette.border.grey300}`,
+    fontSize: '12px',
+    fontStyle: 'italic',
+    color: theme.palette.text.dim,
+  },
   userList: {
     display: 'flex',
     flexWrap: 'wrap',
@@ -1085,6 +1093,7 @@ export default function ModerationPageContent(props: Props) {
                 <th className={classes.th}>Post</th>
                 <th className={classes.th}>Reason</th>
                 <th className={classes.th}>Deleted By</th>
+                <th className={classes.th}>Public</th>
               </tr>
             </thead>
             <tbody>
@@ -1118,10 +1127,17 @@ export default function ModerationPageContent(props: Props) {
                         </a>
                       ) : '—'}
                     </td>
+                    <td className={classes.td} data-label="Public">
+                      {comment.deletedPublic ? 'Yes' : 'No'}
+                    </td>
                   </tr>
                   {expandedRows.has(comment._id) && (
                     <tr>
-                      <td colSpan={5}>{renderContent(comment.contents)}</td>
+                      <td colSpan={6}>
+                        {comment.deletedPublic
+                          ? renderContent(comment.contents)
+                          : <div className={classes.hiddenContentNote}>Contents are not shown for comments deleted without trace.</div>}
+                      </td>
                     </tr>
                   )}
                 </React.Fragment>

--- a/app/moderation/page.tsx
+++ b/app/moderation/page.tsx
@@ -466,9 +466,11 @@ async function fetchDeletedComments(db: SqlClient, limit: number, offset: number
       WITH paginated_comments AS (
         SELECT
           c._id, c."userId", c."postId", c."deletedDate", c."deletedReason",
-          c."deletedPublic", c.contents, c."deletedByUserId"
+          c."deletedPublic", c."deletedByUserId",
+          -- Comments deleted without trace are listed in the log, but their contents stay hidden
+          CASE WHEN c."deletedPublic" THEN c.contents END AS contents
         FROM "Comments" c
-        WHERE c.deleted = TRUE AND c."deletedPublic" = TRUE
+        WHERE c.deleted IS TRUE
         ORDER BY c."deletedDate" DESC NULLS LAST
         LIMIT $1 OFFSET $2
       )
@@ -487,7 +489,7 @@ async function fetchDeletedComments(db: SqlClient, limit: number, offset: number
     db.one<{count: number}>(`
       SELECT COUNT(*) as count
       FROM "Comments"
-      WHERE deleted = TRUE AND "deletedPublic" = TRUE
+      WHERE deleted IS TRUE
     `)
   ]);
 

--- a/app/moderation/page.tsx
+++ b/app/moderation/page.tsx
@@ -466,9 +466,7 @@ async function fetchDeletedComments(db: SqlClient, limit: number, offset: number
       WITH paginated_comments AS (
         SELECT
           c._id, c."userId", c."postId", c."deletedDate", c."deletedReason",
-          c."deletedPublic", c."deletedByUserId",
-          -- Comments deleted without trace are listed in the log, but their contents stay hidden
-          CASE WHEN c."deletedPublic" THEN c.contents END AS contents
+          c."deletedPublic", c.contents, c."deletedByUserId"
         FROM "Comments" c
         WHERE c.deleted IS TRUE
         ORDER BY c."deletedDate" DESC NULLS LAST


### PR DESCRIPTION
## Problem

The `/moderation` page's Deleted Comments section filtered with `deleted = TRUE AND "deletedPublic" = TRUE`, which excluded every "delete without trace" deletion (those set `deletedPublic: false`). The previous moderation log used the `allCommentsDeleted` view (no `deletedPublic` filter) and had a "Deleted Public" column, so without-trace deletions used to be listed. On the dev DB this was hiding 16,832 of 20,582 deleted comments.

## Changes

- `fetchDeletedComments` now lists all deleted comments (`WHERE deleted IS TRUE`), for both the page query and the count. Contents are shown on expand for every row, same as before.
- Added a **Public** (Yes/No) column so the two kinds of deletion are distinguishable.
- Switched `deleted = TRUE` to `deleted IS TRUE`: the partial indexes from #12128 use `WHERE "deleted" IS TRUE`, and Postgres doesn't match `= TRUE` against that predicate, so the query wasn't using its index. With `IS TRUE` it uses the existing `idx_Comments_deletedDate` (0.6ms vs 23ms on dev). No migration needed. `idx_Comments_deletedPublic_deletedDate` is now unused and could be dropped in a follow-up.

## Verification

- `yarn tsc` clean for the changed files.
- Ran the new SQL read-only against the dev DB: both deletion types returned.
- Loaded the page on a local dev server: "Deleted Comments (20582)", Yes/No rows interleaved, expansion shows contents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
