### PR TITLE
Remove History section from supermod undo sidebar

### DIFF
--- a/packages/lesswrong/components/sunshineDashboard/supermod/ModerationInbox.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/supermod/ModerationInbox.tsx
@@ -458,7 +458,6 @@ const ModerationInboxInner = ({ users, posts, classifiedPosts, curationPosts, la
                 <div className={classes.undoQueueSection}>
                   <ModerationUndoHistory
                     undoQueue={state.undoQueue}
-                    history={state.history}
                     dispatch={dispatch}
                   />
                 </div>

--- a/packages/lesswrong/components/sunshineDashboard/supermod/ModerationUndoHistory.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/supermod/ModerationUndoHistory.tsx
@@ -2,7 +2,7 @@
 
 import React, { useEffect, useState } from 'react';
 import { defineStyles, useStyles } from '@/components/hooks/useStyles';
-import type { UndoHistoryItem, InboxAction, HistoryItem } from './inboxReducer';
+import type { UndoHistoryItem, InboxAction } from './inboxReducer';
 import classNames from 'classnames';
 import KeystrokeDisplay from './KeystrokeDisplay';
 import { UNDO_QUEUE_DURATION } from './constants';
@@ -111,25 +111,12 @@ const styles = defineStyles('ModerationUndoHistory', (theme: ThemeType) => ({
     color: theme.palette.grey[500],
     minWidth: 20,
   },
-  historyItem: {
-    opacity: 0.6,
-  },
   empty: {
     color: theme.palette.grey[500],
     fontSize: 12,
     fontStyle: 'italic',
   },
-  loadMore: {
-    fontSize: 12,
-    color: theme.palette.grey[500],
-    cursor: 'pointer',
-    '&:hover': {
-      color: theme.palette.grey[800],
-    },
-  },
 }));
-
-const HISTORY_PAGE_SIZE = 2;
 
 const ProgressBar = ({ expiresAt, totalDuration }: { expiresAt: number; totalDuration: number }) => {
   const classes = useStyles(styles);
@@ -175,15 +162,12 @@ const TimeRemaining = ({ expiresAt }: { expiresAt: number }) => {
 
 const ModerationUndoHistory = ({
   undoQueue,
-  history,
   dispatch,
 }: {
   undoQueue: UndoHistoryItem[];
-  history: HistoryItem[];
   dispatch: React.Dispatch<InboxAction>;
 }) => {
   const classes = useStyles(styles);
-  const [historyLimit, setHistoryLimit] = useState(HISTORY_PAGE_SIZE);
 
   // Warn user if they try to close the tab or navigate away while there are pending actions
   useEffect(() => {
@@ -250,31 +234,6 @@ const ModerationUndoHistory = ({
               </div>
             </div>
           ))
-        )}
-      </div>
-
-      <div className={classes.section}>
-        <div className={classes.sectionTitle}>History</div>
-        {history.length === 0 ? (
-          <div className={classes.empty}>No history</div>
-        ) : (
-          <>
-            {history.slice(-historyLimit).reverse().map((item) => (
-              <div key={`${item.user._id}-${item.timestamp}`} className={classNames(classes.item, classes.historyItem)}>
-                <div className={classes.itemContent}>
-                  <div className={classes.itemLeft}>
-                    <span className={classes.userName}>{item.user.displayName}</span>
-                    <span className={classes.actionLabel}>{item.actionLabel}</span>
-                  </div>
-                </div>
-              </div>
-            ))}
-            {history.length > historyLimit && (
-              <div className={classes.loadMore} onClick={() => setHistoryLimit(historyLimit + HISTORY_PAGE_SIZE)}>
-                Load more
-              </div>
-            )}
-          </>
         )}
       </div>
     </div>

--- a/packages/lesswrong/components/sunshineDashboard/supermod/ModerationUserDetailView.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/supermod/ModerationUserDetailView.tsx
@@ -101,7 +101,6 @@ const ModerationUserDetailView = ({
           <div className={classes.undoQueueColumn}>
             <ModerationUndoHistory
               undoQueue={state.undoQueue}
-              history={state.history}
               dispatch={dispatch}
             />
           </div>


### PR DESCRIPTION
Removes the "History" list rendered under the Undo Queue in `/admin/supermod`. The sidebar now shows only the pending undo queue.

This is a UI-only change: the reducer still tracks `state.history` and still moves expired undo entries into it on `EXPIRE_UNDO_ITEM`, so the history infrastructure and its unit tests are untouched. Only the rendering (the History section, its `historyItem`/`loadMore` styles, and the "Load more" paging state) is removed, along with the now-unused `history` prop on `ModerationUndoHistory`.

Screenshot omitted: `/admin/supermod` is admin-only and needs a logged-in prod-shaped session, which isn't reachable from the local preview environment. The visible change is the deletion of the "History" heading and the entries beneath it; the Undo Queue section above is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1217804521284303) by [Unito](https://www.unito.io)