### PR TITLE
Clear the source account's oldSlugs when merging accounts

### DIFF
--- a/packages/lesswrong/server/scripts/mergeAccounts.ts
+++ b/packages/lesswrong/server/scripts/mergeAccounts.ts
@@ -6,6 +6,7 @@ import { Votes } from '../../server/collections/votes/collection';
 import { Conversations } from '../../server/collections/conversations/collection'
 import { asyncForeachSequential } from '../../lib/utils/asyncUtils';
 import sumBy from 'lodash/sumBy';
+import uniq from 'lodash/uniq';
 import ConversationsRepo from '../repos/ConversationsRepo';
 import LocalgroupsRepo from '../repos/LocalgroupsRepo';
 import PostsRepo from '../repos/PostsRepo';
@@ -520,7 +521,8 @@ export const mergeAccounts = async ({sourceUserId, targetUserId, dryRun, deadlin
     await transferServices(sourceUser, targetUser, dryRun)
   }})
   
-  // Change slug of source account by appending "old" and reset oldSlugs array
+  // Change slug of source account by appending "old", and move its oldSlugs onto
+  // the target account so that stale URLs redirect to the surviving account
   // eslint-disable-next-line no-console
   console.log("Change slugs of source account")
   try {
@@ -529,16 +531,20 @@ export const mergeAccounts = async ({sourceUserId, targetUserId, dryRun, deadlin
       await Users.rawUpdateOne(
         {_id: sourceUserId},
         {$set: {
-          slug: await getUnusedSlugByCollectionName("Users", `${sourceUser.slug}-old`, true)
+          slug: await getUnusedSlugByCollectionName("Users", `${sourceUser.slug}-old`, true),
+          // Cleared because the target account takes them over below; leaving them
+          // here would make the same slug resolve to two different profiles, and
+          // would make it permanently unclaimable by anyone else
+          oldSlugs: []
         }}
       );
     
       // Add slug to oldSlugs array of target account
-      const newOldSlugs = [
+      const newOldSlugs = uniq([
         ...(targetUser.oldSlugs || []), 
         ...(sourceUser.oldSlugs || []), 
         sourceUser.slug
-      ]
+      ])
       // eslint-disable-next-line no-console
       console.log("Changing slugs of target account", sourceUser.slug, newOldSlugs)
       


### PR DESCRIPTION
## Context

Came up while consolidating a user's duplicate accounts (an Intercom request: delete a duplicate account created for an ACX meetup, and move their real account onto the freed `/users/milli` slug).

`mergeAccounts` copies the source account's `oldSlugs` onto the target but never clears the source's own, despite a comment claiming it "reset oldSlugs array". Two consequences:

- Every one of the source's old slugs ends up on **two** users. The `usersProfile` view matches `{$or: [{slug}, {oldSlugs}]}` ([views.ts:48](packages/lesswrong/lib/collections/users/views.ts#L48)), so a stale profile URL resolves to an arbitrary one of the two accounts — and `slugIsUsed` sees the slug as taken forever, so an admin can never reassign it. That's exactly the failure mode you hit when trying to hand a merged-away slug to the surviving account.
- `newOldSlugs` wasn't deduped, so repeated merges accumulated duplicate entries.

## Change

Clear the source's `oldSlugs` in the same `rawUpdateOne` that renames its slug — matching what `SoftDeleteUser` already does ("clear them so the old username isn't discoverable") — and dedupe the target's array with `uniq`. Comment updated to describe what the code actually does.

Only affects future merges; the `dryRun` guard is unchanged. Cleaning up already-duplicated `oldSlugs` rows in prod is out of scope.

## Testing

`mergeAccounts` has no unit test coverage, so I exercised it against the dev DB via `yarn repl dev lw` with two throwaway users — the source seeded with an extra `oldSlugs` entry — then removed them:

```
dry run: success=true completed=true failures=0
dry run left source untouched: true
real run: success=true completed=true failures=[]
source slug is renamed: mergeslugtest-src-AChHEG-old
source oldSlugs cleared: []
target oldSlugs: ["mergeslugtest-stale-AChHEG","mergeslugtest-src-AChHEG"]
target oldSlugs has no duplicates: true
target inherited source slug once: true
target inherited stale slug once: true
target could reclaim "mergeslugtest-src-AChHEG": true
```

That last assertion is the thing that was broken: after the merge, an explicit admin slug change on the target to the source's former slug now succeeds instead of throwing `Slug ... is already taken`.

`yarn tsc` shows no errors in the changed file (the 17 it does report are pre-existing worktree-env noise — missing `@hocuspocus/*` and no `.next` build).

## Not fixed here

[slugUtil.ts:128](packages/lesswrong/server/utils/slugUtil.ts#L128)'s TODO is still unimplemented: explicitly claiming a slug doesn't remove it from another document's `oldSlugs`, it just rejects. So freed slugs can still get stuck for other reasons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1217772046885492) by [Unito](https://www.unito.io)
