### PR TITLE
Bump research sandbox agent to Fable 5.1 and Claude Code 2.1.257

### DIFF
--- a/packages/lesswrong/server/research/sandbox/sandboxLayout.ts
+++ b/packages/lesswrong/server/research/sandbox/sandboxLayout.ts
@@ -36,9 +36,9 @@ export const CLAUDE_MD_PATH = `${CLAUDE_DIR}/CLAUDE.md`;
  * this, rebuild the baseline snapshots, and existing sandboxes reconcile on
  * their next launch.
  */
-export const PINNED_CLAUDE_CODE_VERSION = "2.1.207";
+export const PINNED_CLAUDE_CODE_VERSION = "2.1.257";
 
 /** The model the research agent runs (`claude --model ...`). Requires a CLI
  * version that knows the model family — see PINNED_CLAUDE_CODE_VERSION. */
-export const RESEARCH_AGENT_MODEL = "claude-fable-5";
+export const RESEARCH_AGENT_MODEL = "claude-fable-5-1";
 // export const RESEARCH_AGENT_MODEL = "claude-opus-4-8";


### PR DESCRIPTION
Updates the two pins in `sandboxLayout.ts` for the /research sandboxes:

- `RESEARCH_AGENT_MODEL`: `claude-fable-5` → `claude-fable-5-1`
- `PINNED_CLAUDE_CODE_VERSION`: `2.1.207` → `2.1.257` (current npm latest)

No other code changes needed. The deploy build regenerates the supervisor bundle (which bakes in the model), and the launch path overlays it and reconciles the CLI version, so existing and fresh sandboxes pick up both changes on their next launch after deploy.

**After deploy**, rebuild the baseline snapshots so fresh provisions don't pay the npm upgrade cost on boot, once per runtime with a `SandboxBaselineSnapshots` row:

```
yarn research-supervisor-build
yarn repl prod lw packages/lesswrong/server/scripts/buildResearchSandboxSnapshot.ts 'buildResearchSandboxSnapshot({ runtime: "node24", noExpire: true })'
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019HPk1vM5rJq2kFy2VM5RZq

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1218071722997769) by [Unito](https://www.unito.io)
