### PR TITLE
Bump LLM chat title generation from Haiku 3 to Haiku 4.5

### DIFF
--- a/packages/lesswrong/server/resolvers/anthropicResolvers.ts
+++ b/packages/lesswrong/server/resolvers/anthropicResolvers.ts
@@ -200,7 +200,7 @@ async function getConversationTitle(args: BasePromptArgs) {
 
   const client = getAnthropicClientOrThrow()
   const titleResult = await client.messages.create({
-    model: "claude-3-haiku-20240307",
+    model: "claude-haiku-4-5",
     max_tokens: 50,
     messages: [{role: "user", content: titleGenerationPrompt}]
   })


### PR DESCRIPTION
`getConversationTitle` in `packages/lesswrong/server/resolvers/anthropicResolvers.ts` (used to name new LLM chat conversations) was still hardcoded to `claude-3-haiku-20240307`. This was the last remaining Claude 3.x model reference in the codebase; this bumps it to `claude-haiku-4-5`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015PSHXFFTWPo9hHMDosC8oX

---
_Generated by [Claude Code](https://claude.ai/code/session_015PSHXFFTWPo9hHMDosC8oX)_

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1217967481386426) by [Unito](https://www.unito.io)
