### PR TITLE
Match LLM blocks to comment text

### DIFF
--- a/packages/lesswrong/components/common/ContentStylesValues.ts
+++ b/packages/lesswrong/components/common/ContentStylesValues.ts
@@ -132,6 +132,11 @@ export const styles = defineStyles("ContentStyles", (theme: ThemeType) => ({
   },
   commentBody: {
     ...commentBodyStyles(theme),
+    '&& .llm-content-block': {
+      // LLM blocks use a slightly larger font in posts, but in comments the
+      // generated text should match the surrounding comment's size.
+      fontSize: 'inherit',
+    },
   },
   commentBodyExceptPointerEvents: {
     ...commentBodyStyles(theme, true)


### PR DESCRIPTION
Slack: https://lightconeinfrastructure.slack.com/archives/C75BWSNBH/p1788476167929289
Diff: https://github.com/ForumMagnum/ForumMagnum/compare/master...fix-comment-llm-style
Preview deployment: `https://baserates-test-git-fix-comment-llm-style-lesswrong.vercel.app`

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1218193073896984) by [Unito](https://www.unito.io)
