### PR TITLE
Add admin-deletion and self-deletion filters to the moderation log's deleted comments

### DIFF
--- a/app/moderation/ModerationPageContent.tsx
+++ b/app/moderation/ModerationPageContent.tsx
@@ -665,6 +665,8 @@ interface Props {
   deletedComments: ModerationComment[];
   deletedCommentsCount: number;
   deletedCommentsOffset: number;
+  hideAdminDeletions: boolean;
+  hideSelfDeletions: boolean;
   rejectedPosts: ModerationPost[];
   rejectedPostsCount: number;
   rejectedPostsOffset: number;
@@ -698,6 +700,8 @@ export default function ModerationPageContent(props: Props) {
     deletedComments,
     deletedCommentsCount,
     deletedCommentsOffset,
+    hideAdminDeletions,
+    hideSelfDeletions,
     rejectedPosts,
     rejectedPostsCount,
     rejectedPostsOffset,
@@ -1074,9 +1078,30 @@ export default function ModerationPageContent(props: Props) {
       </div>
 
       {/* Deleted Comments Table */}
-      {deletedComments.length > 0 && (
+      {(deletedComments.length > 0 || hideAdminDeletions || hideSelfDeletions) && (
         <div className={classes.section}>
-          <div className={classes.sectionHeader}>Deleted Comments ({deletedCommentsCount})</div>
+          <div className={`${classes.sectionHeader} ${classes.sectionHeaderFlex}`}>
+            <span>Deleted Comments ({deletedCommentsCount})</span>
+            <div className={classes.filterGroup}>
+              <Link to={buildToggleUrl('hideAdminDeletions', hideAdminDeletions, 'deletedCommentsOffset')} className={classes.filterCheckbox} scroll={false}>
+                <input
+                  type="checkbox"
+                  checked={hideAdminDeletions}
+                  readOnly
+                />{' '}
+                Hide admin deletions
+              </Link>
+              <Link to={buildToggleUrl('hideSelfDeletions', hideSelfDeletions, 'deletedCommentsOffset')} className={classes.filterCheckbox} scroll={false}>
+                <input
+                  type="checkbox"
+                  checked={hideSelfDeletions}
+                  readOnly
+                />{' '}
+                Hide self-deletions
+              </Link>
+            </div>
+          </div>
+          {deletedComments.length > 0 ? (
           <table className={classes.table}>
             <thead>
               <tr>
@@ -1132,6 +1157,9 @@ export default function ModerationPageContent(props: Props) {
               ))}
             </tbody>
           </table>
+          ) : (
+            <div className={classes.empty}>No deleted comments match the current filters</div>
+          )}
           {renderPagination('deletedComments', deletedCommentsCount, deletedCommentsOffset)}
         </div>
       )}

--- a/app/moderation/page.tsx
+++ b/app/moderation/page.tsx
@@ -7,6 +7,7 @@ import { getSqlClientOrThrow } from "@/server/sql/sqlClient";
 import { unstable_cache } from 'next/cache';
 import ModerationPageContent from "./ModerationPageContent";
 import { assertRouteAttributes } from "@/lib/routeChecks/assertRouteAttributes";
+import { adminAccountSetting } from "@/lib/instanceSettings";
 
 export async function generateMetadata(): Promise<Metadata> {
   return merge({}, await getDefaultMetadata(), getPageTitleFields('Moderation Log'), {
@@ -44,6 +45,8 @@ export default async function Page({
   const showExpiredRateLimits = params?.showExpiredRateLimits === 'true';
   const showNewUserRateLimits = params?.showNewUserRateLimits === 'true';
   const showExpiredBans = params?.showExpiredBans === 'true';
+  const hideAdminDeletions = params?.hideAdminDeletions === 'true';
+  const hideSelfDeletions = params?.hideSelfDeletions === 'true';
 
   const limit = defaultLimit;
   const db = getSqlClientOrThrow();
@@ -73,7 +76,8 @@ export default async function Page({
   );
 
   const getCachedDeletedComments = unstable_cache(
-    async (limit: number, offset: number) => fetchDeletedComments(db, limit, offset),
+    async (limit: number, offset: number, hideAdminDeletions: boolean, hideSelfDeletions: boolean) =>
+      fetchDeletedComments(db, limit, offset, hideAdminDeletions, hideSelfDeletions),
     [`moderation-deleted-comments-${commitSha}`],
     { revalidate: 1800, tags: ['moderation-deleted-comments'] }
   );
@@ -112,7 +116,7 @@ export default async function Page({
   const { comments: moderatorCommentIds, count: moderatorCommentsCount } = await getCachedModeratorCommentIds(limit, moderatorCommentsOffset);
   const moderatorPosts = await getCachedModeratorPosts();
   const { rateLimits: activeRateLimits, count: activeRateLimitsCount } = await getCachedActiveRateLimits(limit, activeRateLimitsOffset, showExpiredRateLimits, showNewUserRateLimits);
-  const { comments: deletedComments, count: deletedCommentsCount } = await getCachedDeletedComments(limit, deletedCommentsOffset);
+  const { comments: deletedComments, count: deletedCommentsCount } = await getCachedDeletedComments(limit, deletedCommentsOffset, hideAdminDeletions, hideSelfDeletions);
   const { posts: rejectedPosts, count: rejectedPostsCount } = await getCachedRejectedPosts(limit, rejectedPostsOffset);
   const { comments: rejectedComments, count: rejectedCommentsCount } = await getCachedRejectedComments(limit, rejectedCommentsOffset);
   const { posts: postsWithBannedUsers, count: postsWithBannedUsersCount } = await getCachedPostsWithBannedUsers(limit, bannedFromPostsOffset);
@@ -134,6 +138,8 @@ export default async function Page({
         deletedComments={deletedComments}
         deletedCommentsCount={deletedCommentsCount}
         deletedCommentsOffset={deletedCommentsOffset}
+        hideAdminDeletions={hideAdminDeletions}
+        hideSelfDeletions={hideSelfDeletions}
         rejectedPosts={rejectedPosts}
         rejectedPostsCount={rejectedPostsCount}
         rejectedPostsOffset={rejectedPostsOffset}
@@ -460,7 +466,21 @@ async function fetchActiveRateLimits(db: SqlClient, limit: number, offset: numbe
   return { rateLimits, count: activeRateLimitsCountResult.count };
 }
 
-async function fetchDeletedComments(db: SqlClient, limit: number, offset: number) {
+async function fetchDeletedComments(db: SqlClient, limit: number, offset: number, hideAdminDeletions: boolean, hideSelfDeletions: boolean) {
+  // A comment with no deletedByUserId (older data) counts as neither an admin
+  // deletion nor a self-deletion, so it stays visible under both filters. The
+  // admin team account isn't flagged isAdmin but only deletes on behalf of
+  // admins (e.g. deleteUserContent), so it counts as an admin deletion.
+  const adminAccountId = adminAccountSetting.get()?._id ?? null;
+  const deletionFilters = `
+    ${hideSelfDeletions ? `AND c."deletedByUserId" IS DISTINCT FROM c."userId"` : ''}
+    ${hideAdminDeletions ? `AND NOT EXISTS (
+      SELECT 1 FROM "Users" au
+      WHERE au._id = c."deletedByUserId"
+        AND (au."isAdmin" IS TRUE OR au._id = $(adminAccountId))
+    )` : ''}
+  `;
+
   const [deletedCommentsData, deletedCommentsCountResult] = await Promise.all([
     db.manyOrNone<DeletedCommentRow>(`
       WITH paginated_comments AS (
@@ -469,8 +489,9 @@ async function fetchDeletedComments(db: SqlClient, limit: number, offset: number
           c."deletedPublic", c.contents, c."deletedByUserId"
         FROM "Comments" c
         WHERE c.deleted IS TRUE
+        ${deletionFilters}
         ORDER BY c."deletedDate" DESC NULLS LAST
-        LIMIT $1 OFFSET $2
+        LIMIT $(limit) OFFSET $(offset)
       )
       SELECT
         c._id, c."userId", c."postId", c."deletedDate", c."deletedReason",
@@ -483,12 +504,13 @@ async function fetchDeletedComments(db: SqlClient, limit: number, offset: number
       LEFT JOIN "Users" du ON c."deletedByUserId" = du._id
       LEFT JOIN "Posts" p ON c."postId" = p._id
       ORDER BY c."deletedDate" DESC NULLS LAST
-    `, [limit, offset]),
+    `, { limit, offset, adminAccountId }),
     db.one<{count: number}>(`
       SELECT COUNT(*) as count
-      FROM "Comments"
-      WHERE deleted IS TRUE
-    `)
+      FROM "Comments" c
+      WHERE c.deleted IS TRUE
+      ${deletionFilters}
+    `, { adminAccountId })
   ]);
 
   const comments = deletedCommentsData.map(row => ({


### PR DESCRIPTION
Adds two settings to the **Deleted Comments** section of the `/moderation` page, so the log can be narrowed to deletions done by moderation of *other people's* comments:

- **Hide admin deletions** — hides comments whose deleter is a site admin, or the admin team account (which isn't flagged `isAdmin` but only deletes on behalf of admins, e.g. via `deleteUserContent`).
- **Hide self-deletions** — hides comments deleted by their own author.

Both are URL-param checkbox toggles in the section header, following the existing pattern used for "Show new user rate limits" / "Show expired bans". Toggling resets the section's pagination. Comments with no `deletedByUserId` (older data) count as neither category and stay visible under both filters. When a filter is active but matches nothing, the section stays rendered with an empty state so the toggles remain reachable.

Tested locally against the LW dev DB: unfiltered 20,582 deleted comments; hide self-deletions → 11,548; hide admin deletions → 16,415; both → 7,743, with rendered rows spot-checked to contain no author-deleted rows and no admin/team-account deleters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1217751367684971) by [Unito](https://www.unito.io)
