### PR TITLE
Fix doubled ToC heading when a block has nested <strong> and <b>

### DIFF
--- a/packages/lesswrong/lib/tableOfContents.ts
+++ b/packages/lesswrong/lib/tableOfContents.ts
@@ -106,6 +106,10 @@ export function extractTableOfContents({
 
   let headings: Array<ToCSection> = [];
   let usedAnchors: Record<string, boolean> = {};
+  // Elements that have already been accepted as headings. Used to avoid
+  // counting a heading twice when heading tags are nested, eg
+  // <p><strong><b>Heading</b></strong></p>.
+  const acceptedHeadingElements: HTMLElement[] = [];
 
   // First, find the headings in the document, create a linear list of them,
   // and insert anchors at each one.
@@ -117,6 +121,12 @@ export function extractTableOfContents({
     // Skip headings inside spoiler/collapsible content or code blocks; those
     // are hidden or literal content and should not appear in the ToC.
     if (element.closest('.spoilers, .spoiler, .detailsBlockContent, pre, code')) {
+      continue;
+    }
+    // Skip elements nested inside an element that was already counted as a
+    // heading; querySelectorAll returns ancestors before descendants, so the
+    // outer element is always the one that's kept.
+    if (isInsideAcceptedHeading(element, acceptedHeadingElements)) {
       continue;
     }
     let tagName = element.tagName.toLowerCase();
@@ -135,6 +145,7 @@ export function extractTableOfContents({
       let anchor = titleToAnchor(title, usedAnchors);
       usedAnchors[anchor] = true;
       element.id = anchor;
+      acceptedHeadingElements.push(element);
       headings.push({
         title: title,
         anchor: anchor,
@@ -183,6 +194,10 @@ export function extractTableOfContents({
     html: document.body.innerHTML,
     sections: headings,
   };
+}
+
+function isInsideAcceptedHeading(element: HTMLElement, acceptedHeadingElements: HTMLElement[]): boolean {
+  return acceptedHeadingElements.some(heading => heading !== element && heading.contains(element));
 }
 
 /**

--- a/packages/lesswrong/unitTests/tableOfContents.tests.ts
+++ b/packages/lesswrong/unitTests/tableOfContents.tests.ts
@@ -115,6 +115,28 @@ describe("extractTableOfContents", () => {
     });
   });
 
+  it("Regression: <b> nested inside <strong> counts as a single heading", () => {
+    const html = normalizeHtml(`
+      <p><strong><b>Doubly bold</b></strong></p>
+      <p>Some content</p>
+      <p><b><strong>Bold twice again</strong></b></p>
+    `);
+    const { document, window } = parseDocumentFromString(html);
+    const tocData = extractTableOfContents({ document, window });
+    expect(tocData).toEqual({
+      html: normalizeHtml(`
+        <p><strong id="Doubly_bold"><b>Doubly bold</b></strong></p>
+        <p>Some content</p>
+        <p><b id="Bold_twice_again"><strong>Bold twice again</strong></b></p>
+      `),
+      sections: [
+        { title: "Doubly bold", anchor: "Doubly_bold", level: 1 },
+        { title: "Bold twice again", anchor: "Bold_twice_again", level: 1 },
+        { anchor: "postHeadingsDivider", divider: true, level: 0 },
+      ],
+    });
+  });
+
   it("Regression: Trailing whitespace counts towards anchor", () => {
     const html = `<p><strong>DanielFilan ($23,544):&#160; Funding to produce 12 more AXRP episodes, the AI X-risk Podcast.&#160; </strong></p>`;
 


### PR DESCRIPTION
<details>
<summary>Prompts Used</summary>

User: In Lexical, deleting a table that's the last thing in the document, by placing the cursor after it and pressing backspace, crashes with: `Uncaught Error: Expected node with key 193 to exist but it's not in the nodeMap.` (the key number varies), after which the editor JS breaks.

Fable 5.1:

> Fixed. The crash is a known upstream bug in `@lexical/table` 0.44 ([facebook/lexical#8670](https://github.com/facebook/lexical/issues/8670)); I reproduced it in a unit test and added an app-level workaround, since the real fix only ships in lexical 0.46.
>
> **Root cause:** With scrollable tables active (our `tableHorizontalScroll: true`), pressing ArrowDown while the selection is outside a table makes `@lexical/table` record that table's node key in `shouldCheckSelectionForTable` — part of a Firefox caret-placement workaround. The key is consumed by the *next* `SELECTION_CHANGE_COMMAND`, via `$getNodeByKeyOrThrow`. Normally the ArrowDown moves the caret and the resulting selection change consumes the key immediately. But when the cursor is after a trailing table (in the sentinel paragraph our `BlockCursorNavigationPlugin` maintains there), ArrowDown can't move the caret, so no selection change happens and the key stays pending. Backspace then deletes the table, and the selection change triggered by the deletion dereferences the dead key — the "Expected node with key N to exist" throw, with the key varying because it's the deleted table's key. The throw escapes mid-selection-change handling, which is why the editor stays broken afterward.
>
> **What I did:**
>
> - `packages/lesswrong/unitTests/tableBackspaceDelete.tests.tsx` — a jsdom test mounting the real plugins (vendored `TablePlugin` with horizontal scroll, `BlockCursorNavigationPlugin`, and a variant with the Yjs `CollaborationPlugin` on a fake in-memory provider). The ArrowDown→backspace→selection-change sequence reproduced the exact error before the fix; all four scenarios pass now, and the tests also verify the table actually gets deleted and that later edits still work.
> - `packages/lesswrong/components/editor/lexicalPlugins/tables/TableDeleteCrashWorkaroundPlugin.tsx` (mounted in `Editor.tsx` next to `TablesPlugin`) — before backspace/delete/undo/redo, if an ArrowDown happened with no selection change since (the only state where the stale key can be pending), it dispatches a synthetic `SELECTION_CHANGE_COMMAND` so the pending key is consumed while the table still exists, which is a harmless no-op. It never fires during normal editing.
> - `notes/lexical-upgrade-for-table-stale-key-bug.md` — the proper fix is upgrading lexical to ≥0.46 (upstream PR [#8674](https://github.com/facebook/lexical/pull/8674), which also fixes a second "poisoned observer registry" variant that can't be worked around from app code); the note says to delete the workaround plugin then and keep the regression test.
>
> `yarn tsc` is clean apart from pre-existing errors in your locally-modified `Layout.tsx` (`WrapperComponentThatIsNew` undefined), which predate this session. One caveat: I verified the fix via the unit-test harness, not in a live browser — worth a quick manual check that backspace-deleting a trailing table now works in the real editor.
<hr>
A post with a section heading wrapped in both <strong> and <b> winds up with two copies of that heading in the ToC. Fix, and, if the bug wasn't always there, determine when it was introduced.

> Fixed, with a regression test, and the bug is dated.
>
> **Cause.** In `packages/lesswrong/lib/tableOfContents.ts`, `extractTableOfContents` queries for `h1,h2,h3,h4,strong,b` and gets back both the outer `<strong>` and the inner `<b>`. The whole-paragraph check accepted each of them independently, because each is the sole content of its parent and its text equals the paragraph's text. So both got an anchor and a ToC entry.
>
> **Fix.** The extraction loop now records each element it accepts as a heading and skips any later candidate that is nested inside one of them. Since `querySelectorAll` returns ancestors before descendants, the outer element is the one kept, so the anchor lands on the `<strong>`. This also covers `<b><strong>`, `<strong><strong>`, and similar nestings.
>
> **Test.** Added a case to `packages/lesswrong/unitTests/tableOfContents.tests.ts` covering both nesting orders. It fails on the old code and passes with the fix. The full file passes and `yarn tsc` is clean.
>
> **When it was introduced.** The bug was not always there. The original 2018 code required a `<strong>` or `<b>` to have a `<p>` as its direct parent, which excluded the inner tag. Commit 9c62824fa9 ("Improve tagIsWholeParagraph heuristics", 2022-07-03, merged to master in PR #5159 on 2022-07-06) replaced that with a check that the tag's siblings are all the same tag type and that the enclosing paragraph's text matches, which the inner tag also satisfies. The 2024 DOM rewrite (PR merged 2024-04-03) ported the same logic faithfully, so the double entry has existed since July 2022.
>
> Nothing is committed. The two modified files are ready for review.
</details>

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1218170525486053) by [Unito](https://www.unito.io)
