### PR TITLE
Fix a visual glitch when side-comments wrap a list item

### DIFF
--- a/packages/lesswrong/components/contents/ContentItemBody.tsx
+++ b/packages/lesswrong/components/contents/ContentItemBody.tsx
@@ -48,6 +48,65 @@ export const rootTagShouldBeHorizontallyScrollable = (tagName: string, attribs: 
 type SubstitutionsAttr = Array<{substitutionIndex: number, isSplitContinuation: boolean, invertColors?: boolean}>;
 
 /**
+ * Tags which, when they appear as the first thing inside a block, mean that
+ * block's contents are laid out as blocks rather than as inline content.
+ */
+const blockLevelTagNames = new Set([
+  "address", "article", "aside", "blockquote", "details", "dialog", "div", "dd",
+  "dl", "dt", "fieldset", "figcaption", "figure", "footer", "form", "h1", "h2",
+  "h3", "h4", "h5", "h6", "header", "hgroup", "hr", "li", "main", "nav", "ol",
+  "p", "pre", "section", "table", "ul",
+]);
+
+/**
+ * Block-level tags which we can't put an id-insertion inside of, either because
+ * they can't have children at all, or because their content model doesn't allow
+ * arbitrary inline content.
+ */
+const dontDescendIntoTagNames = new Set([
+  "hr", "table", "thead", "tbody", "tfoot", "tr",
+]);
+
+/**
+ * Given the children of an element which is the target of an id-insertion,
+ * return the index of the child that the insertion should be moved into, or
+ * null if the insertion should just go at the start of this element.
+ *
+ * Id-insertions (used for side-comment indicators) are inline elements which
+ * are inserted at the start of the block they're attached to. If that block's
+ * contents are themselves blocks (as in `<li><p>...</p></li>`, which is how
+ * list items in posts are usually structured), then inserting an inline element
+ * at the start displaces the first block from matching `:first-child`. Content
+ * styles use that selector to suppress the top margin of the first paragraph in
+ * a block, so the result is a spurious blank line at the start of the list item.
+ * Recursing into the first block child instead avoids this (and the anonymous
+ * block box that an inline element in a block-formatting context would
+ * otherwise generate).
+ */
+function getIdInsertionDescendIndex(childNodes: DomHandlerChildNode[]): number|null {
+  for (let i=0; i<childNodes.length; i++) {
+    const child = childNodes[i];
+    if (child.type === htmlparser2.ElementType.Text) {
+      // Whitespace between tags doesn't count as inline content
+      if (child.data.trim() === "") continue;
+      return null;
+    }
+    if (child.type === htmlparser2.ElementType.Comment) {
+      continue;
+    }
+    if (child.type !== htmlparser2.ElementType.Tag) {
+      return null;
+    }
+    const tagName = child.tagName.toLowerCase();
+    if (!blockLevelTagNames.has(tagName) || dontDescendIntoTagNames.has(tagName)) {
+      return null;
+    }
+    return i;
+  }
+  return null;
+}
+
+/**
  * Renders user-generated HTML, with progressive enhancements. Replaces
  * ContentItemBody, by parsing and recursing through an HTML parse tree rather
  * than doing post-mount modifications.
@@ -157,10 +216,17 @@ export const ContentItemBody = (props: ContentItemBodyProps) => {
   );
 }
 
-const ContentItemBodyInner = ({parsedHtml, passedThroughProps, root=false}: {
+const ContentItemBodyInner = ({parsedHtml, passedThroughProps, root=false, insertedAtStart}: {
   parsedHtml: DomHandlerChildNode,
   passedThroughProps: PassedThroughContentItemBodyProps,
   root?: boolean,
+
+  /**
+   * An id-insertion which was targeted at an ancestor of this element, but which
+   * was moved down into this element because that ancestor's contents are blocks
+   * rather than inline content. See `getIdInsertionDescendIndex`.
+   */
+  insertedAtStart?: React.ReactNode,
 }) => {
   const { replacedSubstrings, themeName } = passedThroughProps;
   const { captureEvent } = useTracking();
@@ -198,10 +264,25 @@ const ContentItemBodyInner = ({parsedHtml, passedThroughProps, root=false}: {
       const id = attribs.id;
       const classNames = parsedHtml.attribs.class?.split(' ') ?? [];
 
+      const ownIdInsertion = (id && passedThroughProps.idInsertions?.[id])
+        ? passedThroughProps.idInsertions[id]
+        : null;
+      const idInsertion: React.ReactNode = (insertedAtStart && ownIdInsertion)
+        ? <>{insertedAtStart}{ownIdInsertion}</>
+        : (insertedAtStart ?? ownIdInsertion);
+
+      // If this element has an insertion but its contents are blocks rather
+      // than inline content, put the insertion inside the first of those
+      // blocks, rather than at the start of this element.
+      const descendIndex = idInsertion
+        ? getIdInsertionDescendIndex(parsedHtml.childNodes)
+        : null;
+
       let mappedChildren: React.ReactNode[] = parsedHtml.childNodes.map((c,i) => <ContentItemBodyInner
         key={i}
         parsedHtml={c}
         passedThroughProps={passedThroughProps}
+        insertedAtStart={i===descendIndex ? idInsertion : undefined}
       />)
 
       if (classNames.includes("footnotes") && hasCollapsedFootnotes) {
@@ -226,8 +307,7 @@ const ContentItemBodyInner = ({parsedHtml, passedThroughProps, root=false}: {
       }
 
       let result: React.ReactNode|React.ReactNode[] = mappedChildren;
-      if (id && passedThroughProps.idInsertions?.[id]) {
-        const idInsertion = passedThroughProps.idInsertions[id];
+      if (idInsertion && descendIndex===null) {
         result = [
           <React.Fragment key="inserted">{idInsertion}</React.Fragment>,
            ...result


### PR DESCRIPTION
<details>
<summary>Prompts Used</summary>

User:

The post http://localhost:3000/posts/s22XzjQsrh6JXhXGH/big-world-intuitions has a side-comment on the list item that starts with "when you are working on a hard technical problem". Its wrapping is causing a formatting glitch: it looks as if the list item starts with a blank line or blank paragraph element. Look at the inline-comments wrapping code and attempt to fix this (category of) formatting glitches.

Claude Fable:

> Fixed. Here's what was going on and what I changed.
>
> ## Root cause
>
> The side comment's blockquote matched two nested blocks in the post — the `<li>` and the `<p>` inside it — and `findQuoteInPost` returns the *first* (outermost) match, so `sideCommentsByBlock` keyed the comment to `block11`, the `<li>`. `ContentItemBody` then inserted the `SideItem` anchor (an empty `<span>`) as the first child of the list item:
>
> ```html
> <li id="block11"><span></span><p id="block12">when you are working on…</p></li>
> ```
>
> That displaced the `<p>` from matching `p:first-child { margin-top: 0 }` (from `pBodyStyle` in `themes/stylePiping.ts`). Measured in the page: the glitched paragraph had `margin-top: 18.2px` where a normal list item's paragraph has `0px`, so the item sat 18.2px below its predecessor instead of the usual 6.5px — reading as a leading blank line.
>
> ## Fix
>
> `packages/lesswrong/components/contents/ContentItemBody.tsx` — id-insertions now descend into the innermost block instead of landing in a block-formatting context. New `getIdInsertionDescendIndex` looks at the target element's children: if the first meaningful child (ignoring inter-tag whitespace and comments) is a block-level element, the insertion is handed down to that child via a new `insertedAtStart` prop, recursively. So `<li><p>…` puts the anchor inside the `<p>`; `<li><ul><li><p>…` walks all the way down. It stops descending at inline content, and won't descend into tags that can't hold inline content (`table`, `tr`, `hr`, …). Insertions from an outer and inner block combine rather than one being lost.
>
> This covers the whole category: `<li><p>`, `<blockquote><p>`, and nested lists — all common shapes in lexical/ckeditor posts — plus it avoids the anonymous block box an inline element in a block container would generate.
>
> Verified against the live page with Playwright: the anchor now sits inside `<p id="block12">`, its `margin-top` is back to `0px`, the gap to the previous list item is the normal 6.5px, and the side-comment icon is still positioned alongside the item (top 1710 vs the li at 1712).
>
> `packages/lesswrong/unitTests/contentItemBodyIdInsertions.tests.tsx` — 8 new render tests covering those cases. `yarn tsc` shows only pre-existing unrelated errors (`geist/font`, `react-arborist`, `prismjs`, `app/admin/pangram`), and eslint is clean on both files.
>
> ## Left alone, noted in `notes/side-comment-block-matching.md`
>
> - The server picking the outer block is arguably the more principled place to fix, but changing it requires invalidating `SideCommentCaches`, and the client fix covers already-cached data.
> - Related pre-existing sloppiness: the duplicate intervals also make `annotateMatchedSpans` emit `class="blockquote_X_1 blockquote_X_1"` (harmless, but redundant).
</details>

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1217750563316461) by [Unito](https://www.unito.io)
