### PR TITLE
Show Inkhaven Residency #3 on the frontpage for 10 days

### DIFF
--- a/packages/lesswrong/components/common/LWHome.tsx
+++ b/packages/lesswrong/components/common/LWHome.tsx
@@ -26,6 +26,7 @@ import UltraFeedErrorFallback from '../ultraFeed/UltraFeedErrorFallback';
 
 import dynamic from 'next/dynamic';
 import { IsReturningVisitorContextProvider } from '@/components/layout/IsReturningVisitorContextProvider';
+import { INKHAVEN_RESIDENCY_3_END, INKHAVEN_RESIDENCY_3_SPOTLIGHT_ID, INKHAVEN_RESIDENCY_3_START } from '../seasonal/Inkhaven2026Banner';
 const RecentDiscussionFeed = dynamic(() => import("../recentDiscussion/RecentDiscussionFeed"), { ssr: false });
 
 const styles = defineStyles("LWHome", () => ({
@@ -41,14 +42,11 @@ const styles = defineStyles("LWHome", () => ({
   },
 }));
 
-const LESSONLINE_MOBILE_SPOTLIGHT_ID = 'j4q2gcjowKqfpdjsR';
-const LESSONLINE_MOBILE_SPOTLIGHT_UNTIL = new Date('2026-03-26T00:00:00Z');
-
-const getLessOnlineMobileSpotlightOverrideId = (now: Date = new Date()): string | null => (
-  now.getTime() < LESSONLINE_MOBILE_SPOTLIGHT_UNTIL.getTime()
-    ? LESSONLINE_MOBILE_SPOTLIGHT_ID
-    : null
-);
+const getMobileSpotlightOverrideId = (now: Date = new Date()): string | null => {
+  return now >= INKHAVEN_RESIDENCY_3_START && now < INKHAVEN_RESIDENCY_3_END
+    ? INKHAVEN_RESIDENCY_3_SPOTLIGHT_ID
+    : null;
+};
 
 const getStructuredData = () => ({
   "@context": "http://schema.org",
@@ -80,7 +78,7 @@ const getStructuredData = () => ({
 
 const LWHome = () => {
   const classes = useStyles(styles);
-  const mobileSpotlightOverrideId = getLessOnlineMobileSpotlightOverrideId();
+  const mobileSpotlightOverrideId = getMobileSpotlightOverrideId();
 
   return (
       <AnalyticsContext pageContext="homePage">

--- a/packages/lesswrong/components/layout/LWBackgroundImage.tsx
+++ b/packages/lesswrong/components/layout/LWBackgroundImage.tsx
@@ -7,7 +7,7 @@ import { isHomeRoute, isRouteWithLeftNavigationColumn } from '@/lib/routeChecks'
 import { useCookiesWithConsent } from '../hooks/useCookiesWithConsent';
 import { HIDE_SOLSTICE_GLOBE_COOKIE } from '@/lib/cookies/cookies';
 import { SolsticeSeasonBanner } from '../seasonal/solsticeSeason/SolsticeSeasonBanner';
-import { Inkhaven2026Banner } from '../seasonal/Inkhaven2026Banner';
+import { Inkhaven2026Banner, INKHAVEN_RESIDENCY_3_END, INKHAVEN_RESIDENCY_3_START } from '../seasonal/Inkhaven2026Banner';
 import { LessOnline2026Banner } from '../seasonal/LessOnline2026Banner';
 import withErrorBoundary from '@/components/common/withErrorBoundary';
 import { getReviewPhase, reviewIsActive, reviewResultsPostPath } from '@/lib/reviewUtils';
@@ -16,13 +16,9 @@ import { useCurrentTime } from '@/lib/utils/timeUtil';
 import { Link } from '@/lib/reactRouterWrapper';
 import { usePrerenderablePathname } from '../next/usePrerenderablePathname';
 
-// Inkhaven Cohort #2 banner active period
-const INKHAVEN_2026_START = new Date('2026-01-10T00:00:00-08:00');
-const INKHAVEN_2026_END = new Date('2026-02-01T00:00:00-08:00');
-
 function useIsInkhaven2026Active(): boolean {
   const now = useCurrentTime();
-  return now >= INKHAVEN_2026_START && now < INKHAVEN_2026_END;
+  return now >= INKHAVEN_RESIDENCY_3_START && now < INKHAVEN_RESIDENCY_3_END;
 }
 
 // LessOnline 2026 banner active period

--- a/packages/lesswrong/components/seasonal/Inkhaven2026Banner.tsx
+++ b/packages/lesswrong/components/seasonal/Inkhaven2026Banner.tsx
@@ -3,6 +3,12 @@ import { AnalyticsContext } from "../../lib/analyticsEvents";
 import { defineStyles, useStyles } from '../hooks/useStyles';
 import CloudinaryImage2 from "../common/CloudinaryImage2";
 
+// Frontpage campaign: 10 days from 2026-08-28.
+export const INKHAVEN_RESIDENCY_3_SPOTLIGHT_ID = 'SbqCm443KuNuxoZKt';
+export const INKHAVEN_RESIDENCY_3_START = new Date('2026-08-28T00:00:00-07:00');
+export const INKHAVEN_RESIDENCY_3_END = new Date('2026-09-07T00:00:00-07:00');
+const INKHAVEN_RESIDENCY_3_BANNER_PUBLIC_ID = 'ChatGPT_Image_Aug_28_2026_07_27_41_PM_t1nbcb';
+
 const styles = defineStyles("Inkhaven2026Banner", (theme: ThemeType) => ({
   root: {
     position: 'absolute',
@@ -17,37 +23,21 @@ const styles = defineStyles("Inkhaven2026Banner", (theme: ThemeType) => ({
     },
   },
   image: {
-    width: '400px',
+    width: '100%',
     height: 'auto',
+    maxHeight: '92vh',
     objectFit: 'contain',
-  },
-  gradientOverlayDown: {
-    position: 'absolute',
-    top: 0,
-    left: 0,
-    right: 0,
-    bottom: 0,
-    background: `linear-gradient(to bottom, 
-                transparent 50%,
-                ${theme.palette.background.default} 90%)`,
-    pointerEvents: 'none',
-  },
-  gradientOverlayLeft: {
-    position: 'absolute',
-    top: 0,
-    left: 0,
-    right: 0,
-    bottom: 0,
-    background: `linear-gradient(to left, 
-                transparent 50%,
-                ${theme.palette.background.default} 95%)`,
-    pointerEvents: 'none',
+    objectPosition: 'right top',
+    display: 'block',
+    transform: 'translate(-56px, calc(-4vh - 10px)) scale(0.85)',
+    transformOrigin: 'top right',
   },
   imageColumn: {
     position: 'absolute',
     top: 0,
     right: 0,
-    width: '400px',
+    height: '100vh',
+    width: '480px',
     [theme.breakpoints.down(1200)]: {
       display: 'none'
     },
@@ -56,16 +46,19 @@ const styles = defineStyles("Inkhaven2026Banner", (theme: ThemeType) => ({
     ...theme.typography.postStyle,
     position: 'absolute',
     right: 16,
-    bottom: 80,
+    bottom: 88,
     color: theme.palette.greyAlpha(0.87),
     textShadow: `0 0 3px ${theme.palette.background.default}, 0 0 3px ${theme.palette.background.default}`,
     textAlign: 'right',
     width: 500,
     [theme.breakpoints.down(1600)]: {
-      width: 300,
+      width: 400,
     },
     [theme.breakpoints.down(1380)]: {
-      width: 200
+      width: 360
+    },
+    [theme.breakpoints.down(1280)]: {
+      width: 320,
     },
     pointerEvents: 'auto',
     '& h2': {
@@ -103,16 +96,18 @@ const styles = defineStyles("Inkhaven2026Banner", (theme: ThemeType) => ({
     fontSize: '16px !important',
     fontStyle: 'normal',
     marginBottom: '16px !important',
-    maxWidth: '300px',
+    maxWidth: 365,
+    [theme.breakpoints.down(1380)]: {
+      maxWidth: 320,
+    },
+    [theme.breakpoints.down(1280)]: {
+      maxWidth: 280,
+    },
     marginLeft: 'auto',
     textAlign: 'right',
   },
-  cohortBadge: {
-    ...theme.typography.commentStyle,
-    fontSize: '14px',
-    fontWeight: 500,
-    opacity: 0.8,
-    marginBottom: 4,
+  noWidow: {
+    whiteSpace: 'nowrap',
   },
 }));
 
@@ -124,19 +119,16 @@ export const Inkhaven2026Banner = () => {
       <div className={classes.root}>
         <div className={classes.imageColumn}>
           <CloudinaryImage2
-            loading="lazy"
+            publicId={INKHAVEN_RESIDENCY_3_BANNER_PUBLIC_ID}
+            objectFit="contain"
+            imgProps={{c: "limit", g: "auto"}}
             className={classes.image}
-            publicId="benitopace_in_an_orb_a_cute_little_mouse_is_sitting_in_its_hot__f27fefa8-6325-448c-befb-04655b8c940e_mvhgw0"
-            darkPublicId="e172921e-982f-4fde-a30d-35837955acb6_l1fdhw"
           />
-          <div className={classes.gradientOverlayDown} />
-          <div className={classes.gradientOverlayLeft} />
         </div>
         <div className={classes.inkhavenBannerText}>
-          <div className={classes.cohortBadge}>Cohort #2</div>
-          <h2><a href="https://www.inkhaven.blog">Inkhaven</a></h2>
+          <h2><a href="https://www.inkhaven.blog">Inkhaven<br /><span className={classes.noWidow}>Residency #3</span></a></h2>
           <div className={classes.inkhavenBannerDateAndLocation}>
-            A month-long writing residency. Publish a blogpost every day for 30 days. April 1–30, 2026 in Berkeley, CA. Scholarships available.
+            A month-long writing residency. Publish a blogpost every day for 30 days. Nov 10–Dec 11, 2026 in Berkeley, CA. <span className={classes.noWidow}>Scholarships available.</span>
           </div>
           <div style={{display: 'inline-block', alignItems: 'center'}}>
             <a href="https://www.inkhaven.blog" target="_blank" rel="noopener noreferrer"><button>Apply Now</button></a>

--- a/packages/lesswrong/components/spotlights/SpotlightItem.tsx
+++ b/packages/lesswrong/components/spotlights/SpotlightItem.tsx
@@ -33,6 +33,7 @@ import range from 'lodash/range';
 import { CommentByIdSuspense } from '../comments/CommentById';
 import { SingleLineCommentPlaceholder } from '../comments/SingleLineComment';
 import { descriptionStyles } from './SpotlightDescriptionStyles';
+import { INKHAVEN_RESIDENCY_3_SPOTLIGHT_ID } from '../seasonal/Inkhaven2026Banner';
 
 import dynamic from 'next/dynamic';
 const SpotlightForm = dynamic(() => import('./SpotlightForm').then(mod => ({ default: mod.SpotlightForm })), { ssr: false });
@@ -309,6 +310,19 @@ const styles = defineStyles("SpotlightItem", (theme: ThemeType) => ({
     transform: "translateX(13%) scale(1.15)", // splash images aren't quite designed for this context and need this adjustment. Scale 1.15 to deal with a few random images that had weird whitespace.
     filter: "brightness(1.2)",
   },
+  splashImageFlush: {
+    transform: "none",
+    filter: "none",
+    [theme.breakpoints.down('xs')]: {
+      // Mobile cards drop the body, so the splash is otherwise a thin strip.
+      // Zoom into the typewriter (lower-right of this splash).
+      height: "240%",
+      width: "auto",
+      top: "auto",
+      bottom: "calc(-42% + 8px)",
+      right: "-6%",
+    },
+  },
   splashImageContainer: {
     position: "absolute",
     top: 0,
@@ -530,7 +544,9 @@ export const SpotlightItem = ({
             </div>
             {/* note: if the height of SingleLineComment ends up changing, this will need to be updated */}
             {spotlight.spotlightSplashImageUrl && <div className={classes.splashImageContainer} style={{height: `calc(100% + ${(spotlightReviews.length ?? 0) * 30}px)`}}>
-              <img src={spotlight.spotlightSplashImageUrl} className={classNames(classes.image, classes.imageFade, classes.splashImage)}/>
+              <img src={spotlight.spotlightSplashImageUrl} className={classNames(classes.image, classes.imageFade, classes.splashImage, {
+                [classes.splashImageFlush]: spotlight._id === INKHAVEN_RESIDENCY_3_SPOTLIGHT_ID,
+              })}/>
             </div>}
             {spotlight.spotlightImageId && <CloudinaryImage2
               publicId={spotlight.spotlightImageId}

--- a/packages/lesswrong/server/resolvers/llmModelResolvers.ts
+++ b/packages/lesswrong/server/resolvers/llmModelResolvers.ts
@@ -71,7 +71,6 @@ async function fetchLlmModelOptions(): Promise<string[]> {
     return [...new Set(featuredModelsFirst(models).map(getDisplayName))];
   } catch (error) {
     captureException(error);
-    console.error("Failed to fetch LLM model options from OpenRouter", error);
     return [];
   }
 }


### PR DESCRIPTION
## Summary
- Replaces the expired Cohort #2 homepage banner with Inkhaven Residency #3 (Nov 10–Dec 11, 2026) through Sep 7.
- Pins spotlight `SbqCm443KuNuxoZKt` on mobile for the same window, with splash placement that crops to the typewriter on phones.
- Uses the Cloudinary art already uploaded; the spotlight row is already in prod (not promoted into the rotating desktop slot).

## Test plan
- [ ] After deploy, desktop homepage (≥1200px) shows the right-side Inkhaven banner with Residency #3 copy and Apply Now.
- [ ] Mobile homepage (<1200px) shows the pinned Inkhaven spotlight (Winter subtitle; body has Max Harms, Scott Sumner, Nov 10–Dec 11).
- [ ] Phone-width card zooms the splash on the typewriter and does not clip the right edge.
- [ ] After Sep 7, both the banner and the mobile pin disappear.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1217976937782299) by [Unito](https://www.unito.io)
