### PR TITLE
Link author displayName on /editPost to their profile page

### DIFF
--- a/packages/lesswrong/components/posts/PostForm.tsx
+++ b/packages/lesswrong/components/posts/PostForm.tsx
@@ -1,4 +1,6 @@
 import { EditablePost, PostSubmitMeta, userCanEditCoauthors, canUserEditPostMetadata, detectLinkpost } from "@/lib/collections/posts/helpers";
+import { userGetProfileUrl } from "@/lib/collections/users/helpers";
+import { Link } from "@/lib/reactRouterWrapper";
 import { getDefaultEditorPlaceholder } from '@/lib/editor/defaultEditorPlaceholder';
 import { isLWorAF, isEAForum } from "@/lib/instanceSettings";
 import { useForm } from "@tanstack/react-form";
@@ -713,7 +715,9 @@ const PostForm = ({
           <div className={classes.metadataRow}>
             <span className={classes.metaAuthorInfo}>
               by{" "}
-              <span className={classes.metaAuthorName}>{initialData.user?.displayName ?? currentUser?.displayName}</span>
+              <Link to={userGetProfileUrl(initialData.user ?? currentUser)} className={classes.metaAuthorName}>
+                {initialData.user?.displayName ?? currentUser?.displayName}
+              </Link>
               <form.Field name="coauthorUserIds">
                 {(field) => <>
                   {(field.state.value ?? []).map((userId) => (


### PR DESCRIPTION
On the post edit page (`/editPost`), the author's display name in the metadata row ("by …") was rendered as a plain `<span>`. This PR wraps it in a `Link` to the author's profile page (via `userGetProfileUrl`), keeping the existing `metaAuthorName` styling — global link styles make it inherit the same color/weight, with the standard hover-dim effect.

The link target uses `initialData.user ?? currentUser`, matching the existing fallback used for the displayed name (new posts don't yet have a saved `user`, so the current user is the author).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JwcbP72uQQyLQ541kGnnLt

---
_Generated by [Claude Code](https://claude.ai/code/session_01JwcbP72uQQyLQ541kGnnLt)_

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1217967612276212) by [Unito](https://www.unito.io)
