### PR TITLE
Label the link text and URL fields in the Lexical link editor

### DIFF
--- a/packages/lesswrong/components/lexical/plugins/FloatingLinkEditorPlugin/index.tsx
+++ b/packages/lesswrong/components/lexical/plugins/FloatingLinkEditorPlugin/index.tsx
@@ -45,6 +45,7 @@ import { Trash3Icon } from '../../icons/Trash3Icon';
 import { SuccessAltIcon } from '../../icons/SuccessAltIcon';
 import { CloseIcon } from '../../icons/CloseIcon';
 import ForumIcon from '@/components/common/ForumIcon';
+import classNames from 'classnames';
 
 const styles = defineStyles('LexicalFloatingLinkEditorPlugin', (theme: ThemeType) => ({
   linkEditor: {
@@ -81,19 +82,45 @@ const styles = defineStyles('LexicalFloatingLinkEditorPlugin', (theme: ThemeType
       verticalAlign: '-0.25em',
     },
   },
-  linkInput: {
-    display: 'block',
-    width: 'calc(100% - 24px)',
+  // A labelled input row: the pill that used to be the <input> itself is now a
+  // <label> wrapping a persistent field name and a borderless input, so the
+  // name stays visible once the field has content. Clicking anywhere in the
+  // pill focuses the input.
+  fieldRow: {
+    display: 'flex',
+    alignItems: 'center',
     boxSizing: 'border-box',
     margin: '8px 12px',
     padding: '8px 12px',
     borderRadius: 15,
     backgroundColor: theme.palette.grey[200],
-    fontSize: 15,
-    color: theme.palette.grey[700],
+    cursor: 'text',
+  },
+  urlFieldRow: {
+    flex: 1,
+    minWidth: 0,
+  },
+  fieldLabel: {
+    flexShrink: 0,
+    minWidth: 34,
+    marginRight: 8,
+    paddingRight: 8,
+    borderRight: `1px solid ${theme.palette.greyAlpha(0.15)}`,
+    fontSize: 13,
+    fontWeight: 500,
+    color: theme.palette.grey[600],
+    userSelect: 'none',
+  },
+  linkInput: {
+    flex: 1,
+    minWidth: 0,
+    margin: 0,
+    padding: 0,
     border: 0,
     outline: 0,
-    position: 'relative',
+    backgroundColor: 'transparent',
+    fontSize: 15,
+    color: theme.palette.grey[700],
     fontFamily: 'inherit',
   },
   linkView: {
@@ -140,20 +167,6 @@ const styles = defineStyles('LexicalFloatingLinkEditorPlugin', (theme: ThemeType
   editUrlRow: {
     display: 'flex',
     alignItems: 'center',
-  },
-  linkUrlInput: {
-    flex: 1,
-    minWidth: 0,
-    boxSizing: 'border-box',
-    margin: '8px 12px',
-    padding: '8px 12px',
-    borderRadius: 15,
-    backgroundColor: theme.palette.grey[200],
-    fontSize: 15,
-    color: theme.palette.grey[700],
-    border: 0,
-    outline: 0,
-    fontFamily: 'inherit',
   },
 }));
 
@@ -495,28 +508,35 @@ function FloatingLinkEditor({
     <div ref={editorRef} className={classes.linkEditor}>
       {!isLink && !isLinkEditMode ? null : isLinkEditMode ? (
         <div className={classes.editContainer}>
-          <input
-            className={classes.linkInput}
-            placeholder="Link text"
-            value={editedLinkText}
-            onChange={(event) => {
-              setEditedLinkText(event.target.value);
-            }}
-            onKeyDown={handleTextInputKeyDown}
-          />
-          <div className={classes.editUrlRow}>
+          <label className={classes.fieldRow}>
+            <span className={classes.fieldLabel}>Text</span>
             <input
-              ref={inputRef}
-              className={classes.linkUrlInput}
-              placeholder="Link URL"
-              value={editedLinkUrl}
+              className={classes.linkInput}
+              aria-label="Link text"
+              value={editedLinkText}
               onChange={(event) => {
-                setEditedLinkUrl(event.target.value);
+                setEditedLinkText(event.target.value);
               }}
-              onKeyDown={(event) => {
-                monitorInputInteraction(event);
-              }}
+              onKeyDown={handleTextInputKeyDown}
             />
+          </label>
+          <div className={classes.editUrlRow}>
+            <label className={classNames(classes.fieldRow, classes.urlFieldRow)}>
+              <span className={classes.fieldLabel}>URL</span>
+              <input
+                ref={inputRef}
+                className={classes.linkInput}
+                aria-label="Link URL"
+                placeholder="https://example.com"
+                value={editedLinkUrl}
+                onChange={(event) => {
+                  setEditedLinkUrl(event.target.value);
+                }}
+                onKeyDown={(event) => {
+                  monitorInputInteraction(event);
+                }}
+              />
+            </label>
             <button
               className={classes.linkAction}
               type="button"


### PR DESCRIPTION
The floating link editor shows two identical grey pills, one for the link text and one for the URL. The only thing telling them apart was the placeholder, and placeholders disappear as soon as a field has content. That is exactly the case you hit when you click the pencil on an existing link: both fields are populated, both look the same, and there is nothing left on screen saying which is which. Reported in #12469.

Each input is now wrapped in a <label> that carries a short persistent name ("Text", "URL") separated from the value by a hairline rule. The pill styling moves from the input to the label, and the input inside it is transparent and borderless, so the rows look the same as before apart from the added prefix. Both inputs also get an aria-label, which they previously lacked entirely even though every button in the same popover has one.

The popover floats over the editor and vertical room is tight, so the labels sit inline rather than stacked above the fields. Measured in Chromium, the edit-mode popover goes from 100px to 103.6px tall, and the flip-above-the-link behaviour added in 20b3d3202 still triggers on a link near the bottom of a comment box. The URL placeholder becomes "https://example.com", which is now a format hint rather than the field's only name; the text field no longer needs a placeholder.

<img width="850" height="362" alt="linkeditor-before-after" src="https://github.com/user-attachments/assets/f435c0db-c605-4a11-90fb-045b3b58cff0" />

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1217854571066345) by [Unito](https://www.unito.io)
