### PR TITLE
Add partial index for topShortform so old AllPosts time blocks load

### DIFF
--- a/packages/lesswrong/server/databaseIndexes/commentsDbIndexes.ts
+++ b/packages/lesswrong/server/databaseIndexes/commentsDbIndexes.ts
@@ -68,6 +68,18 @@ export function getDbIndexesOnComments() {
   
   // Will be used for experimental shortform display on AllPosts page
   indexSet.addIndex("Comments", { topLevelCommentId: 1, postedAt: 1, baseScore:1});
+
+  // topShortform (AllPosts time blocks): the view's sort order over exactly the rows it
+  // selects, so a date range with no shortform can't fall back to walking all of Comments
+  // by baseScore looking for 5 matches.
+  indexSet.addIndex("Comments",
+    { baseScore: -1, postedAt: -1 },
+    {
+      name: "comments.top_shortform",
+      partialFilterExpression: { shortform: true, parentCommentId: null, deleted: false },
+      concurrently: true,
+    }
+  );
   
   // Filtering comments down to ones that include "nominated for Review" so further sort indexes not necessary
   indexSet.addIndex("Comments",

--- a/packages/lesswrong/server/migrations/20260821T180000.add_Comments_top_shortform_index.ts
+++ b/packages/lesswrong/server/migrations/20260821T180000.add_Comments_top_shortform_index.ts
@@ -1,0 +1,9 @@
+import Comments from "../collections/comments/collection";
+import { updateIndexes } from "./meta/utils";
+
+export const up = async (_: MigrationContext) => {
+  return updateIndexes(Comments);
+}
+
+export const down = async (_: MigrationContext) => {
+}

--- a/schema/accepted_schema.sql
+++ b/schema/accepted_schema.sql
@@ -490,6 +490,15 @@ CREATE INDEX IF NOT EXISTS "idx_Comments_shortform_topLevelCommentId_lastSubthre
 -- Index "idx_Comments_topLevelCommentId_postedAt_baseScore"
 CREATE INDEX IF NOT EXISTS "idx_Comments_topLevelCommentId_postedAt_baseScore" ON "Comments" USING btree ("topLevelCommentId", "postedAt", "baseScore");
 
+-- Index "idx_comments_top_shortform"
+CREATE INDEX IF NOT EXISTS "idx_comments_top_shortform" ON "Comments" USING btree ("baseScore", "postedAt")
+WHERE
+  (
+    "shortform" IS TRUE AND
+    "parentCommentId" IS NULL AND
+    "deleted" IS FALSE
+  );
+
 -- Index "idx_comments_nominations2018"
 CREATE INDEX IF NOT EXISTS "idx_comments_nominations2018" ON "Comments" USING btree (
   "nominatedForReview",


### PR DESCRIPTION
Alternative to #12791, same bug, minimal version: one index definition, one migration, regenerated schema.

## The bug

`/allPosts?after=2013-01-01&before=2014-01-01` renders the `2013` heading and then nothing for ~30s. The `topShortform` comments query batched alongside the post list takes ~34s cold on prod for that range (~120ms for 2016 or 2020).

## Root cause (from `EXPLAIN ANALYZE` on dev, exact SQL the resolver emits)

Not a missing `postedAt` index — 2016 and 2020 already use the existing `idx_comments_shortform_topLevelCommentId_…` index with `shortform = true AND postedAt` range as index conditions. 2013 gets a different plan:

```
Limit (rows=5)
  -> Incremental Sort  Presorted Key: "baseScore"
     -> Index Scan Backward using "manualIdx_baseScore" on "Comments"
          Filter: shortform IS TRUE AND parentCommentId IS NULL AND postedAt in range …
```

The planner estimates ~1455 matches (it assumes `shortform` and `postedAt` are independent; shortform didn't exist in 2013), so it expects to find 5 quickly by walking the hand-made `manualIdx_baseScore` index from the top. Actual matches: 0, so it walks all 1.1M comments. 17s on dev, 34s cold on prod. High-volume years with no shortform (2011–2015) are the ones that hit it.

## The fix

```sql
CREATE INDEX "idx_comments_top_shortform" ON "Comments" ("baseScore", "postedAt")
WHERE "shortform" IS TRUE AND "parentCommentId" IS NULL AND "deleted" IS FALSE;
```

The view's sort order over exactly the rows the view selects. The planner keeps its "walk in sort order, stop at 5" strategy, but the walk is now bounded by a 488 kB index instead of the table. Built `CONCURRENTLY` via `updateIndexes(Comments)`, same path as prior index migrations.

## Measured (dev DB, index built inside a transaction then rolled back)

| Year | Before | After | Plan cost |
|---|---|---|---|
| 2013 | 16,943 ms | **0.26 ms** | 9780 → 27 |
| 2011 | 1,199 ms | 0.17 ms | |
| 2016 | 0.07 ms | 0.16 ms | |
| 2019 / 2020 / 2024 / 2026 | 5–50 ms | 0.08–0.11 ms | |

Shapes that were tried and rejected: `(postedAt) WHERE shortform IS TRUE` still loses to the baseScore walk (16.9s); `(postedAt) WHERE <full predicate>` wins by only 1.7× on cost, fragile to estimate drift. The `(baseScore, postedAt)` version wins by ~375×.

## Follow-up worth considering

`manualIdx_baseScore` (`btree("baseScore") INCLUDE (…)`, not in the codebase) is what enables this class of plan for *any* Comments query with selective filters + `ORDER BY baseScore LIMIT n`. If `pg_stat_user_indexes.idx_scan` on prod shows nothing uses it, dropping it removes the trap in general. Not needed for this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1217750399354205) by [Unito](https://www.unito.io)
