### PR TITLE
Add daily public data dump of all public posts and comments

### DIFF
--- a/app/api/cron/public-data-dump/route.ts
+++ b/app/api/cron/public-data-dump/route.ts
@@ -1,0 +1,20 @@
+import type { NextRequest } from 'next/server';
+import { generatePublicDataDump } from '@/server/publicDataDump';
+import { isLW } from '@/lib/instanceSettings';
+
+export const maxDuration = 800;
+
+export async function GET(request: NextRequest) {
+  const authHeader = request.headers.get('authorization');
+  if (authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
+    return new Response('Unauthorized', { status: 401 });
+  }
+
+  if (!isLW()) {
+    return new Response('OK', { status: 200 });
+  }
+
+  const stats = await generatePublicDataDump();
+
+  return Response.json(stats);
+}

--- a/app/api/public-dump/route.ts
+++ b/app/api/public-dump/route.ts
@@ -1,0 +1,25 @@
+import { list } from '@vercel/blob';
+
+/**
+ * Stable public download URL for the daily public data dump: redirects to the
+ * latest gzipped NDJSON dump in the Vercel Blob store. The dump itself is
+ * produced by the public-data-dump cron route.
+ */
+export async function GET() {
+  if (!process.env.BLOB_READ_WRITE_TOKEN) {
+    return new Response('No data dump available', { status: 404 });
+  }
+
+  const { blobs } = await list({ prefix: 'public-dumps/lesswrong-public-dump-latest', limit: 1 });
+  if (!blobs.length) {
+    return new Response('No data dump available', { status: 404 });
+  }
+
+  return new Response(null, {
+    status: 302,
+    headers: {
+      'Location': blobs[0].url,
+      'Cache-Control': 'public, s-maxage=3600, stale-while-revalidate=86400',
+    },
+  });
+}

--- a/package.json
+++ b/package.json
@@ -162,6 +162,7 @@
     "@types/uuid": "^7.0.2",
     "@types/warning": "^3.0.3",
     "@typescript/native-preview": "^7.0.0-dev.20260527.2",
+    "@vercel/blob": "^2.8.0",
     "@vercel/functions": "^3.1.0",
     "@vercel/sandbox": "2.0.0-beta.21",
     "ai": "^6.0.182",

--- a/packages/lesswrong/lib/generated/routeManifest.ts
+++ b/packages/lesswrong/lib/generated/routeManifest.ts
@@ -347,6 +347,9 @@ export const routeTrie = {
             "every-ten-minutes": {
               "hasRoute": true
             },
+            "public-data-dump": {
+              "hasRoute": true
+            },
             "run-twitter-bot": {
               "hasRoute": true
             },
@@ -373,6 +376,7 @@ export const routeTrie = {
             "every-midnight": "every-midnight",
             "every-minute": "every-minute",
             "every-ten-minutes": "every-ten-minutes",
+            "public-data-dump": "public-data-dump",
             "run-twitter-bot": "run-twitter-bot",
             "update-analytics-collections": "update-analytics-collections",
             "update-missing-post-embeddings": "update-missing-post-embeddings",
@@ -415,6 +419,9 @@ export const routeTrie = {
           "hasRoute": true
         },
         "notificationEvents": {
+          "hasRoute": true
+        },
+        "public-dump": {
           "hasRoute": true
         },
         "quit": {
@@ -656,6 +663,7 @@ export const routeTrie = {
         "mcp": "mcp",
         "notificationcount": "notificationCount",
         "notificationevents": "notificationEvents",
+        "public-dump": "public-dump",
         "quit": "quit",
         "registerclientid": "registerClientId",
         "research": "research",

--- a/packages/lesswrong/server/publicDataDump.ts
+++ b/packages/lesswrong/server/publicDataDump.ts
@@ -1,0 +1,183 @@
+import { createWriteStream } from "fs";
+import { Readable } from "stream";
+import { pipeline } from "stream/promises";
+import { createGzip } from "zlib";
+import { put, copy, list, del, head } from "@vercel/blob";
+import PostsRepo from "./repos/PostsRepo";
+import CommentsRepo from "./repos/CommentsRepo";
+
+const DUMP_PATHNAME_PREFIX = "public-dumps/";
+const LATEST_DUMP_PATHNAME = `${DUMP_PATHNAME_PREFIX}lesswrong-public-dump-latest.ndjson.gz`;
+const MANIFEST_PATHNAME = `${DUMP_PATHNAME_PREFIX}manifest.json`;
+const POSTS_BATCH_SIZE = 400;
+const COMMENTS_BATCH_SIZE = 2000;
+const DUMP_RETENTION_DAYS = 30;
+
+export interface PublicDataDumpOptions {
+  /** Write the gzipped dump to a local file instead of Vercel Blob (for testing via `yarn repl`) */
+  outfile?: string,
+  /** Cap on exported posts (for testing) */
+  postLimit?: number,
+  /** Cap on exported comments (for testing) */
+  commentLimit?: number,
+}
+
+export interface PublicDataDumpStats {
+  posts: number,
+  comments: number,
+  uncompressedBytes: number,
+  compressedBytes: number | null,
+  url: string | null,
+}
+
+/**
+ * Yields the dump as NDJSON lines: one meta line, then one line per public
+ * post, then one line per public comment. Which documents count as public is
+ * decided by the SQL in {@link PostsRepo.getPublicPostsForDump} and
+ * {@link CommentsRepo.getPublicCommentsForDump}; only the fields those
+ * queries select are exported, so nothing non-public (vote data, emails, IPs,
+ * drafts) is ever serialized here.
+ */
+async function* generateDumpLines(
+  options: PublicDataDumpOptions,
+  stats: PublicDataDumpStats,
+): AsyncGenerator<string> {
+  const postsRepo = new PostsRepo();
+  const commentsRepo = new CommentsRepo();
+
+  const metaLine = JSON.stringify({
+    type: "meta",
+    format: 1,
+    site: "https://www.lesswrong.com",
+    generatedAt: new Date().toISOString(),
+    license: "Content is owned by its authors; see each author's profile and lesswrong.com's terms of use.",
+  }) + "\n";
+  stats.uncompressedBytes += metaLine.length;
+  yield metaLine;
+
+  let afterPostId = "";
+  for (;;) {
+    const batch = await postsRepo.getPublicPostsForDump(afterPostId, POSTS_BATCH_SIZE);
+    if (!batch.length) break;
+    for (const row of batch) {
+      const line = JSON.stringify({ type: "post", ...row }) + "\n";
+      stats.posts++;
+      stats.uncompressedBytes += line.length;
+      yield line;
+    }
+    afterPostId = batch[batch.length - 1]._id;
+    if (options.postLimit && stats.posts >= options.postLimit) break;
+  }
+
+  let afterCommentId = "";
+  for (;;) {
+    const batch = await commentsRepo.getPublicCommentsForDump(afterCommentId, COMMENTS_BATCH_SIZE);
+    if (!batch.length) break;
+    for (const row of batch) {
+      const line = JSON.stringify({ type: "comment", ...row }) + "\n";
+      stats.comments++;
+      stats.uncompressedBytes += line.length;
+      yield line;
+    }
+    afterCommentId = batch[batch.length - 1]._id;
+    if (options.commentLimit && stats.comments >= options.commentLimit) break;
+  }
+}
+
+/**
+ * Delete dated dumps older than the retention window. The latest-alias and
+ * manifest blobs are overwritten in place each run and are never pruned.
+ */
+async function pruneOldDumps(): Promise<void> {
+  const cutoff = Date.now() - DUMP_RETENTION_DAYS * 24 * 60 * 60 * 1000;
+  const { blobs } = await list({ prefix: DUMP_PATHNAME_PREFIX, limit: 1000 });
+  const stale = blobs.filter(blob =>
+    blob.pathname !== LATEST_DUMP_PATHNAME &&
+    blob.pathname !== MANIFEST_PATHNAME &&
+    new Date(blob.uploadedAt).getTime() < cutoff
+  );
+  if (stale.length) {
+    await del(stale.map(blob => blob.url));
+  }
+}
+
+/**
+ * Generate the daily public data dump — every publicly-visible post and
+ * comment, serialized as gzipped NDJSON — and upload it to Vercel Blob as a
+ * dated file plus a stable "latest" alias and a small JSON manifest.
+ *
+ * Runs from the public-data-dump cron route. Requires a Vercel Blob store to
+ * be connected to the project (BLOB_READ_WRITE_TOKEN).
+ */
+export async function generatePublicDataDump(options: PublicDataDumpOptions = {}): Promise<PublicDataDumpStats> {
+  const stats: PublicDataDumpStats = {
+    posts: 0,
+    comments: 0,
+    uncompressedBytes: 0,
+    compressedBytes: null,
+    url: null,
+  };
+
+  const source = Readable.from(generateDumpLines(options, stats));
+  const gzip = createGzip({ level: 6 });
+
+  if (options.outfile) {
+    await pipeline(source, gzip, createWriteStream(options.outfile));
+    return stats;
+  }
+
+  if (!process.env.BLOB_READ_WRITE_TOKEN) {
+    throw new Error("BLOB_READ_WRITE_TOKEN is not set; connect a Vercel Blob store to the project before running the public data dump");
+  }
+
+  const dateString = new Date().toISOString().slice(0, 10);
+  const datedPathname = `${DUMP_PATHNAME_PREFIX}lesswrong-public-dump-${dateString}.ndjson.gz`;
+  const uploadPromise = put(datedPathname, gzip, {
+    access: "public",
+    contentType: "application/gzip",
+    addRandomSuffix: false,
+    allowOverwrite: true,
+    multipart: true,
+  });
+
+  let datedBlobUrl: string;
+  try {
+    const [, uploadResult] = await Promise.all([pipeline(source, gzip), uploadPromise]);
+    datedBlobUrl = uploadResult.url;
+  } catch (e) {
+    source.destroy();
+    gzip.destroy();
+    throw e;
+  }
+
+  const [latestBlob, datedBlobDetails] = await Promise.all([
+    copy(datedBlobUrl, LATEST_DUMP_PATHNAME, {
+      access: "public",
+      contentType: "application/gzip",
+      addRandomSuffix: false,
+      allowOverwrite: true,
+    }),
+    head(datedBlobUrl),
+  ]);
+  stats.url = latestBlob.url;
+  stats.compressedBytes = datedBlobDetails.size;
+
+  await put(MANIFEST_PATHNAME, JSON.stringify({
+    generatedAt: new Date().toISOString(),
+    latestUrl: latestBlob.url,
+    datedUrl: datedBlobUrl,
+    posts: stats.posts,
+    comments: stats.comments,
+    uncompressedBytes: stats.uncompressedBytes,
+    compressedBytes: stats.compressedBytes,
+  }, null, 2), {
+    access: "public",
+    contentType: "application/json",
+    addRandomSuffix: false,
+    allowOverwrite: true,
+  });
+
+  await pruneOldDumps();
+
+  return stats;
+}

--- a/packages/lesswrong/server/repos/CommentsRepo.ts
+++ b/packages/lesswrong/server/repos/CommentsRepo.ts
@@ -7,7 +7,7 @@ import orderBy from 'lodash/orderBy';
 import { filterWhereFieldsNotNull } from "../../lib/utils/typeGuardUtils";
 import { recordPerfMetrics } from "./perfMetricWrapper";
 import { isAF } from "../../lib/instanceSettings";
-import { getViewableCommentsSelector, getViewablePostsSelector } from "./helpers";
+import { getPublicDumpPostsSelector, getViewableCommentsSelector, getViewablePostsSelector } from "./helpers";
 import { FeedCommentFromDb, ThreadEngagementStats } from "../../components/ultraFeed/ultraFeedTypes";
 import { REVIEW_YEAR } from "@/lib/reviewUtils";
 
@@ -15,6 +15,23 @@ type ExtendedCommentWithReactions = DbComment & {
   yourVote?: string,
   theirVote?: string,
   userVote?: string,
+}
+
+export interface PublicDumpCommentRow {
+  _id: string,
+  postId: string,
+  parentCommentId: string | null,
+  topLevelCommentId: string | null,
+  userId: string | null,
+  author: string | null,
+  authorSlug: string | null,
+  postedAt: Date,
+  baseScore: number | null,
+  voteCount: number | null,
+  answer: boolean,
+  shortform: boolean,
+  af: boolean,
+  html: string | null,
 }
 
 class CommentsRepo extends AbstractRepo<"Comments"> {
@@ -823,6 +840,42 @@ class CommentsRepo extends AbstractRepo<"Comments"> {
     });
 
     return engagementStats;
+  }
+
+  /**
+   * One keyset-paginated batch of publicly-visible comments for the public
+   * data dump. Includes shortform and debate-response comments; requires the
+   * parent post to itself be publicly dumped, so comments on drafts, unlisted
+   * posts, etc. are excluded (as are tag-discussion comments, which have no
+   * postId). Older comments predating the Revisions table store their content
+   * inline in "contents", hence the COALESCE. Ordered by _id; pass the last
+   * _id of the previous batch as `after` (empty string for the first batch).
+   */
+  async getPublicCommentsForDump(after: string, limit: number): Promise<PublicDumpCommentRow[]> {
+    return this.getRawDb().manyOrNone(`
+      -- CommentsRepo.getPublicCommentsForDump
+      SELECT
+        c."_id", c."postId", c."parentCommentId", c."topLevelCommentId", c."userId",
+        CASE WHEN u."deleted" THEN NULL ELSE u."displayName" END AS "author",
+        CASE WHEN u."deleted" THEN NULL ELSE u."slug" END AS "authorSlug",
+        c."postedAt",
+        CASE WHEN c."hideKarma" THEN NULL ELSE c."baseScore" END AS "baseScore",
+        CASE WHEN c."hideKarma" THEN NULL ELSE c."voteCount" END AS "voteCount",
+        c."answer", c."shortform", c."af",
+        COALESCE(r."html", c."contents"->>'html') AS "html"
+      FROM "Comments" c
+      JOIN "Posts" p ON p."_id" = c."postId"
+      LEFT JOIN "Revisions" r ON r."_id" = c."contents_latest"
+      LEFT JOIN "Users" u ON u."_id" = c."userId"
+      WHERE c."_id" > $(after)
+      AND c."deleted" IS NOT TRUE
+      AND c."rejected" IS NOT TRUE
+      AND c."draft" IS NOT TRUE
+      AND c."authorIsUnreviewed" IS NOT TRUE
+      AND ${getPublicDumpPostsSelector("p")}
+      ORDER BY c."_id"
+      LIMIT $(limit)
+    `, { after, limit });
   }
 }
 

--- a/packages/lesswrong/server/repos/PostsRepo.ts
+++ b/packages/lesswrong/server/repos/PostsRepo.ts
@@ -1,6 +1,6 @@
 import Posts from "../../server/collections/posts/collection";
 import AbstractRepo from "./AbstractRepo";
-import { getViewableEventsSelector, getViewablePostsSelector } from "./helpers";
+import { getPublicDumpPostsSelector, getViewableEventsSelector, getViewablePostsSelector } from "./helpers";
 import { recordPerfMetrics } from "./perfMetricWrapper";
 import { isAF } from "../../lib/instanceSettings";
 import {FilterPostsForReview} from '@/components/bookmarks/ReadHistoryTab'
@@ -15,6 +15,27 @@ type DbPostWithContents = DbPost & {contents?: DbRevision | null};
 type MeanPostKarma = {
   _id: number,
   meanKarma: number,
+}
+
+export interface PublicDumpPostRow {
+  _id: string,
+  title: string,
+  slug: string,
+  postedAt: Date,
+  userId: string | null,
+  author: string | null,
+  authorSlug: string | null,
+  url: string | null,
+  question: boolean,
+  isEvent: boolean,
+  shortform: boolean,
+  af: boolean,
+  baseScore: number,
+  voteCount: number,
+  commentCount: number | null,
+  curatedDate: Date | null,
+  frontpageDate: Date | null,
+  html: string | null,
 }
 
 const constructFilters = (
@@ -1068,6 +1089,33 @@ class PostsRepo extends AbstractRepo<"Posts"> {
       LIMIT 1
     `);
     return row?.curatedDate ?? null;
+  }
+
+  /**
+   * One keyset-paginated batch of publicly-visible posts for the public data
+   * dump, with the latest revision's html and the author's public identity.
+   * Ordered by _id; pass the last _id of the previous batch as `after` (empty
+   * string for the first batch).
+   */
+  async getPublicPostsForDump(after: string, limit: number): Promise<PublicDumpPostRow[]> {
+    return this.getRawDb().manyOrNone(`
+      -- PostsRepo.getPublicPostsForDump
+      SELECT
+        p."_id", p."title", p."slug", p."postedAt", p."userId",
+        CASE WHEN u."deleted" THEN NULL ELSE u."displayName" END AS "author",
+        CASE WHEN u."deleted" THEN NULL ELSE u."slug" END AS "authorSlug",
+        p."url", p."question", p."isEvent", p."shortform", p."af",
+        p."baseScore", p."voteCount", p."commentCount",
+        p."curatedDate", p."frontpageDate",
+        r."html"
+      FROM "Posts" p
+      LEFT JOIN "Revisions" r ON r."_id" = p."contents_latest"
+      LEFT JOIN "Users" u ON u."_id" = p."userId"
+      WHERE p."_id" > $(after)
+      AND ${getPublicDumpPostsSelector("p")}
+      ORDER BY p."_id"
+      LIMIT $(limit)
+    `, { after, limit });
   }
 }
 

--- a/packages/lesswrong/server/repos/helpers.ts
+++ b/packages/lesswrong/server/repos/helpers.ts
@@ -55,6 +55,28 @@ export const getViewableTagsSelector = (tagsTableAlias?: string) => {
   `;
 }
 
+/**
+ * Posts included in the public data dump: everything a logged-out user could
+ * read via a direct link (mirroring `postCheckAccess`), including events and
+ * shortform containers, but excluding unlisted posts (which are deliberately
+ * de-discoverable) and rejected posts. Unlike `getViewablePostsSelector`,
+ * which encodes what appears in listings, this encodes what is public.
+ */
+export const getPublicDumpPostsSelector = (postsTableAlias?: string) => {
+  const aliasPrefix = postsTableAlias ? `${postsTableAlias}.` : "";
+  return `
+    ${aliasPrefix}"status" = ${postStatuses.STATUS_APPROVED} AND
+    ${aliasPrefix}"draft" IS NOT TRUE AND
+    ${aliasPrefix}"deletedDraft" IS NOT TRUE AND
+    ${aliasPrefix}"isFuture" IS NOT TRUE AND
+    ${aliasPrefix}"rejected" IS NOT TRUE AND
+    ${aliasPrefix}"authorIsUnreviewed" IS NOT TRUE AND
+    ${aliasPrefix}"unlisted" IS NOT TRUE AND
+    ${aliasPrefix}"onlyVisibleToLoggedIn" IS NOT TRUE AND
+    ${aliasPrefix}"postedAt" IS NOT NULL
+  `;
+};
+
 export const getViewableCommentsSelector = (commentsTableAlias?: string) => {
   const aliasPrefix = commentsTableAlias ? `${commentsTableAlias}.` : "";
   return `

--- a/vercel.json
+++ b/vercel.json
@@ -41,5 +41,8 @@
   }, {
     "path": "/api/cron/curation-status-to-slack",
     "schedule": "0 19 * * *"
+  }, {
+    "path": "/api/cron/public-data-dump",
+    "schedule": "0 9 * * *"
   }]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8772,6 +8772,33 @@
   resolved "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz"
   integrity sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==
 
+"@vercel/blob@^2.8.0":
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/@vercel/blob/-/blob-2.8.0.tgz#64b68d35ed5eba236f7375157ba1396a07968168"
+  integrity sha512-Nu+HWKpkgovCh/ezlG7wCVwF7RErTzLzZMbGKFBdGBCbTKyK+s5VXPLl+0+TpNEQPH8AVaGzOpIsXUOtkqylCQ==
+  dependencies:
+    "@vercel/oidc" "^3.6.1"
+    async-retry "^1.3.3"
+    is-buffer "^2.0.5"
+    is-node-process "^1.2.0"
+    throttleit "^2.1.0"
+    undici "^6.23.0"
+
+"@vercel/cli-config@0.2.4":
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/@vercel/cli-config/-/cli-config-0.2.4.tgz#59f6f1ecf4f4511db0c7d3459edd30fe7c737ddc"
+  integrity sha512-kZ5SojbrV06GHoU6QIWGwDXLov+s9rWZ7QqdqKfJfBGCNUieGfgaCjeeenNy8Y+QC0bwC0dZ2B4l5Hvdmrgpdw==
+  dependencies:
+    xdg-app-paths "5"
+    zod "4.1.11"
+
+"@vercel/cli-exec@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@vercel/cli-exec/-/cli-exec-1.0.1.tgz#5b1d1e8b2dd6909ab810d5e5ee990e6263a0f5a9"
+  integrity sha512-g9XerViJ/paZujufXYcu5XYI2vU2rtB4sgdpjUHde5RnOkdmpu0ngH46LCFGHoPXO/C+qDPSczIHIRN+8Q2YKQ==
+  dependencies:
+    execa "5.1.1"
+
 "@vercel/functions@^3.1.0":
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/@vercel/functions/-/functions-3.1.0.tgz#1301f016e98434e179a0808bba9e764881f6b7ca"
@@ -8796,6 +8823,15 @@
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/@vercel/oidc/-/oidc-3.2.0.tgz#5782a4d4904443f015808705b5537cf9c3b68528"
   integrity sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==
+
+"@vercel/oidc@^3.6.1":
+  version "3.8.5"
+  resolved "https://registry.yarnpkg.com/@vercel/oidc/-/oidc-3.8.5.tgz#24a500f9b60dff4649cf5e6cfc568eba3de6918b"
+  integrity sha512-RwXYtnt6za+5UO4IaLywN/6B95AlLqynPRUWRJxeJ/qufwkcLUbZNUxYtzT0uMpuraWhlNcGqPNGkTnZr4BGBw==
+  dependencies:
+    "@vercel/cli-config" "0.2.4"
+    "@vercel/cli-exec" "1.0.1"
+    jose "^5.9.6"
 
 "@vercel/sandbox@2.0.0-beta.21":
   version "2.0.0-beta.21"
@@ -9508,7 +9544,7 @@ async-limiter@~1.0.0:
   resolved "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz"
   integrity sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==
 
-async-retry@1.3.3:
+async-retry@1.3.3, async-retry@^1.3.3:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/async-retry/-/async-retry-1.3.3.tgz#0e7f36c04d8478e7a58bdbed80cedf977785f280"
   integrity sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==
@@ -13031,7 +13067,7 @@ eventsource@^3.0.2:
   dependencies:
     eventsource-parser "^3.0.1"
 
-execa@^5.0.0:
+execa@5.1.1, execa@^5.0.0:
   version "5.1.1"
   resolved "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz"
   integrity sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==
@@ -14985,7 +15021,7 @@ is-boolean-object@^1.2.1:
     call-bound "^1.0.3"
     has-tostringtag "^1.0.2"
 
-is-buffer@^2.0.2:
+is-buffer@^2.0.2, is-buffer@^2.0.5:
   version "2.0.5"
   resolved "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz"
   integrity sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==
@@ -15165,6 +15201,11 @@ is-negative-zero@^2.0.3:
   version "2.0.3"
   resolved "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz"
   integrity sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==
+
+is-node-process@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/is-node-process/-/is-node-process-1.2.0.tgz#ea02a1b90ddb3934a19aea414e88edef7e11d134"
+  integrity sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==
 
 is-number-object@^1.0.4:
   version "1.0.7"
@@ -15981,6 +16022,11 @@ jiti@^2.3.0:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/jiti/-/jiti-2.6.1.tgz#178ef2fc9a1a594248c20627cd820187a4d78d92"
   integrity sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==
+
+jose@^5.9.6:
+  version "5.10.0"
+  resolved "https://registry.yarnpkg.com/jose/-/jose-5.10.0.tgz#c37346a099d6467c401351a9a0c2161e0f52c4be"
+  integrity sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==
 
 jose@^6.1.3:
   version "6.1.3"
@@ -21525,7 +21571,7 @@ three-slippy-map-globe@1:
   resolved "https://registry.yarnpkg.com/three/-/three-0.181.0.tgz#3cdd7784803649ce9a564215591f19364fe08473"
   integrity sha512-KGf6EOCOQGshXeleKxpxhbowQwAXR2dLlD93egHtZ9Qmk07Saf8sXDR+7wJb53Z1ORZiatZ4WGST9UsVxhHEbg==
 
-throttleit@2.1.0:
+throttleit@2.1.0, throttleit@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/throttleit/-/throttleit-2.1.0.tgz#a7e4aa0bf4845a5bd10daa39ea0c783f631a07b4"
   integrity sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==
@@ -22110,6 +22156,11 @@ undici@^5.5.1:
   integrity sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==
   dependencies:
     "@fastify/busboy" "^2.0.0"
+
+undici@^6.23.0:
+  version "6.28.0"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-6.28.0.tgz#9f0e385744fef5021d6596c5bccd783f61193c1c"
+  integrity sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==
 
 undici@^7.16.0:
   version "7.25.0"
@@ -22852,6 +22903,14 @@ ws@^8.18.0:
   resolved "https://registry.yarnpkg.com/ws/-/ws-8.20.0.tgz#4cd9532358eba60bc863aad1623dfb045a4d4af8"
   integrity sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==
 
+xdg-app-paths@5:
+  version "5.5.1"
+  resolved "https://registry.yarnpkg.com/xdg-app-paths/-/xdg-app-paths-5.5.1.tgz#2d5e94218c6fc4e9b742503889dfd29bbd336b8c"
+  integrity sha512-hI3flOB4PLZIy5prbtTpirobtPE2ZtZ52szO+2mM9Efp6ErM398La+C1lIpNWDfNoQk+6Lsi6nMcCwVB7pxeMQ==
+  dependencies:
+    os-paths "^4.0.1"
+    xdg-portable "^7.2.0"
+
 xdg-app-paths@5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/xdg-app-paths/-/xdg-app-paths-5.1.0.tgz#f52f724f91e88244148c085c09bcd396443d8cae"
@@ -22859,7 +22918,7 @@ xdg-app-paths@5.1.0:
   dependencies:
     xdg-portable "^7.0.0"
 
-xdg-portable@^7.0.0:
+xdg-portable@^7.0.0, xdg-portable@^7.2.0:
   version "7.3.0"
   resolved "https://registry.yarnpkg.com/xdg-portable/-/xdg-portable-7.3.0.tgz#c6b1610de806a2ca1fe65727d5f8402c295d2e96"
   integrity sha512-sqMMuL1rc0FmMBOzCpd0yuy9trqF2yTTVe+E9ogwCSWQCdDEtQUwrZPT6AxqtsFGRNxycgncbP/xmOOSPw5ZUw==
@@ -23035,6 +23094,11 @@ zod@3.24.4:
   version "3.24.4"
   resolved "https://registry.yarnpkg.com/zod/-/zod-3.24.4.tgz#e2e2cca5faaa012d76e527d0d36622e0a90c315f"
   integrity sha512-OdqJE9UDRPwWsrHjLN2F8bPxvwJBK22EHLWtanu0LSYr5YqzsaaW3RMgmjwr8Rypg5k+meEJdSPXJZXE/yqOMg==
+
+zod@4.1.11:
+  version "4.1.11"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-4.1.11.tgz#4aab62f76cfd45e6c6166519ba31b2ea019f75f5"
+  integrity sha512-WPsqwxITS2tzx1bzhIKsEs19ABD5vmCVa4xBo2tq/SrV4RNZtfws1EnCWQXM6yh8bD08a1idvkB5MZSBiZsjwg==
 
 zod@^3.22.4:
   version "3.24.2"


### PR DESCRIPTION
Adds a daily cron that dumps every publicly-visible LessWrong post and comment to a gzipped NDJSON file on Vercel Blob, publicly downloadable at a stable URL (`/api/public-dump` redirects to the latest dump).

## What it does

- `packages/lesswrong/server/publicDataDump.ts` — streams keyset-paginated batches from Postgres through gzip into a Vercel Blob multipart upload (constant memory, no buffering). Uploads a dated file (`public-dumps/lesswrong-public-dump-YYYY-MM-DD.ndjson.gz`), a stable `-latest` alias, and a small `manifest.json` (counts, sizes, URLs). Dated dumps older than 30 days are pruned.
- `PostsRepo.getPublicPostsForDump` / `CommentsRepo.getPublicCommentsForDump` — the batch queries. Public metadata + latest-revision html only; no emails, votes, IPs, or drafts are ever selected. Note ~690k pre-Revisions-table comments store content inline in `Comments.contents`, hence the `COALESCE` — a plain Revisions join would silently drop two-thirds of all comments.
- `getPublicDumpPostsSelector` in `repos/helpers.ts` — a dump-specific visibility selector mirroring `postCheckAccess` for logged-out users (unlike `getViewablePostsSelector`, which encodes listing visibility and would have excluded all shortform).
- `app/api/cron/public-data-dump/route.ts` (+ `vercel.json` schedule, daily 09:00 UTC) — standard `CRON_SECRET`-authed cron route, LW-only, `maxDuration = 800`.
- `app/api/public-dump/route.ts` — stable download URL; 302 to the latest blob.

## Validated against the dev DB

Full export run via `yarn repl dev lw` from a sandbox: **59,058 posts + 1,055,047 comments, 2.46 GB uncompressed → 681 MB gzipped, ~7 minutes** end-to-end (cross-region; in-region prod should be faster, comfortably within the 800s route cap). Line counts reconcile exactly with the queries' totals.

## Setup required before this works in prod

1. Vercel dashboard → Storage → create a **Blob** store and connect it to the project, so `BLOB_READ_WRITE_TOKEN` is injected. That's the only manual step; until then the cron route errors with a clear message and `/api/public-dump` 404s.
2. Confirm the project can use `maxDuration = 800` (requires fluid compute; otherwise lower the cap or move the job out of Vercel).

Cost ballpark: ~680 MB/day with 30-day retention ≈ 20 GB stored (~$0.50/mo) plus Blob egress for downloads.

## Filtering decisions to review

- **Excluded**: drafts/deleted drafts, unpublished (`status != approved`), `isFuture`, **rejected** posts and comments, unreviewed-author content, `onlyVisibleToLoggedIn`, **unlisted** posts (link-accessible but deliberately de-discoverable — debatable), deleted comments, comments on any excluded post, and tag-discussion comments (no `postId`; could be added later).
- **Included**: events, shortform containers and shortform comments, debate-response comments (old-style dialogues live there).
- **Masked**: author name/slug nulled for deleted accounts; comment karma nulled where `hideKarma` (post's `hideCommentKarma`) is set.
- Latest revision only — no revision history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1217997844892770) by [Unito](https://www.unito.io)
