### PR TITLE
Fix UltraFeed seen state, source filtering, and pagination

### DIFF
--- a/packages/lesswrong/components/common/MixedTypeFeed.tsx
+++ b/packages/lesswrong/components/common/MixedTypeFeed.tsx
@@ -30,6 +30,7 @@ export const MixedTypeFeed = <
   
   // Variables for the query (excluding pagination variables which are managed internally)
   variables: Omit<VariablesOf<TQuery>, 'cutoff' | 'offset' | 'limit'>,
+  getPaginationVariables?: (results: Array<{ type: string; [key: string]: unknown }>) => Record<string, unknown>,
   
   // Renderers to convert results into React nodes.
   renderers: ExtractRenderers<TQuery>,
@@ -74,6 +75,7 @@ export const MixedTypeFeed = <
   const {
     query,
     variables,
+    getPaginationVariables,
     renderers,
     firstPageSize=20,
     pageSize=20,
@@ -141,6 +143,7 @@ export const MixedTypeFeed = <
         void fetchMore({
           variables: {
             ...variables,
+            ...getPaginationVariables?.(data[resolverName].results ?? []),
             cutoff: data[resolverName].cutoff,
             offset: data[resolverName].endOffset,
             limit: pageSize,
@@ -235,5 +238,4 @@ function elementIsNearVisible(element: HTMLElement|null, distance: number) {
   const windowHeight = window.innerHeight;
   return (top-distance) <= windowHeight;
 }
-
 

--- a/packages/lesswrong/components/ultraFeed/UltraFeed.tsx
+++ b/packages/lesswrong/components/ultraFeed/UltraFeed.tsx
@@ -206,7 +206,7 @@ const UltraFeedContent = ({
   const classes = useStyles(styles);
   const currentUser = useCurrentUser();
 
-  const { openDialog } = useDialog();
+  const { openDialog, isDialogOpen } = useDialog();
   const { captureEvent } = useTracking();
   const [sessionId] = useState<string>(randomId);
   const refetchForYouRef = useRef<null | ObservableQuery['refetch']>(null);
@@ -255,7 +255,7 @@ const UltraFeedContent = ({
     <AnalyticsContext pageSectionContext="ultraFeed" ultraFeedContext={{ feedSessionId: sessionId }}>
       <AnalyticsInViewTracker eventProps={{inViewType: "ultraFeed"}}>
       <div className={classes.root} ref={feedContainerRef}>
-        <UltraFeedObserverProvider incognitoMode={resolverSettings.incognitoMode}>
+        <UltraFeedObserverProvider incognitoMode={resolverSettings.incognitoMode} activeFeedType={activeTab} paused={isDialogOpen}>
         <OverflowNavObserverProvider>
             {settingsVisible && (
               <div className={useExternalContainer ? classes.settingsContainerExternal : classes.settingsContainer}>

--- a/packages/lesswrong/components/ultraFeed/UltraFeedDebugItem.tsx
+++ b/packages/lesswrong/components/ultraFeed/UltraFeedDebugItem.tsx
@@ -347,6 +347,13 @@ export const UltraFeedDebugThreadItem = ({ item }: { item: FeedCommentThreadFrag
       <div className={classes.type}>{firstComment?.shortform ? 'quick take' : 'thread'}</div>
       <div className={classes.title}>
         <DebugContentLink url={url}>{title}</DebugContentLink>
+        {metadata?.rankedItemType === 'commentThread' && metadata.preselection && (
+          <div>
+            Preselection: #{metadata.preselection.rank}, score {metadata.preselection.score.toFixed(3)};
+            {' '}{metadata.preselection.selected ? 'eligible' : metadata.preselection.reasons.join(', ')}
+            {' '}(limit {metadata.preselection.candidateLimit})
+          </div>
+        )}
       </div>
       <div className={classes.sources}>{formatSources(firstCommentMeta?.sources ?? item.postSources)}</div>
     </div>

--- a/packages/lesswrong/components/ultraFeed/UltraFeedMainFeed.tsx
+++ b/packages/lesswrong/components/ultraFeed/UltraFeedMainFeed.tsx
@@ -75,6 +75,8 @@ const UltraFeedMainFeed = ({
     settings: JSON.stringify({ ...settings.resolverSettings, debugMode, diversityContext: buildUltraFeedDiversityContext(results) }),
   }), [settings, debugMode]);
   const debugHeader = useMemo(() => debugMode ? (
+    <>
+    <p>Thread candidates show their preselection score and exclusion reasons. This shows the best path per root from the initial candidate pool, including threads excluded before final ranking. Earlier database filters and discarded alternative paths are not shown. Topic affinity, replies-to-you, and own-post bonuses are not implemented.</p>
     <UltraFeedDebugHeader
       sortField={debugSortField}
       sortDirection={debugSortDirection}
@@ -83,6 +85,7 @@ const UltraFeedMainFeed = ({
         setDebugSortDirection(direction);
       }}
     />
+    </>
   ) : undefined, [debugMode, debugSortField, debugSortDirection]);
   const debugSortResults = useMemo(() => debugMode
     ? (a: UltraFeedDebugResult, b: UltraFeedDebugResult) => compareUltraFeedDebugResults(a, b, debugSortField, debugSortDirection)
@@ -114,4 +117,3 @@ const UltraFeedMainFeed = ({
 };
 
 export default UltraFeedMainFeed;
-

--- a/packages/lesswrong/components/ultraFeed/UltraFeedMainFeed.tsx
+++ b/packages/lesswrong/components/ultraFeed/UltraFeedMainFeed.tsx
@@ -7,6 +7,7 @@ import type { UltraFeedSettingsType } from './ultraFeedSettingsTypes';
 import type { FeedType } from './ultraFeedTypes';
 import type { ObservableQuery, WatchQueryFetchPolicy } from '@apollo/client';
 import { randomId } from '../../lib/random';
+import { buildUltraFeedDiversityContext } from '@/lib/ultraFeedDiversity';
 import { defineStyles, useStyles } from '../hooks/useStyles';
 import {
   compareUltraFeedDebugResults,
@@ -70,6 +71,9 @@ const UltraFeedMainFeed = ({
   }), [actualSessionId, settings, debugMode]);
 
   const renderers = useMemo(() => createUltraFeedRenderers({ settings, debugMode }), [settings, debugMode]);
+  const getPaginationVariables = useCallback((results: Array<{ type: string; [key: string]: unknown }>) => ({
+    settings: JSON.stringify({ ...settings.resolverSettings, debugMode, diversityContext: buildUltraFeedDiversityContext(results) }),
+  }), [settings, debugMode]);
   const debugHeader = useMemo(() => debugMode ? (
     <UltraFeedDebugHeader
       sortField={debugSortField}
@@ -91,6 +95,7 @@ const UltraFeedMainFeed = ({
       <MixedTypeFeed
         query={UltraFeedQuery}
         variables={variables}
+        getPaginationVariables={getPaginationVariables}
         firstPageSize={firstPageSize}
         pageSize={pageSize}
         refetchRef={refetchRef}
@@ -109,5 +114,4 @@ const UltraFeedMainFeed = ({
 };
 
 export default UltraFeedMainFeed;
-
 

--- a/packages/lesswrong/components/ultraFeed/UltraFeedObserver.tsx
+++ b/packages/lesswrong/components/ultraFeed/UltraFeedObserver.tsx
@@ -14,6 +14,7 @@ import { useMutation } from "@apollo/client/react";
 import { useTracking } from "../../lib/analyticsEvents";
 import { UltraFeedEventCreateMutation } from './ultraFeedMutations';
 import { UltraFeedViewTracker, type ObserveData } from './ultraFeedViewTracker';
+import { useUltraFeedContext } from './UltraFeedContextProvider';
 
 export const MIN_VISIBLE_PX = 100;
 
@@ -43,7 +44,12 @@ const documentTypeToCollectionName = {
   spotlight: "Spotlights"
 } satisfies Record<DocumentType, "Posts" | "Comments" | "Spotlights">;
 
-export const UltraFeedObserverProvider = ({ children, incognitoMode }: { children: ReactNode, incognitoMode: boolean }) => {
+export const UltraFeedObserverProvider = ({ children, incognitoMode, activeFeedType, paused = false }: {
+  children: ReactNode;
+  incognitoMode: boolean;
+  activeFeedType?: string;
+  paused?: boolean;
+}) => {
   const currentUser = useCurrentUser();
   const { captureEvent } = useTracking();
   
@@ -90,7 +96,14 @@ export const UltraFeedObserverProvider = ({ children, incognitoMode }: { childre
     return () => tracker.disconnect();
   }, [tracker]);
 
-  useEffect(() => tracker.setEnabled(!incognitoMode), [tracker, incognitoMode]);
+  useEffect(() => {
+    const updateVisibility = () => tracker.setEnabled(!incognitoMode && !paused && document.visibilityState !== 'hidden');
+    updateVisibility();
+    document.addEventListener('visibilitychange', updateVisibility);
+    return () => document.removeEventListener('visibilitychange', updateVisibility);
+  }, [tracker, incognitoMode, paused]);
+
+  useEffect(() => tracker.setActiveFeedType(activeFeedType), [tracker, activeFeedType]);
 
   const observe = useCallback((element: Element, data: ObserveData) => tracker.observe(element, data), [tracker]);
   const unobserve = useCallback((element: Element) => tracker.unobserve(element), [tracker]);
@@ -139,8 +152,13 @@ export const UltraFeedObserverProvider = ({ children, incognitoMode }: { childre
 
 export const useUltraFeedObserver = () => {
   const context = useContext(UltraFeedObserverContext);
+  const { feedType } = useUltraFeedContext();
+  const register = context?.observe;
+  const observe = useCallback((element: Element, data: ObserveData) => {
+    register?.(element, { ...data, feedType });
+  }, [register, feedType]);
   if (!context) {
     throw new Error('useUltraFeedObserver must be used within an UltraFeedObserverProvider');
   }
-  return context;
+  return { ...context, observe };
 };

--- a/packages/lesswrong/components/ultraFeed/UltraFeedObserver.tsx
+++ b/packages/lesswrong/components/ultraFeed/UltraFeedObserver.tsx
@@ -1,37 +1,4 @@
-/**
- * @file UltraFeedObserver.tsx
- * 
- * This file implements a centralized IntersectionObserver system for the UltraFeed.
- * 
- * **Purpose:**
- * To efficiently track when feed items (posts, comments, etc.) become visible 
- * within the viewport for a sufficient duration (e.g., 300ms) to count as "viewed".
- * It also provides a mechanism (`trackExpansion`) to log when items are expanded.
- * 
- * **How it works:**
- * - It uses a single `IntersectionObserver` instance (`observerRef`) to monitor multiple 
- *   target elements (feed items) added via the `observe` function.
- * - `elementDataMapRef` stores metadata associated with each observed element.
- * - `timerMapRef` manages setTimeout timers for each element entering the viewport.
- * - When an element meets the intersection threshold (`INTERSECTION_THRESHOLD`) for 
- *   the required duration (`VIEW_THRESHOLD_MS`), a 'viewed' event is logged via 
- *   `createUltraFeedEvent`, the element is marked as viewed in `viewedItemsRef`, 
- *   and the observer stops watching it (`unobserve`).
- * - If an element leaves the viewport before the timer completes, the timer is cleared.
- * 
- * **Why this approach? (Performance Rationale):**
- * The primary alternative would be to instantiate a separate IntersectionObserver for 
- * each individual item rendered within `MixedTypeFeed.tsx`. However, a feed can contain 
- * hundreds or potentially thousands of items as the user scrolls. Creating and managing 
- * that many observers would be highly inefficient and could lead to significant 
- * performance degradation (increased memory usage, higher CPU load managing callbacks).
- * 
- * Using a single, centralized observer that monitors multiple targets is a much more 
- * performant pattern recommended by the Intersection Observer API documentation. 
- * This component acts as that central manager, providing a context (`useUltraFeedObserver`) 
- * for individual feed items to register themselves for observation without needing their 
- * own observer instances.
- */
+/** Tracks comment/post exposure separately from delivery and expansion. */
 
 import React, {
   createContext,
@@ -46,17 +13,9 @@ import { useCurrentUser } from "../common/withUser";
 import { useMutation } from "@apollo/client/react";
 import { useTracking } from "../../lib/analyticsEvents";
 import { UltraFeedEventCreateMutation } from './ultraFeedMutations';
+import { UltraFeedViewTracker, type ObserveData } from './ultraFeedViewTracker';
 
-type DocumentType = 'post' | 'comment' | 'spotlight';
-
-interface ObserveData {
-  documentId: string;
-  documentType: DocumentType;
-  postId?: string;
-  servedEventId?: string;
-  feedCardIndex?: number;
-  feedCommentIndex?: number;
-}
+export const MIN_VISIBLE_PX = 100;
 
 interface TrackExpansionData {
   documentId: string;
@@ -78,13 +37,6 @@ interface UltraFeedObserverContextType {
 
 const UltraFeedObserverContext = createContext<UltraFeedObserverContextType | null>(null);
 
-// Minimum amount of the element (in pixels) that must be inside the viewport to
-// count as "visible enough" to register a view event.
-export const MIN_VISIBLE_PX = 100;
-
-const VIEW_THRESHOLD_MS = 1000;
-const LONG_VIEW_THRESHOLD_MS = 10000;
-
 const documentTypeToCollectionName = {
   post: "Posts",
   comment: "Comments",
@@ -97,13 +49,6 @@ export const UltraFeedObserverProvider = ({ children, incognitoMode }: { childre
   
   const [createUltraFeedEvent] = useMutation(UltraFeedEventCreateMutation);
   
-  const observerRef = useRef<IntersectionObserver | null>(null);
-
-  const timerMapRef = useRef<Map<Element, { shortTimerId: ReturnType<typeof setTimeout> | null, longTimerId: ReturnType<typeof setTimeout> | null }>>(new Map());
-  const elementDataMapRef = useRef<Map<Element, ObserveData>>(new Map());
-  const longViewedItemsRef = useRef<Set<string>>(new Set());
-  const shortViewedItemsRef = useRef<Set<string>>(new Set());
-
   const logViewEvent = useCallback((elementData: ObserveData, durationMs: number) => {
     if (incognitoMode || !elementData) return;
 
@@ -131,114 +76,24 @@ export const UltraFeedObserverProvider = ({ children, incognitoMode }: { childre
     });
   }, [createUltraFeedEvent, incognitoMode, captureEvent]);
 
-  const handleIntersection = useCallback((entries: IntersectionObserverEntry[]) => {
-    entries.forEach((entry) => {
-      const element = entry.target;
-      const elementData = elementDataMapRef.current.get(element);
-
-      if (!elementData || longViewedItemsRef.current.has(elementData.documentId)) {
-        return;
-      }
-
-      if (entry.isIntersecting) {
-        if (!timerMapRef.current.has(element)) {
-          if (!elementData) return;
-
-          let shortTimerId: ReturnType<typeof setTimeout> | null = null;
-
-          // 1s view (analytics)
-          if (!shortViewedItemsRef.current.has(elementData.documentId)) {
-            shortTimerId = setTimeout(() => {
-              if (elementDataMapRef.current.has(element)) {
-                logViewEvent(elementData, VIEW_THRESHOLD_MS);
-                shortViewedItemsRef.current.add(elementData.documentId);
-                const timers = timerMapRef.current.get(element);
-                if (timers) timers.shortTimerId = null;
-              }
-            }, VIEW_THRESHOLD_MS);
-          }
-
-          // 10s view (long view analytics)
-          const longTimerId = setTimeout(() => {
-             if (elementDataMapRef.current.has(element)) {
-               const currentElementData = elementDataMapRef.current.get(element);
-               if (!currentElementData) return;
-
-               logViewEvent(currentElementData, LONG_VIEW_THRESHOLD_MS);
-               const documentId = currentElementData.documentId;
-               longViewedItemsRef.current.add(documentId);
-               
-               observerRef.current?.unobserve(element);
-               elementDataMapRef.current.delete(element);
-               timerMapRef.current.delete(element);
-             }
-          }, LONG_VIEW_THRESHOLD_MS);
-
-          timerMapRef.current.set(element, { shortTimerId, longTimerId });
-        }
-      } else {
-        if (timerMapRef.current.has(element)) {
-          const timers = timerMapRef.current.get(element)!;
-          if (timers.shortTimerId) {
-            clearTimeout(timers.shortTimerId);
-          }
-          if (timers.longTimerId) {
-            clearTimeout(timers.longTimerId);
-          }
-          timerMapRef.current.delete(element);
-        }
-      }
-    });
-  }, [logViewEvent]);
+  // Keep the tracker and its target registrations stable across callback/settings changes.
+  const logViewEventRef = useRef(logViewEvent);
+  logViewEventRef.current = logViewEvent;
+  const trackerRef = useRef<UltraFeedViewTracker | null>(null);
+  if (!trackerRef.current) {
+    trackerRef.current = new UltraFeedViewTracker((data, duration) => logViewEventRef.current(data, duration));
+  }
+  const tracker = trackerRef.current;
 
   useEffect(() => {
-    const currentTimerMap = timerMapRef.current;
-    const currentElementDataMap = elementDataMapRef.current;
-    const currentLongViewedItems = longViewedItemsRef.current;
-    const currentShortViewedItems = shortViewedItemsRef.current;
+    tracker.connect();
+    return () => tracker.disconnect();
+  }, [tracker]);
 
-    // We shrink the effective viewport by MIN_VISIBLE_PX on the top and bottom.
-    // Consequently, `entry.isIntersecting === true` means the element has at
-    // least MIN_VISIBLE_PX pixels (or its full height if smaller) visible.
-    observerRef.current = new IntersectionObserver(handleIntersection, {
-      root: null,
-      rootMargin: `-${MIN_VISIBLE_PX}px 0px -${MIN_VISIBLE_PX}px 0px`,
-      threshold: 0,
-    });
-    const observerInstance = observerRef.current;
+  useEffect(() => tracker.setEnabled(!incognitoMode), [tracker, incognitoMode]);
 
-    return () => {
-      observerInstance?.disconnect();
-      currentTimerMap.forEach(timers => {
-        if (timers.shortTimerId) clearTimeout(timers.shortTimerId);
-        if (timers.longTimerId) clearTimeout(timers.longTimerId);
-      });
-      currentTimerMap.clear();
-      currentElementDataMap.clear();
-      currentLongViewedItems.clear();
-      currentShortViewedItems.clear();
-    };
-  }, [handleIntersection]);
-
-  const observe = useCallback((element: Element, data: ObserveData) => {
-    if (observerRef.current && !longViewedItemsRef.current.has(data.documentId) && !elementDataMapRef.current.has(element)) {
-       elementDataMapRef.current.set(element, data);
-       observerRef.current.observe(element);
-    }
-  }, []);
-
-  const unobserve = useCallback((element: Element) => {
-    if (observerRef.current && elementDataMapRef.current.has(element)) {
-      observerRef.current.unobserve(element);
-      if (timerMapRef.current.has(element)) {
-        const timers = timerMapRef.current.get(element)!;
-        if (timers.shortTimerId) clearTimeout(timers.shortTimerId);
-        if (timers.longTimerId) clearTimeout(timers.longTimerId);
-        timerMapRef.current.delete(element);
-      }
-      elementDataMapRef.current.delete(element);
-    }
-  }, []);
+  const observe = useCallback((element: Element, data: ObserveData) => tracker.observe(element, data), [tracker]);
+  const unobserve = useCallback((element: Element) => tracker.unobserve(element), [tracker]);
 
   const trackExpansion = useCallback((data: TrackExpansionData) => {
     if (!currentUser || incognitoMode) return;

--- a/packages/lesswrong/components/ultraFeed/UltraFeedObserver.tsx
+++ b/packages/lesswrong/components/ultraFeed/UltraFeedObserver.tsx
@@ -42,7 +42,7 @@ const documentTypeToCollectionName = {
   post: "Posts",
   comment: "Comments",
   spotlight: "Spotlights"
-} satisfies Record<DocumentType, "Posts" | "Comments" | "Spotlights">;
+} satisfies Record<ObserveData['documentType'], "Posts" | "Comments" | "Spotlights">;
 
 export const UltraFeedObserverProvider = ({ children, incognitoMode, activeFeedType, paused = false }: {
   children: ReactNode;

--- a/packages/lesswrong/components/ultraFeed/UltraFeedPostItem.tsx
+++ b/packages/lesswrong/components/ultraFeed/UltraFeedPostItem.tsx
@@ -473,7 +473,9 @@ const UltraFeedPostItem = ({
       wordCount,
     });
 
-    if (!hasRecordedViewOnExpand) {
+    // Standard expansion analytics above remain enabled, but incognito must not
+    // write post read state or send a Recombee detail view through recordPostView.
+    if (expanded && !settings.resolverSettings.incognitoMode && !hasRecordedViewOnExpand) {
       void recordPostView({ post, extraEventProperties: { type: 'ultraFeedExpansion' } });
       setHasRecordedViewOnExpand(true);
     }
@@ -483,7 +485,8 @@ const UltraFeedPostItem = ({
     post, 
     captureEvent, 
     recordPostView, 
-    hasRecordedViewOnExpand, 
+    hasRecordedViewOnExpand,
+    settings.resolverSettings.incognitoMode,
     isLoadingFull, 
     fullPost,
     postMetaInfo.servedEventId,

--- a/packages/lesswrong/components/ultraFeed/UltraFeedPostItem.tsx
+++ b/packages/lesswrong/components/ultraFeed/UltraFeedPostItem.tsx
@@ -402,7 +402,7 @@ const UltraFeedPostItem = ({
   isHighlightAnimating?: boolean,
 }) => {
   const classes = useStyles(styles);
-  const { observe, trackExpansion } = useUltraFeedObserver();
+  const { observe, unobserve, trackExpansion } = useUltraFeedObserver();
   const elementRef = useRef<HTMLDivElement | null>(null);
   const { openInNewTab, feedType } = useUltraFeedContext();
   const overflowNav = useOverflowNav(elementRef);
@@ -448,7 +448,8 @@ const UltraFeedPostItem = ({
         feedCardIndex: index
       });
     }
-  }, [observe, post._id, postMetaInfo.servedEventId, index]);
+    return () => { if (currentElement) unobserve(currentElement); };
+  }, [observe, unobserve, post._id, postMetaInfo.servedEventId, index]);
 
   const handleContentExpand = useCallback((expanded: boolean, wordCount: number) => {
     setIsContentExpanded(expanded);

--- a/packages/lesswrong/components/ultraFeed/UltraFeedSpotlightItem.tsx
+++ b/packages/lesswrong/components/ultraFeed/UltraFeedSpotlightItem.tsx
@@ -497,7 +497,7 @@ const UltraFeedSpotlightItem = ({
   spotlightMetaInfo?: FeedSpotlightMetaInfo | null,
 }) => {
   const classes = useStyles(useUltraFeedSpotlightItemStyles);
-  const { observe } = useUltraFeedObserver();
+  const { observe, unobserve } = useUltraFeedObserver();
   const elementRef = useRef<HTMLDivElement | null>(null);
   const [isReplying, setIsReplying] = useState(false);
   const currentTime = useCurrentTime();
@@ -523,7 +523,8 @@ const UltraFeedSpotlightItem = ({
         servedEventId: spotlightMetaInfo?.servedEventId ?? '',
       });
     }
-  }, [observe, spotlight, index, spotlightMetaInfo?.servedEventId]);
+    return () => { if (currentElement) unobserve(currentElement); };
+  }, [observe, unobserve, spotlight, index, spotlightMetaInfo?.servedEventId]);
 
   if (!spotlight) {
     return null;

--- a/packages/lesswrong/components/ultraFeed/settingsComponents/UltraFeedSettingsComponents.tsx
+++ b/packages/lesswrong/components/ultraFeed/settingsComponents/UltraFeedSettingsComponents.tsx
@@ -1046,7 +1046,7 @@ export const UnifiedScoringSettings: React.FC<UnifiedScoringSettingsProps> = ({
     {
       key: 'timeDecayHalfLifeHours' as const,
       label: "Time Decay Scale",
-      description: `Controls time decay rate (applies to posts and comments). Higher = slower decay. Formula: scale^0.25 / (ageHrs + 12)^0.25. At ${defaultUnifiedScoringSettings.timeDecayHalfLifeHours}hrs: 1day old = 78%, 1week old = 56%. Default: ${defaultUnifiedScoringSettings.timeDecayHalfLifeHours} hours`,
+      description: `Higher values increase the karma bonus for recent posts and comments relative to other bonuses, up to the karma cap. They do not change how quickly older content loses priority relative to newer content. This setting is a scale, not a half-life. Default: ${defaultUnifiedScoringSettings.timeDecayHalfLifeHours}.`,
       min: 1, max: 48, step: 1,
     },
   ];

--- a/packages/lesswrong/components/ultraFeed/ultraFeedSettingsTypes.ts
+++ b/packages/lesswrong/components/ultraFeed/ultraFeedSettingsTypes.ts
@@ -20,6 +20,7 @@ export type UltraFeedAlgorithm = 'scoring' | 'sampling';
 export interface UnifiedScoringSettings {
   subscribedBonusSetting: number;
   quicktakeBonus: number;
+  /** Persisted legacy name: scales karma bonuses, not the relative decay rate or half-life. */
   timeDecayHalfLifeHours: number;
   postsMultiplier: number;
   threadsMultiplier: number;

--- a/packages/lesswrong/components/ultraFeed/ultraFeedSettingsTypes.ts
+++ b/packages/lesswrong/components/ultraFeed/ultraFeedSettingsTypes.ts
@@ -4,6 +4,7 @@
  */
 import { FeedItemSourceType } from './ultraFeedTypes';
 import { ZodFormattedError } from 'zod';
+import type { UltraFeedDiversityContext } from '@/lib/ultraFeedDiversity';
 
 
 export interface UltraFeedDisplaySettings {
@@ -27,6 +28,8 @@ export interface UnifiedScoringSettings {
 }
 
 export interface UltraFeedResolverSettings {
+  /** Per-request pagination context, supplied by the feed rather than persisted settings. */
+  diversityContext?: UltraFeedDiversityContext;
   incognitoMode: boolean;
   enableDebug: boolean;
   debugMode?: boolean;

--- a/packages/lesswrong/components/ultraFeed/ultraFeedTypes.ts
+++ b/packages/lesswrong/components/ultraFeed/ultraFeedTypes.ts
@@ -275,6 +275,7 @@ export interface ThreadEngagementStats {
 }
 
 export interface ServedEventData {
+  exposureId?: string; // Shared by all comments in one served card
   sessionId: string;    // The session ID for the feed load
   itemIndex: number;    // The index of the item in the served results array
   commentIndex?: number; // The index of the comment within a thread, if applicable

--- a/packages/lesswrong/components/ultraFeed/ultraFeedTypes.ts
+++ b/packages/lesswrong/components/ultraFeed/ultraFeedTypes.ts
@@ -52,6 +52,7 @@ export type RankedItemMetadata =
     }
   | {
       rankedItemType: 'commentThread';
+      preselection?: ThreadPreselectionInfo;
       scoreBreakdown: ThreadScoreBreakdown;
       selectionConstraints: string[];
       position: number;
@@ -154,10 +155,19 @@ export interface PreDisplayFeedComment {
 export type PreDisplayFeedCommentThread = PreDisplayFeedComment[];
 
 export interface FeedCommentsThread {
+  preselection?: ThreadPreselectionInfo;
   comments: PreDisplayFeedComment[];
   primarySource?: FeedItemSourceType;
   postSources?: FeedItemSourceType[];
   rankingMetadata?: RankedItemMetadata;
+}
+
+export interface ThreadPreselectionInfo {
+  score: number;
+  rank: number;
+  candidateLimit: number;
+  selected: boolean;
+  reasons: string[];
 }
 
 export interface FeedPostStub {

--- a/packages/lesswrong/components/ultraFeed/ultraFeedViewTracker.ts
+++ b/packages/lesswrong/components/ultraFeed/ultraFeedViewTracker.ts
@@ -5,6 +5,7 @@ export interface ObserveData {
   servedEventId?: string;
   feedCardIndex?: number;
   feedCommentIndex?: number;
+  feedType?: string;
 }
 
 const viewKey = (data: ObserveData) => data.servedEventId || `${data.documentType}:${data.documentId}`;
@@ -17,6 +18,7 @@ export class UltraFeedViewTracker {
   private viewed = new Set<string>();
   private longViewed = new Set<string>();
   private enabled = true;
+  private activeFeedType?: string;
 
   constructor(private logView: (data: ObserveData, durationMs: number) => void) {}
 
@@ -24,7 +26,7 @@ export class UltraFeedViewTracker {
     this.observer = new IntersectionObserver(entries => {
       for (const entry of entries) {
         this.cancelTimers(entry.target);
-        if (entry.isIntersecting && this.enabled) this.startTimers(entry.target);
+        if (entry.isIntersecting && this.canTrack(entry.target)) this.startTimers(entry.target);
       }
     }, { root: null, rootMargin: '-100px 0px -100px 0px', threshold: 0 });
     if (this.enabled) this.targets.forEach((_, element) => this.observer?.observe(element));
@@ -41,6 +43,17 @@ export class UltraFeedViewTracker {
     this.timers.forEach((_, element) => this.cancelTimers(element));
     this.observer?.disconnect();
     if (enabled) this.targets.forEach((_, element) => this.observer?.observe(element));
+  }
+
+  setActiveFeedType(feedType?: string) {
+    this.activeFeedType = feedType;
+    // Resubscribe so switching feeds starts a fresh continuous visibility interval.
+    this.setEnabled(this.enabled);
+  }
+
+  private canTrack(element: Element) {
+    const data = this.targets.get(element);
+    return this.enabled && !!data && (!this.activeFeedType || data.feedType === this.activeFeedType);
   }
 
   observe(element: Element, data: ObserveData) {
@@ -65,7 +78,7 @@ export class UltraFeedViewTracker {
     if (!data || this.longViewed.has(viewKey(data))) return;
     const timers = [1000, 10000].map(duration => setTimeout(() => {
       const current = this.targets.get(element);
-      if (!this.enabled || !current || current !== data) return;
+      if (!this.canTrack(element) || !current || current !== data) return;
       const seen = duration === 1000 ? this.viewed : this.longViewed;
       if (seen.has(viewKey(data))) return;
       seen.add(viewKey(data));

--- a/packages/lesswrong/components/ultraFeed/ultraFeedViewTracker.ts
+++ b/packages/lesswrong/components/ultraFeed/ultraFeedViewTracker.ts
@@ -1,0 +1,77 @@
+export interface ObserveData {
+  documentId: string;
+  documentType: 'post' | 'comment' | 'spotlight';
+  postId?: string;
+  servedEventId?: string;
+  feedCardIndex?: number;
+  feedCommentIndex?: number;
+}
+
+const viewKey = (data: ObserveData) => data.servedEventId || `${data.documentType}:${data.documentId}`;
+
+/** Owns registrations independently of React effects and analytics callback identity. */
+export class UltraFeedViewTracker {
+  private observer: IntersectionObserver | null = null;
+  private targets = new Map<Element, ObserveData>();
+  private timers = new Map<Element, ReturnType<typeof setTimeout>[]>();
+  private viewed = new Set<string>();
+  private longViewed = new Set<string>();
+  private enabled = true;
+
+  constructor(private logView: (data: ObserveData, durationMs: number) => void) {}
+
+  connect() {
+    this.observer = new IntersectionObserver(entries => {
+      for (const entry of entries) {
+        this.cancelTimers(entry.target);
+        if (entry.isIntersecting && this.enabled) this.startTimers(entry.target);
+      }
+    }, { root: null, rootMargin: '-100px 0px -100px 0px', threshold: 0 });
+    if (this.enabled) this.targets.forEach((_, element) => this.observer?.observe(element));
+  }
+
+  disconnect() {
+    this.observer?.disconnect();
+    this.observer = null;
+    this.timers.forEach((_, element) => this.cancelTimers(element));
+  }
+
+  setEnabled(enabled: boolean) {
+    this.enabled = enabled;
+    this.timers.forEach((_, element) => this.cancelTimers(element));
+    this.observer?.disconnect();
+    if (enabled) this.targets.forEach((_, element) => this.observer?.observe(element));
+  }
+
+  observe(element: Element, data: ObserveData) {
+    this.cancelTimers(element);
+    this.targets.set(element, data);
+    if (this.enabled) this.observer?.observe(element);
+  }
+
+  unobserve(element: Element) {
+    this.cancelTimers(element);
+    this.observer?.unobserve(element);
+    this.targets.delete(element);
+  }
+
+  private cancelTimers(element: Element) {
+    this.timers.get(element)?.forEach(clearTimeout);
+    this.timers.delete(element);
+  }
+
+  private startTimers(element: Element) {
+    const data = this.targets.get(element);
+    if (!data || this.longViewed.has(viewKey(data))) return;
+    const timers = [1000, 10000].map(duration => setTimeout(() => {
+      const current = this.targets.get(element);
+      if (!this.enabled || !current || current !== data) return;
+      const seen = duration === 1000 ? this.viewed : this.longViewed;
+      if (seen.has(viewKey(data))) return;
+      seen.add(viewKey(data));
+      this.logView(data, duration);
+      if (duration === 10000) this.observer?.unobserve(element);
+    }, duration));
+    this.timers.set(element, timers);
+  }
+}

--- a/packages/lesswrong/lib/ultraFeedDiversity.ts
+++ b/packages/lesswrong/lib/ultraFeedDiversity.ts
@@ -1,0 +1,39 @@
+import { z } from 'zod';
+import { allFeedItemSourceTypes } from '@/components/ultraFeed/ultraFeedTypes';
+import type { FeedCommentMetaInfo, FeedPostMetaInfo } from '@/components/ultraFeed/ultraFeedTypes';
+
+const contextSchema = z.object({
+  offset: z.number().int().min(0),
+  history: z.array(z.object({
+    position: z.number().int().min(0),
+    itemType: z.enum(['post', 'commentThread', 'subscriptionSuggestions']),
+    sources: z.array(z.enum(allFeedItemSourceTypes)).max(16),
+    userSubscribedToAuthor: z.boolean(),
+  })).max(20),
+});
+export type UltraFeedDiversityContext = z.infer<typeof contextSchema>;
+
+export function parseUltraFeedDiversityContext(value: unknown): UltraFeedDiversityContext | undefined {
+  const result = contextSchema.safeParse(value);
+  return result.success ? result.data : undefined;
+}
+
+/** Only ranking summaries are sent back; no read logging is needed, including in incognito. */
+export function buildUltraFeedDiversityContext(results: Array<{ type: string; [key: string]: unknown }>): UltraFeedDiversityContext {
+  return { offset: results.length, history: results.slice(-20).map((result, index) => {
+    const position = results.length - Math.min(20, results.length) + index;
+    if (result.type === 'feedCommentThread') {
+      const thread = result.feedCommentThread as { commentMetaInfos?: Record<string, FeedCommentMetaInfo> };
+      const comments = Object.values(thread.commentMetaInfos ?? {});
+      return { position, itemType: 'commentThread' as const,
+        sources: [...new Set(comments.flatMap(comment => comment.sources ?? []))],
+        userSubscribedToAuthor: comments.some(comment => comment.fromSubscribedUser),
+      };
+    }
+    const post = result.feedPost as { postMetaInfo?: FeedPostMetaInfo } | undefined;
+    const sources = result.type === 'feedSpotlight' ? ['spotlights' as const] : post?.postMetaInfo?.sources ?? [];
+    return { position, itemType: result.type === 'feedSubscriptionSuggestions' ? 'subscriptionSuggestions' as const : 'post' as const,
+      sources, userSubscribedToAuthor: sources.includes('subscriptionsPosts'),
+    };
+  }) };
+}

--- a/packages/lesswrong/lib/ultraFeedDiversity.ts
+++ b/packages/lesswrong/lib/ultraFeedDiversity.ts
@@ -19,7 +19,9 @@ export function parseUltraFeedDiversityContext(value: unknown): UltraFeedDiversi
 }
 
 /** Only ranking summaries are sent back; no read logging is needed, including in incognito. */
-export function buildUltraFeedDiversityContext(results: Array<{ type: string; [key: string]: unknown }>): UltraFeedDiversityContext {
+export function buildUltraFeedDiversityContext(displayedResults: Array<{ type: string; [key: string]: unknown }>): UltraFeedDiversityContext {
+  // Suggestions and markers are appended outside ranking and must not consume guaranteed slots.
+  const results = displayedResults.filter(result => result.type !== 'feedSubscriptionSuggestions' && result.type !== 'feedMarker');
   return { offset: results.length, history: results.slice(-20).map((result, index) => {
     const position = results.length - Math.min(20, results.length) + index;
     if (result.type === 'feedCommentThread') {

--- a/packages/lesswrong/server/markAsUnread.ts
+++ b/packages/lesswrong/server/markAsUnread.ts
@@ -1,4 +1,5 @@
 import gql from 'graphql-tag';
+import { randomId } from '@/lib/random';
 
 export const markAsUnreadTypeDefs = gql`
   extend type Mutation {
@@ -12,7 +13,14 @@ export const markAsUnreadMutations = {
     const { currentUser } = context;
     if (!currentUser) return isRead;
 
-    await context.repos.readStatuses.upsertReadStatus(currentUser._id, postId, isRead);
+    const readStatus = await context.repos.readStatuses.upsertReadStatus(currentUser._id, postId, isRead);
+    if (!isRead) {
+      await context.UltraFeedEvents.rawInsertMany([{
+        _id: randomId(), userId: currentUser._id, documentId: postId,
+        collectionName: 'Posts', eventType: 'interacted',
+        createdAt: readStatus.lastUpdated, feedItemId: null, event: { action: 'markUnread' },
+      }]);
+    }
     
     // TODO: Create an entry in LWEvents
     

--- a/packages/lesswrong/server/repos/CommentsRepo.ts
+++ b/packages/lesswrong/server/repos/CommentsRepo.ts
@@ -9,7 +9,7 @@ import { filterWhereFieldsNotNull } from "../../lib/utils/typeGuardUtils";
 import { recordPerfMetrics } from "./perfMetricWrapper";
 import { isAF } from "../../lib/instanceSettings";
 import { getViewableCommentsSelector, getViewablePostsSelector } from "./helpers";
-import { FeedCommentFromDb, ThreadEngagementStats } from "../../components/ultraFeed/ultraFeedTypes";
+import { feedCommentSourceTypesArray, FeedItemSourceType, FeedCommentFromDb, ThreadEngagementStats } from "../../components/ultraFeed/ultraFeedTypes";
 import { REVIEW_YEAR } from "@/lib/reviewUtils";
 
 type ExtendedCommentWithReactions = DbComment & {
@@ -453,6 +453,7 @@ class CommentsRepo extends AbstractRepo<"Comments"> {
     initialCandidateLookbackDays: number,
     commentServedEventRecencyHours: number,
     restrictCandidatesToSubscribed = false,
+    enabledSources: FeedItemSourceType[] = [...feedCommentSourceTypesArray],
   ): Promise<FeedCommentFromDb[]> {
     const initialCandidateLimit = 500;
 
@@ -491,6 +492,11 @@ class CommentsRepo extends AbstractRepo<"Comments"> {
               AND c."userId" != $(userIdOrClientId)
               AND c."postedAt" > (NOW() - INTERVAL '1 day' * $(initialCandidateLookbackDaysParam))
               AND p.draft IS NOT TRUE
+              AND (CASE
+                WHEN c.shortform IS TRUE THEN 'quicktakes'
+                WHEN c."userId" IN (SELECT "authorId" FROM "SubscribedAuthorIds") THEN 'subscriptionsComments'
+                ELSE 'recentComments'
+              END) = ANY($(enabledSources)::text[])
               AND (CASE WHEN $(restrictCandidatesToSubscribed) THEN c."userId" IN (SELECT "authorId" FROM "SubscribedAuthorIds") ELSE TRUE END)
           ORDER BY 
               (CASE WHEN c."reviewingForReview" = $(reviewYear) THEN 0 ELSE 1 END),
@@ -583,6 +589,7 @@ class CommentsRepo extends AbstractRepo<"Comments"> {
       initialCandidateLookbackDaysParam: initialCandidateLookbackDays,
       commentServedEventRecencyHoursParam: commentServedEventRecencyHours,
       restrictCandidatesToSubscribed,
+      enabledSources,
       reviewYear: REVIEW_YEAR.toString(),
     });
 

--- a/packages/lesswrong/server/repos/CommentsRepo.ts
+++ b/packages/lesswrong/server/repos/CommentsRepo.ts
@@ -541,8 +541,7 @@ class CommentsRepo extends AbstractRepo<"Comments"> {
           AND ue."userId" = $(userIdOrClientId)
           AND (ue."eventType" <> 'served' OR ue."createdAt" > current_timestamp - INTERVAL '1 hour' * $(commentServedEventRecencyHoursParam))
           AND ue."documentId" IN (SELECT _id FROM "AllRelevantComments")
-        ORDER BY (CASE WHEN "eventType" = 'served' THEN 1 ELSE 0 END) ASC
-        LIMIT 5000
+        -- Bound work by candidate IDs, not by event count: truncation loses seen state.
       ),
       "CommentEvents" AS (
           -- Aggregate the user's latest events for each comment

--- a/packages/lesswrong/server/repos/CommentsRepo.ts
+++ b/packages/lesswrong/server/repos/CommentsRepo.ts
@@ -763,38 +763,63 @@ class CommentsRepo extends AbstractRepo<"Comments"> {
             )
         ) threadsOnReadPosts ON recentActiveThreads."threadTopLevelId" = threadsOnReadPosts."threadTopLevelId"
       LEFT JOIN
-        ( -- get repeated thread exposures to calculate repetition penalty
+        ( -- Count a card exposure once, not once per comment or duration milestone.
           SELECT
-            COALESCE(c_repetition."topLevelCommentId", c_repetition._id) AS "threadTopLevelId",
-            COUNT(DISTINCT ufe_repetition."createdAt") AS "recentServingCount",
+            exposures."threadTopLevelId",
+            COUNT(*) AS "recentServingCount",
             ARRAY_AGG(
-              EXTRACT(EPOCH FROM (NOW() - ufe_repetition."createdAt")) / 3600 
-              ORDER BY ufe_repetition."createdAt" DESC
+              EXTRACT(EPOCH FROM (NOW() - exposures."exposedAt")) / 3600
+              ORDER BY exposures."exposedAt" DESC
             ) AS "servingHoursAgo"
-          FROM "UltraFeedEvents" ufe_repetition
-          JOIN "Comments" c_repetition ON ufe_repetition."documentId" = c_repetition._id
-          WHERE ufe_repetition."userId" = $(userIdOrClientId)
-            AND ufe_repetition."collectionName" = 'Comments'
-            AND ufe_repetition."createdAt" > (NOW() - INTERVAL '6 hours') -- Shorter lookback for repetition
-            AND (
-              (
-                ufe_repetition."eventType" = 'served'
-                AND $(sessionId) IS NOT NULL
-                AND ufe_repetition.event->>'sessionId' = $(sessionId)
+          FROM (
+            SELECT
+              COALESCE(c_repetition."topLevelCommentId", c_repetition._id) AS "threadTopLevelId",
+              CASE
+                WHEN served.event->>'exposureId' IS NOT NULL
+                  THEN jsonb_build_array('exposure', served.event->>'exposureId')
+                -- Compatibility with For You events written before exposureId existed.
+                WHEN served.event->>'sessionId' IS NOT NULL AND served.event->>'itemIndex' IS NOT NULL
+                  THEN jsonb_build_array('card', served.event->>'sessionId', served.event->>'itemIndex')
+                -- For older events without card metadata, at least merge a comment's
+                -- short/long views. Unlinked events remain separate observations.
+                ELSE jsonb_build_array('event', COALESCE(ufe_repetition."feedItemId", ufe_repetition._id))
+              END AS "exposureKey",
+              COALESCE(
+                MIN(ufe_repetition."createdAt") FILTER (WHERE ufe_repetition."eventType" = 'viewed'),
+                MIN(ufe_repetition."createdAt")
+              ) AS "exposedAt"
+            FROM "UltraFeedEvents" ufe_repetition
+            JOIN "Comments" c_repetition ON ufe_repetition."documentId" = c_repetition._id
+            LEFT JOIN "UltraFeedEvents" served
+              ON served._id = COALESCE(ufe_repetition."feedItemId", ufe_repetition._id)
+              AND served."eventType" = 'served'
+              AND served."userId" = ufe_repetition."userId"
+              AND served."collectionName" = 'Comments'
+              AND served."documentId" = ufe_repetition."documentId"
+            WHERE ufe_repetition."userId" = $(userIdOrClientId)
+              AND ufe_repetition."collectionName" = 'Comments'
+              AND ufe_repetition."createdAt" > (NOW() - INTERVAL '6 hours') -- Shorter lookback for repetition
+              AND (
+                (
+                  ufe_repetition."eventType" = 'served'
+                  AND $(sessionId) IS NOT NULL
+                  AND ufe_repetition.event->>'sessionId' = $(sessionId)
+                )
+                OR ufe_repetition."eventType" = 'viewed'
               )
-              OR ufe_repetition."eventType" = 'viewed'
-            )
-            AND COALESCE(c_repetition."topLevelCommentId", c_repetition._id) IN (
-                SELECT "threadTopLevelId_inner_rat" FROM (
-                    SELECT COALESCE(c_inner."topLevelCommentId", c_inner._id) AS "threadTopLevelId_inner_rat", MAX(c_inner."postedAt") AS "lastCommentActivity_inner"
-                    FROM "Comments" c_inner
-                    WHERE ${getViewableCommentsFilter('c_inner')}
-                    GROUP BY COALESCE(c_inner."topLevelCommentId", c_inner._id)
-                    ORDER BY "lastCommentActivity_inner" DESC
-                    LIMIT $(threadCandidateLimit)
-                ) recent_threads_filter_for_servings
-            )
-          GROUP BY COALESCE(c_repetition."topLevelCommentId", c_repetition._id)
+              AND COALESCE(c_repetition."topLevelCommentId", c_repetition._id) IN (
+                  SELECT "threadTopLevelId_inner_rat" FROM (
+                      SELECT COALESCE(c_inner."topLevelCommentId", c_inner._id) AS "threadTopLevelId_inner_rat", MAX(c_inner."postedAt") AS "lastCommentActivity_inner"
+                      FROM "Comments" c_inner
+                      WHERE ${getViewableCommentsFilter('c_inner')}
+                      GROUP BY COALESCE(c_inner."topLevelCommentId", c_inner._id)
+                      ORDER BY "lastCommentActivity_inner" DESC
+                      LIMIT $(threadCandidateLimit)
+                  ) recent_threads_filter_for_servings
+              )
+            GROUP BY COALESCE(c_repetition."topLevelCommentId", c_repetition._id), "exposureKey"
+          ) exposures
+          GROUP BY exposures."threadTopLevelId"
         ) recentServings ON recentActiveThreads."threadTopLevelId" = recentServings."threadTopLevelId"
     `, {
       userIdOrClientId,

--- a/packages/lesswrong/server/repos/CommentsRepo.ts
+++ b/packages/lesswrong/server/repos/CommentsRepo.ts
@@ -528,37 +528,18 @@ class CommentsRepo extends AbstractRepo<"Comments"> {
           WHERE
               ${getUniversalCommentFilterClause('c')}
       ),
-      "ReadStatusViews" AS (
-        -- Generate implied view events from ReadStatuses table
-        SELECT
-          c._id AS "documentId",
-          rs."lastUpdated" AS "createdAt",
-          'viewed' AS "eventType"
-        FROM "AllRelevantComments" c
-        JOIN "ReadStatuses" rs ON c."postId" = rs."postId"
-        WHERE rs."userId" = $(userIdOrClientId)
-          AND rs."isRead" IS TRUE
-          AND c."postedAt" < rs."lastUpdated"
-      ),
       "UsersEvents" AS (
-        -- Select from the combined and ordered events
-        SELECT * FROM (
-          -- Combine both real events and implied events from read statuses
-          SELECT
-            ue."documentId",
-            ue."createdAt",
-            ue."eventType"
-          FROM "UltraFeedEvents" ue
-          WHERE ue."collectionName" = 'Comments'
-            AND "userId" = $(userIdOrClientId)
-            AND (ue."eventType" <> 'served' OR ue."createdAt" > current_timestamp - INTERVAL '1 hour' * $(commentServedEventRecencyHoursParam))
-            AND ue."documentId" IN (SELECT _id FROM "AllRelevantComments")
-          
-          UNION ALL
-          
-          -- Add the implied view events from ReadStatuses
-          SELECT * FROM "ReadStatusViews"
-        ) AS CombinedEvents -- Treat the UNION result as a derived table
+        -- A post visit is not evidence that any of its comments were seen.
+        -- Only comment-specific feed events determine comment read state.
+        SELECT
+          ue."documentId",
+          ue."createdAt",
+          ue."eventType"
+        FROM "UltraFeedEvents" ue
+        WHERE ue."collectionName" = 'Comments'
+          AND ue."userId" = $(userIdOrClientId)
+          AND (ue."eventType" <> 'served' OR ue."createdAt" > current_timestamp - INTERVAL '1 hour' * $(commentServedEventRecencyHoursParam))
+          AND ue."documentId" IN (SELECT _id FROM "AllRelevantComments")
         ORDER BY (CASE WHEN "eventType" = 'served' THEN 1 ELSE 0 END) ASC
         LIMIT 5000
       ),

--- a/packages/lesswrong/server/repos/CommentsRepo.ts
+++ b/packages/lesswrong/server/repos/CommentsRepo.ts
@@ -1,3 +1,4 @@
+import { ultraFeedReadIsCurrentSql } from "../ultraFeed/ultraFeedReadState";
 import Comments from "../../server/collections/comments/collection";
 import AbstractRepo from "./AbstractRepo";
 import SelectQuery from "@/server/sql/SelectQuery";
@@ -748,6 +749,8 @@ class CommentsRepo extends AbstractRepo<"Comments"> {
             WHERE ufe_posts."userId" = $(userIdOrClientId)
               AND ufe_posts."collectionName" = 'Posts'
               AND ufe_posts."eventType" != 'served'
+              AND ufe_posts.event->>'action' IS DISTINCT FROM 'markUnread'
+              AND ${ultraFeedReadIsCurrentSql('$(userIdOrClientId)', 'ufe_posts."documentId"', 'ufe_posts."createdAt"')}
               AND ufe_posts."createdAt" > (NOW() - INTERVAL $(lookbackInterval))
           ) "readPosts_subquery" ON c_read."postId" = "readPosts_subquery"."postId"
           WHERE c_read."postedAt" > (NOW() - INTERVAL $(lookbackInterval))

--- a/packages/lesswrong/server/repos/PostsRepo.ts
+++ b/packages/lesswrong/server/repos/PostsRepo.ts
@@ -1,3 +1,4 @@
+import { ultraFeedReadIsCurrentSql } from "../ultraFeed/ultraFeedReadState";
 import Posts from "../../server/collections/posts/collection";
 import AbstractRepo from "./AbstractRepo";
 import { getViewableEventsSelector, getViewablePostsSelector } from "./helpers";
@@ -888,10 +889,12 @@ class PostsRepo extends AbstractRepo<"Posts"> {
       ),
       ufe_limited AS (
         SELECT "documentId", "createdAt", "eventType"
-        FROM "UltraFeedEvents"
+        FROM "UltraFeedEvents" ue
         WHERE 
           "userId" = $(userId)
           AND "collectionName" = 'Posts'
+          AND event->>'action' IS DISTINCT FROM 'markUnread'
+          AND ${ultraFeedReadIsCurrentSql('$(userId)', 'ue."documentId"', 'ue."createdAt"')}
           AND "createdAt" > NOW() - INTERVAL '$(maxAgeDays) days'
         ORDER BY "createdAt" DESC
         LIMIT 2000
@@ -907,6 +910,7 @@ class PostsRepo extends AbstractRepo<"Posts"> {
           SELECT rs."postId" AS "documentId", rs."lastUpdated" AS "createdAt", 'viewed' AS "eventType"
           FROM "ReadStatuses" rs
           WHERE rs."userId" = $(userId)
+            AND rs."isRead" IS TRUE
             AND rs."lastUpdated" > NOW() - INTERVAL '$(maxAgeDays) days'
         ) ce
         GROUP BY ce."documentId"
@@ -1004,11 +1008,12 @@ class PostsRepo extends AbstractRepo<"Posts"> {
           "documentId",
           MAX(CASE WHEN "eventType" = 'viewed' THEN "createdAt" ELSE NULL END) as "lastViewed",
           MAX(CASE WHEN "eventType" IN ('upvote', 'downvote', 'strongUpvote', 'strongDownvote', 'comment') THEN "createdAt" ELSE NULL END) as "lastInteracted"
-        FROM "UltraFeedEvents"
+        FROM "UltraFeedEvents" events
         WHERE 
           "userId" = $2
           AND "documentId" = ANY($1::text[])
           AND "collectionName" = 'Posts'
+          AND ${ultraFeedReadIsCurrentSql('$2', 'events."documentId"', 'events."createdAt"')}
         GROUP BY "documentId"
       ) ue ON ue."documentId" = p._id
     `, [postIds, userId]);

--- a/packages/lesswrong/server/repos/PostsRepo.ts
+++ b/packages/lesswrong/server/repos/PostsRepo.ts
@@ -887,7 +887,7 @@ class PostsRepo extends AbstractRepo<"Posts"> {
           AND s."collectionName" = 'Users'
           AND s."type" IN ('newActivityForFeed', 'newPosts')
       ),
-      ufe_limited AS (
+      candidate_events AS (
         SELECT "documentId", "createdAt", "eventType"
         FROM "UltraFeedEvents" ue
         WHERE 
@@ -896,8 +896,10 @@ class PostsRepo extends AbstractRepo<"Posts"> {
           AND event->>'action' IS DISTINCT FROM 'markUnread'
           AND ${ultraFeedReadIsCurrentSql('$(userId)', 'ue."documentId"', 'ue."createdAt"')}
           AND "createdAt" > NOW() - INTERVAL '$(maxAgeDays) days'
-        ORDER BY "createdAt" DESC
-        LIMIT 2000
+          AND "eventType" <> 'served'
+          AND "documentId" IN (
+            SELECT _id FROM "Posts" WHERE "postedAt" > NOW() - INTERVAL '$(maxAgeDays) days'
+          )
       ),
       read_state AS (
         SELECT
@@ -905,7 +907,7 @@ class PostsRepo extends AbstractRepo<"Posts"> {
           MAX(CASE WHEN ce."eventType" = 'viewed' THEN ce."createdAt" ELSE NULL END) AS "lastViewed",
           MAX(CASE WHEN ce."eventType" <> 'viewed' AND ce."eventType" <> 'served' THEN ce."createdAt" ELSE NULL END) AS "lastInteracted"
         FROM (
-          SELECT "documentId", "createdAt", "eventType" FROM ufe_limited
+          SELECT "documentId", "createdAt", "eventType" FROM candidate_events
           UNION ALL
           SELECT rs."postId" AS "documentId", rs."lastUpdated" AS "createdAt", 'viewed' AS "eventType"
           FROM "ReadStatuses" rs

--- a/packages/lesswrong/server/repos/SpotlightsRepo.ts
+++ b/packages/lesswrong/server/repos/SpotlightsRepo.ts
@@ -23,14 +23,13 @@ class SpotlightsRepo extends AbstractRepo<"Spotlights"> {
       WITH "RecentViews" AS (
         SELECT
           "documentId",
-          COUNT(*) AS "viewCount"
+          COUNT(DISTINCT COALESCE("feedItemId", _id)) AS "viewCount"
         FROM "UltraFeedEvents"
         WHERE "collectionName" = 'Spotlights'
           AND "eventType" = 'viewed'
           AND "createdAt" > NOW() - INTERVAL '90 days'
           AND "userId" = $(userIdOrClientId)
         GROUP BY "documentId"
-        HAVING COUNT(*) <= 5
       )
       SELECT
         s._id,
@@ -41,6 +40,7 @@ class SpotlightsRepo extends AbstractRepo<"Spotlights"> {
       WHERE s."draft" IS NOT TRUE
         AND s."deletedDraft" IS NOT TRUE
         AND "documentType" = 'Post'
+        AND COALESCE(rv."viewCount", 0) <= 5
       order by
         COALESCE(rv."viewCount", 0) ASC,
         RANDOM()

--- a/packages/lesswrong/server/repos/UltraFeedEventsRepo.ts
+++ b/packages/lesswrong/server/repos/UltraFeedEventsRepo.ts
@@ -1,6 +1,7 @@
 import AbstractRepo from './AbstractRepo';
 import UltraFeedEvents from '../collections/ultraFeedEvents/collection';
 import { recordPerfMetrics } from './perfMetricWrapper';
+import { ultraFeedReadIsCurrentSql } from '../ultraFeed/ultraFeedReadState';
 import { FeedItemSourceType, FeedItemRenderType, FeedItemDisplayStatus } from '@/components/ultraFeed/ultraFeedTypes';
 
 export interface UnviewedItem {
@@ -77,7 +78,7 @@ class UltraFeedEventsRepo extends AbstractRepo<'UltraFeedEvents'> {
           SUM(CASE WHEN "eventType" = 'served' THEN 1 ELSE 0 END) as serve_count,
           MAX(CASE WHEN "eventType" = 'served' THEN "createdAt" END) as last_served,
           MAX(CASE WHEN "eventType" = 'viewed' THEN 1 ELSE 0 END) as was_viewed
-        FROM "UltraFeedEvents"
+        FROM "UltraFeedEvents" ue
         WHERE "userId" = $(userId)
           AND "collectionName" = 'Posts'
           AND "eventType" IN ('served', 'viewed')
@@ -86,6 +87,7 @@ class UltraFeedEventsRepo extends AbstractRepo<'UltraFeedEvents'> {
             ("eventType" = 'served' AND event->'sources' ? $(scenarioId))
             OR "eventType" = 'viewed'
           )
+          AND ("eventType" = 'served' OR ${ultraFeedReadIsCurrentSql('$(userId)', 'ue."documentId"', 'ue."createdAt"')})
         GROUP BY "documentId"
       ) s
       WHERE s.serve_count < 3 AND s.was_viewed = 0
@@ -119,12 +121,13 @@ class UltraFeedEventsRepo extends AbstractRepo<'UltraFeedEvents'> {
       FROM (
         -- Check UltraFeedEvents for viewed events
         SELECT "documentId" AS "postId"
-        FROM "UltraFeedEvents"
+        FROM "UltraFeedEvents" ue
         WHERE 
           "userId" = $(userId)
           AND "collectionName" = 'Posts'
           AND "eventType" = 'viewed'
           AND "documentId" = ANY($(postIds)::text[])
+          AND ${ultraFeedReadIsCurrentSql('$(userId)', 'ue."documentId"', 'ue."createdAt"')}
         
         UNION
         

--- a/packages/lesswrong/server/resolvers/ultraFeedResolver.ts
+++ b/packages/lesswrong/server/resolvers/ultraFeedResolver.ts
@@ -29,7 +29,6 @@ import { userIsAdmin, userIsAdminOrMod } from '@/lib/vulcan-users/permissions';
 import {
   loadMultipleEntitiesById,
   createUltraFeedResponse,
-  UltraFeedEventInsertData,
   insertSubscriptionSuggestions
 } from './ultraFeedResolverHelpers';
 import { getAlgorithm, type UltraFeedAlgorithmName } from '../ultraFeed/algorithms/algorithmRegistry';
@@ -41,6 +40,7 @@ import {
 import { scoreAllUltraFeedItems } from '../ultraFeed/ultraFeedRanking';
 import { buildRankingConfigFromSettings } from '../ultraFeed/ultraFeedRankingConfig';
 import UltraFeedEvents from "../collections/ultraFeedEvents/collection";
+import { createUltraFeedEvents } from "../ultraFeed/ultraFeedEvents";
 
 const ultraFeedLog = loggerConstructor('ultrafeed');
 
@@ -472,76 +472,6 @@ const transformItemsForResolver = (
   }));
 };
 
-const createUltraFeedEvents = (
-  results: UltraFeedResolverType[],
-  userOrClientId: UserOrClientId,
-  sessionId: string,
-  offset: number
-): UltraFeedEventInsertData[] => {
-  const eventsToCreate: UltraFeedEventInsertData[] = [];
-  const userId = userOrClientId.id;
-  const isLoggedOut = userOrClientId.type === 'client';
-  
-  results.forEach((item, index) => {
-    const actualItemIndex = offset + index;
-    
-    if (item.type === "feedSpotlight" && item.feedSpotlight?.spotlight?._id) {
-      const servedEventId = item.feedSpotlight.spotlightMetaInfo.servedEventId;
-      eventsToCreate.push({
-        _id: servedEventId,
-        userId,
-        eventType: "served",
-        collectionName: "Spotlights",
-        documentId: item.feedSpotlight.spotlight._id,
-        event: { sessionId, itemIndex: actualItemIndex, sources: ["spotlights"], ...(isLoggedOut ? { loggedOut: true } : {}) }
-      });
-    } else if (item.type === "feedCommentThread" && (item.feedCommentThread?.comments?.length ?? 0) > 0) {
-        const threadData = item.feedCommentThread;
-        const comments = threadData?.comments;
-        const commentMetaInfos = threadData?.commentMetaInfos;
-        const sources = threadData?.commentMetaInfos?.[comments?.[0]?._id ?? ""]?.sources ?? [];
-        comments?.forEach((comment: DbComment, commentIndex) => {
-          if (comment?._id) {
-            const displayStatus = commentMetaInfos?.[comment._id]?.displayStatus;
-            const servedEventId = commentMetaInfos?.[comment._id]?.servedEventId;
-            if (servedEventId) {
-              eventsToCreate.push({ 
-                 _id: servedEventId,
-                 userId, 
-                 eventType: "served", 
-                 collectionName: "Comments", 
-                 documentId: comment._id, 
-                 event: { 
-                  sessionId, 
-                  itemIndex: actualItemIndex, 
-                  commentIndex, 
-                  displayStatus,
-                  sources,
-                  ...(isLoggedOut ? { loggedOut: true } : {})
-                }
-                });
-            }
-          }
-        });
-    } else if (item.type === "feedPost" && item.feedPost?.post?._id) {
-      const feedItem = item.feedPost;
-      const servedEventId = feedItem.postMetaInfo?.servedEventId;
-      const sources = feedItem.postMetaInfo?.sources ?? [];
-      if (feedItem.post._id && servedEventId) { 
-        eventsToCreate.push({ 
-          _id: servedEventId,
-          userId, 
-          eventType: "served", 
-          collectionName: "Posts", 
-          documentId: feedItem.post._id,
-          event: { sessionId, itemIndex: actualItemIndex, sources, ...(isLoggedOut ? { loggedOut: true } : {}) }
-        });
-      }
-    }
-  });
-  
-  return eventsToCreate;
-};
 
 interface UltraFeedArgs {
   limit?: number;

--- a/packages/lesswrong/server/resolvers/ultraFeedResolver.ts
+++ b/packages/lesswrong/server/resolvers/ultraFeedResolver.ts
@@ -1,11 +1,10 @@
+import { calculateFetchLimits } from "../ultraFeed/ultraFeedFetchLimits";
 import {
   FeedItemSourceType, UltraFeedResolverType,
   FeedSpotlight, FeedFullPost, FeedCommentMetaInfo,
   PreDisplayFeedComment,
   FeedCommentsThread,
   FeedCommentsThreadResolverType,
-  feedCommentSourceTypesArray,
-  feedSpotlightSourceTypesArray,
   FeedPostStub,
   UserOrClientId,
   ThreadEngagementStats,
@@ -481,52 +480,6 @@ interface UltraFeedArgs {
   settings: string;
 }
 
-const calculateFetchLimits = (
-  sourceWeights: Record<string, number>,
-  totalLimit: number,
-  offset: number = 0,
-  bufferMultiplier = 3.6,
-  latestAndSubscribedPostMultiplier = 3.0,
-  recombeeMultiplier = 3.6,
-): {
-  totalWeight: number;
-  recombeePostFetchLimit: number;
-  hackerNewsPostFetchLimit: number;
-  subscribedPostFetchLimit: number;
-  commentFetchLimit: number;
-  spotlightFetchLimit: number;
-  bookmarkFetchLimit: number;
-  bufferMultiplier: number;
-} => {
-  const totalWeight = Object.values(sourceWeights).reduce((sum: number, weight) => sum + weight, 0);
-  
-  const recombeePostWeight = sourceWeights['recombee-lesswrong-ultrafeed'] ?? 0;
-  const hackerNewsPostWeight = sourceWeights['hacker-news'] ?? 0;
-  const subscribedPostWeight = sourceWeights['subscriptionsPosts'] ?? 0;
-  const bookmarkWeight = sourceWeights['bookmarks'] ?? 0;
-  const totalCommentWeight = feedCommentSourceTypesArray.reduce((sum: number, type: FeedItemSourceType) => sum + (sourceWeights[type] || 0), 0);
-  const totalSpotlightWeight = feedSpotlightSourceTypesArray.reduce((sum: number, type: FeedItemSourceType) => sum + (sourceWeights[type] || 0), 0);
-
-  const baseCommentFetchLimit = Math.ceil(totalLimit * (totalCommentWeight / totalWeight) * bufferMultiplier);
-  
-  // Scale up comment fetch limit based on offset to reduce repetition in subsequent calls: grows incrementally with each call, capped at 200
-  const commentFetchLimit = Math.min(baseCommentFetchLimit + Math.round(offset / 2), 200);
-  
-  if (offset > 0 && commentFetchLimit > baseCommentFetchLimit) {
-    ultraFeedLog(`Scaled up comment fetch limit: ${baseCommentFetchLimit} → ${commentFetchLimit} (base from limit=${totalLimit}, offset=${offset})`);
-  }
-
-  return {
-    totalWeight,
-    recombeePostFetchLimit: Math.ceil(totalLimit * (recombeePostWeight / totalWeight) * recombeeMultiplier),
-    hackerNewsPostFetchLimit: Math.ceil(totalLimit * (hackerNewsPostWeight / totalWeight) * latestAndSubscribedPostMultiplier),
-    subscribedPostFetchLimit: Math.ceil(totalLimit * (subscribedPostWeight / totalWeight) * latestAndSubscribedPostMultiplier),
-    commentFetchLimit,
-    spotlightFetchLimit: Math.ceil(totalLimit * (totalSpotlightWeight / totalWeight) * bufferMultiplier),
-    bookmarkFetchLimit: Math.ceil(totalLimit * (bookmarkWeight / totalWeight) * bufferMultiplier),
-    bufferMultiplier
-  };
-};
 
 /**
  * UltraFeed resolver

--- a/packages/lesswrong/server/resolvers/ultraFeedResolver.ts
+++ b/packages/lesswrong/server/resolvers/ultraFeedResolver.ts
@@ -670,7 +670,7 @@ export const ultraFeedGraphQLQueries = {
       const sampledItems = insertSubscriptionSuggestions(sampledItemsDeduped, (): SampledItem => ({
         type: "feedSubscriptionSuggestions",
         feedSubscriptionSuggestions: { suggestedUserIds: [] }
-      }), 0.2, 4);
+      }), 0.2, sampledItemsDeduped.length);
       
       const { spotlightIds, commentIds, postIds, needsSuggestedUsers } = extractIdsToLoad(sampledItems);
 

--- a/packages/lesswrong/server/resolvers/ultraFeedResolver.ts
+++ b/packages/lesswrong/server/resolvers/ultraFeedResolver.ts
@@ -198,7 +198,7 @@ function dedupSampledItems(sampled: SampledItem[]): SampledItem[] {
 const DEFAULT_RESOLVER_SETTINGS: UltraFeedResolverSettings = DEFAULT_ULTRAFEED_SETTINGS.resolverSettings;
 
 const parseUltraFeedSettings = (settingsJson?: string): UltraFeedResolverSettings => {
-  let parsedSettings: UltraFeedResolverSettings = DEFAULT_RESOLVER_SETTINGS;
+  let parsedSettings: UltraFeedResolverSettings = cloneDeep(DEFAULT_RESOLVER_SETTINGS);
   if (settingsJson) {
     try {
       const settingsFromArg = JSON.parse(settingsJson);
@@ -506,6 +506,7 @@ export const ultraFeedGraphQLQueries = {
     }
 
     const parsedSettings = parseUltraFeedSettings(settingsJson);
+    parsedSettings.debugMode = !!parsedSettings.debugMode && userIsAdminOrMod(currentUser);
     const sourceWeights = parsedSettings.sourceWeights;
     const incognitoMode = parsedSettings.incognitoMode;
 

--- a/packages/lesswrong/server/resolvers/ultraFeedSubscriptionsResolver.ts
+++ b/packages/lesswrong/server/resolvers/ultraFeedSubscriptionsResolver.ts
@@ -429,6 +429,7 @@ export const ultraFeedSubscriptionsQueries = {
         }
       } else if (item.type === 'feedCommentThread') {
         const commentsList: DbComment[] = item.data.comments ?? [];
+        const exposureId = randomId();
         commentsList.forEach((c: DbComment, commentIndex: number) => {
           const servedEventId = item.data.commentMetaInfos?.[c._id]?.servedEventId ?? randomId();
           eventsToCreate.push({
@@ -437,7 +438,7 @@ export const ultraFeedSubscriptionsQueries = {
             eventType: 'served',
             collectionName: 'Comments',
             documentId: c._id,
-            event: { feedType: 'following', itemIndex, commentIndex, sources: ['subscriptionsComments'] },
+            event: { feedType: 'following', exposureId, itemIndex, commentIndex, sources: ['subscriptionsComments'] },
           });
         });
       }

--- a/packages/lesswrong/server/ultraFeed/algorithms/scoringAlgorithm.ts
+++ b/packages/lesswrong/server/ultraFeed/algorithms/scoringAlgorithm.ts
@@ -13,6 +13,7 @@ import type { RankableItem, RankedItemMetadata } from '../ultraFeedRankingTypes'
 import type { UltraFeedResolverSettings } from '@/components/ultraFeed/ultraFeedSettingsTypes';
 import { rankUltraFeedItems } from '../ultraFeedRanking';
 import { buildRankingConfigFromSettings } from '../ultraFeedRankingConfig';
+import { parseUltraFeedDiversityContext } from '@/lib/ultraFeedDiversity';
 
 export const scoringAlgorithm: UltraFeedAlgorithm = {
   name: 'scoring',
@@ -25,6 +26,6 @@ export const scoringAlgorithm: UltraFeedAlgorithm = {
     const config = buildRankingConfigFromSettings(settings.unifiedScoring);
     
     const enabledItems = items.filter(item => item.sources.some(source => settings.sourceWeights[source] > 0));
-    return rankUltraFeedItems(enabledItems, totalItems, config);
+    return rankUltraFeedItems(enabledItems, totalItems, config, undefined, parseUltraFeedDiversityContext(settings.diversityContext));
   },
 };

--- a/packages/lesswrong/server/ultraFeed/algorithms/scoringAlgorithm.ts
+++ b/packages/lesswrong/server/ultraFeed/algorithms/scoringAlgorithm.ts
@@ -24,7 +24,7 @@ export const scoringAlgorithm: UltraFeedAlgorithm = {
   ): Array<{ id: string; metadata?: RankedItemMetadata }> {
     const config = buildRankingConfigFromSettings(settings.unifiedScoring);
     
-    return rankUltraFeedItems(items, totalItems, config);
+    const enabledItems = items.filter(item => item.sources.some(source => settings.sourceWeights[source] > 0));
+    return rankUltraFeedItems(enabledItems, totalItems, config);
   },
 };
-

--- a/packages/lesswrong/server/ultraFeed/ultraFeedEvents.ts
+++ b/packages/lesswrong/server/ultraFeed/ultraFeedEvents.ts
@@ -1,0 +1,76 @@
+import type { UltraFeedResolverType, UserOrClientId } from "@/components/ultraFeed/ultraFeedTypes";
+import type { UltraFeedEventInsertData } from "../resolvers/ultraFeedResolverHelpers";
+import { randomId } from "@/lib/random";
+
+export const createUltraFeedEvents = (
+  results: UltraFeedResolverType[],
+  userOrClientId: UserOrClientId,
+  sessionId: string,
+  offset: number
+): UltraFeedEventInsertData[] => {
+  const eventsToCreate: UltraFeedEventInsertData[] = [];
+  const userId = userOrClientId.id;
+  const isLoggedOut = userOrClientId.type === 'client';
+
+  results.forEach((item, index) => {
+    const actualItemIndex = offset + index;
+
+    if (item.type === "feedSpotlight" && item.feedSpotlight?.spotlight?._id) {
+      const servedEventId = item.feedSpotlight.spotlightMetaInfo.servedEventId;
+      eventsToCreate.push({
+        _id: servedEventId,
+        userId,
+        eventType: "served",
+        collectionName: "Spotlights",
+        documentId: item.feedSpotlight.spotlight._id,
+        event: { sessionId, itemIndex: actualItemIndex, sources: ["spotlights"], ...(isLoggedOut ? { loggedOut: true } : {}) }
+      });
+    } else if (item.type === "feedCommentThread" && (item.feedCommentThread?.comments?.length ?? 0) > 0) {
+        const exposureId = randomId();
+        const threadData = item.feedCommentThread;
+        const comments = threadData?.comments;
+        const commentMetaInfos = threadData?.commentMetaInfos;
+        const sources = threadData?.commentMetaInfos?.[comments?.[0]?._id ?? ""]?.sources ?? [];
+        comments?.forEach((comment: DbComment, commentIndex) => {
+          if (comment?._id) {
+            const displayStatus = commentMetaInfos?.[comment._id]?.displayStatus;
+            const servedEventId = commentMetaInfos?.[comment._id]?.servedEventId;
+            if (servedEventId) {
+              eventsToCreate.push({
+                 _id: servedEventId,
+                 userId,
+                 eventType: "served",
+                 collectionName: "Comments",
+                 documentId: comment._id,
+                 event: {
+                  sessionId,
+                  exposureId,
+                  itemIndex: actualItemIndex,
+                  commentIndex,
+                  displayStatus,
+                  sources,
+                  ...(isLoggedOut ? { loggedOut: true } : {})
+                }
+                });
+            }
+          }
+        });
+    } else if (item.type === "feedPost" && item.feedPost?.post?._id) {
+      const feedItem = item.feedPost;
+      const servedEventId = feedItem.postMetaInfo?.servedEventId;
+      const sources = feedItem.postMetaInfo?.sources ?? [];
+      if (feedItem.post._id && servedEventId) {
+        eventsToCreate.push({
+          _id: servedEventId,
+          userId,
+          eventType: "served",
+          collectionName: "Posts",
+          documentId: feedItem.post._id,
+          event: { sessionId, itemIndex: actualItemIndex, sources, ...(isLoggedOut ? { loggedOut: true } : {}) }
+        });
+      }
+    }
+  });
+
+  return eventsToCreate;
+};

--- a/packages/lesswrong/server/ultraFeed/ultraFeedFetchLimits.ts
+++ b/packages/lesswrong/server/ultraFeed/ultraFeedFetchLimits.ts
@@ -23,7 +23,7 @@ export const calculateFetchLimits = (
   const hackerNewsPostWeight = sourceWeights['hacker-news'] ?? 0;
   const subscribedPostWeight = sourceWeights['subscriptionsPosts'] ?? 0;
   const bookmarkWeight = sourceWeights['bookmarks'] ?? 0;
-  const totalCommentWeight = feedCommentSourceTypesArray.reduce((sum: number, type: FeedItemSourceType) => sum + (sourceWeights[type] || 0), 0);
+  const totalCommentWeight = feedCommentSourceTypesArray.filter(type => type !== 'bookmarks').reduce((sum: number, type: FeedItemSourceType) => sum + (sourceWeights[type] || 0), 0);
   const totalSpotlightWeight = feedSpotlightSourceTypesArray.reduce((sum: number, type: FeedItemSourceType) => sum + (sourceWeights[type] || 0), 0);
 
   const baseCommentFetchLimit = Math.ceil(totalLimit * (totalCommentWeight / (totalWeight || 1)) * bufferMultiplier);

--- a/packages/lesswrong/server/ultraFeed/ultraFeedFetchLimits.ts
+++ b/packages/lesswrong/server/ultraFeed/ultraFeedFetchLimits.ts
@@ -1,0 +1,45 @@
+import { feedCommentSourceTypesArray, feedSpotlightSourceTypesArray, type FeedItemSourceType } from "@/components/ultraFeed/ultraFeedTypes";
+
+export const calculateFetchLimits = (
+  sourceWeights: Record<string, number>,
+  totalLimit: number,
+  offset: number = 0,
+  bufferMultiplier = 3.6,
+  latestAndSubscribedPostMultiplier = 3.0,
+  recombeeMultiplier = 3.6,
+): {
+  totalWeight: number;
+  recombeePostFetchLimit: number;
+  hackerNewsPostFetchLimit: number;
+  subscribedPostFetchLimit: number;
+  commentFetchLimit: number;
+  spotlightFetchLimit: number;
+  bookmarkFetchLimit: number;
+  bufferMultiplier: number;
+} => {
+  const totalWeight = Object.values(sourceWeights).reduce((sum: number, weight) => sum + weight, 0);
+
+  const recombeePostWeight = sourceWeights['recombee-lesswrong-ultrafeed'] ?? 0;
+  const hackerNewsPostWeight = sourceWeights['hacker-news'] ?? 0;
+  const subscribedPostWeight = sourceWeights['subscriptionsPosts'] ?? 0;
+  const bookmarkWeight = sourceWeights['bookmarks'] ?? 0;
+  const totalCommentWeight = feedCommentSourceTypesArray.reduce((sum: number, type: FeedItemSourceType) => sum + (sourceWeights[type] || 0), 0);
+  const totalSpotlightWeight = feedSpotlightSourceTypesArray.reduce((sum: number, type: FeedItemSourceType) => sum + (sourceWeights[type] || 0), 0);
+
+  const baseCommentFetchLimit = Math.ceil(totalLimit * (totalCommentWeight / (totalWeight || 1)) * bufferMultiplier);
+
+  // Scale up comment fetch limit based on offset to reduce repetition in subsequent calls: grows incrementally with each call, capped at 200
+  const commentFetchLimit = totalCommentWeight > 0 ? Math.min(baseCommentFetchLimit + Math.round(offset / 2), 200) : 0;
+
+
+  return {
+    totalWeight,
+    recombeePostFetchLimit: Math.ceil(totalLimit * (recombeePostWeight / (totalWeight || 1)) * recombeeMultiplier),
+    hackerNewsPostFetchLimit: Math.ceil(totalLimit * (hackerNewsPostWeight / (totalWeight || 1)) * latestAndSubscribedPostMultiplier),
+    subscribedPostFetchLimit: Math.ceil(totalLimit * (subscribedPostWeight / (totalWeight || 1)) * latestAndSubscribedPostMultiplier),
+    commentFetchLimit,
+    spotlightFetchLimit: Math.ceil(totalLimit * (totalSpotlightWeight / (totalWeight || 1)) * bufferMultiplier),
+    bookmarkFetchLimit: Math.ceil(totalLimit * (bookmarkWeight / (totalWeight || 1)) * bufferMultiplier),
+    bufferMultiplier
+  };
+};

--- a/packages/lesswrong/server/ultraFeed/ultraFeedPostHelpers.ts
+++ b/packages/lesswrong/server/ultraFeed/ultraFeedPostHelpers.ts
@@ -183,7 +183,7 @@ export async function getUltraFeedPostThreads(
       ? getRecommendedPostsForUltraFeed(context, recommendedPostsLimit, recombeeScenario)
       : Promise.resolve([]),
     (latestAndSubscribedPostsLimit > 0)
-      ? getLatestAndSubscribedPosts(context, latestAndSubscribedPostsLimit, maxAgeDays)
+      ? getLatestAndSubscribedPosts(context, latestAndSubscribedPostsLimit, maxAgeDays, settings.sourceWeights['hacker-news'] <= 0)
       : Promise.resolve([]),
   ]);
 

--- a/packages/lesswrong/server/ultraFeed/ultraFeedPostHelpers.ts
+++ b/packages/lesswrong/server/ultraFeed/ultraFeedPostHelpers.ts
@@ -1,9 +1,9 @@
-import { FeedFullPost, FeedItemSourceType, FeedPostStub } from "@/components/ultraFeed/ultraFeedTypes";
+import { FeedFullPost, FeedItemSourceType } from "@/components/ultraFeed/ultraFeedTypes";
 import { FilterSettings, getDefaultFilterSettings } from "@/lib/filterSettings";
 import { recombeeApi, recombeeRequestHelpers } from "@/server/recombee/client";
-import { RecombeeRecommendationArgs } from "@/lib/collections/users/recommendationSettings";
 import { UltraFeedResolverSettings } from "@/components/ultraFeed/ultraFeedSettingsTypes";
 import keyBy from 'lodash/keyBy';
+import { accessFilterMultiple } from "@/lib/utils/schemaUtils";
 
 // Configuration for unviewed items optimization
 const UNVIEWED_RECOMBEE_CONFIG = {
@@ -31,113 +31,62 @@ export async function getRecommendedPostsForUltraFeed(
     return [];
   }
 
-  let unviewedRecombeePostIds: string[] = [];
-  let adjustedLimit = limit;
-  
-  if (userIdOrClientId) {
-    unviewedRecombeePostIds = await repos.ultraFeedEvents.getUnviewedRecombeePostIds(
-      userIdOrClientId,
-      scenarioId,
-      UNVIEWED_RECOMBEE_CONFIG.lookbackDays,
-      limit
-    );
-    
-    const unviewedRatio = unviewedRecombeePostIds.length / limit;
-    
-    if (unviewedRatio >= UNVIEWED_RECOMBEE_CONFIG.skipFetchThreshold) {
-      // We have enough cached items, return them directly
-      const posts = await context.loaders.Posts.loadMany(unviewedRecombeePostIds.slice(0, limit));
-      
-      return posts
-        .filter((post): post is DbPost => !(post instanceof Error))
-        .slice(0, limit)
-        .map((post): FeedFullPost => ({
-          post,
-          postMetaInfo: {
-            sources: [scenarioId as FeedItemSourceType],
-            displayStatus: 'expanded',
-            highlight: true, // May be overridden by getViewedPostIds (these are unviewed from recent lookback period but concievably were viewed in the past)
-          },
-        }));
-    } else if (unviewedRatio >= UNVIEWED_RECOMBEE_CONFIG.reduceFetchThreshold) {
-      adjustedLimit = Math.ceil(limit * 0.5);
-    }
-  }
-
-  let exclusionFilterString: string | undefined = undefined;
-  const allExcludedIds = [
+  if (limit <= 0) return [];
+  const excluded = new Set([
     ...(currentUser?.hiddenPostsMetadata?.map(metadata => metadata.postId) ?? []),
     ...additionalExcludedIds,
-    ...unviewedRecombeePostIds
-  ];
-  
-  if (allExcludedIds.length > 0) {
-    const exclusionFilter = allExcludedIds.map(id => `"${id}"`).join(',');
-    exclusionFilterString = `'itemId' NOT IN {${exclusionFilter}}`;
-  }
-
-  const lwAlgoSettings: RecombeeRecommendationArgs = {
-    scenario: scenarioId,
-    filterSettings: currentUser?.frontpageFilterSettings,
-    skipTopOfListPosts: true,
-    rotationRate: 0.5,
-    rotationTime: 24 * 30, // 30 days
-    ...(exclusionFilterString && { filter: exclusionFilterString }),
+  ]);
+  const filters: FilterSettings = currentUser?.frontpageFilterSettings ?? getDefaultFilterSettings();
+  const eligible = (post: Partial<DbPost>) => {
+    if (!post._id || excluded.has(post._id) || post.draft || post.rejected || post.deletedDraft) return false;
+    if (filters.personalBlog === 'Hidden' && !post.frontpageDate) return false;
+    return filters.tags.every(tag => {
+      const relevance = post.tagRelevance?.[tag.tagId] ?? 0;
+      return (tag.filterMode !== 'Hidden' || relevance < 1)
+        && (tag.filterMode !== 'Required' || relevance >= 1);
+    });
   };
 
-  const recommendedResults = await recombeeApi.getRecommendationsForUser(recombeeUser, adjustedLimit, lwAlgoSettings, context);
-  
-  const allPostIds = [
-    ...unviewedRecombeePostIds.slice(0, limit),
-    ...recommendedResults.map(item => item.post?._id).filter((id): id is string => !!id)
-  ];
-  
-  let viewedPostIds = new Set<string>();
-  if (userIdOrClientId && allPostIds.length > 0) {
-    viewedPostIds = await repos.ultraFeedEvents.getViewedPostIds(userIdOrClientId, allPostIds);
-  }
-  
-  const displayPosts = recommendedResults.map((item): FeedFullPost | null => {
-    if (!item.post?._id) return null;
-    const { post, recommId, scenario, generatedAt } = item;
-
-    const recommInfo = (recommId && generatedAt) ? {
-      recommId,
-      scenario: scenario || scenarioId,
-      generatedAt,
-    } : undefined;
-
-    return {
-      post,
+  const cachedIds = userIdOrClientId
+    ? await repos.ultraFeedEvents.getUnviewedRecombeePostIds(userIdOrClientId, scenarioId, UNVIEWED_RECOMBEE_CONFIG.lookbackDays, limit)
+    : [];
+  const loaded = await context.loaders.Posts.loadMany(cachedIds);
+  const cachedPosts = await accessFilterMultiple(currentUser, 'Posts',
+    loaded.filter((post): post is DbPost => !!post && !(post instanceof Error) && eligible(post)), context);
+  const cachedItems: FeedFullPost[] = cachedPosts.map(post => ({
+    post, postMetaInfo: { sources: [scenarioId as FeedItemSourceType], displayStatus: 'expanded', highlight: false },
+  }));
+  const ratio = cachedItems.length / limit;
+  let freshItems: FeedFullPost[] = [];
+  if (ratio < UNVIEWED_RECOMBEE_CONFIG.skipFetchThreshold) {
+    const fetchLimit = ratio >= UNVIEWED_RECOMBEE_CONFIG.reduceFetchThreshold ? Math.ceil(limit * 0.5) : limit;
+    const allExcludedIds = [...excluded, ...cachedPosts.map(post => post._id!)];
+    const filter = allExcludedIds.length
+      ? `'itemId' NOT IN {${allExcludedIds.map(id => JSON.stringify(id)).join(',')}}`
+      : undefined;
+    const recommended = await recombeeApi.getRecommendationsForUser(recombeeUser, fetchLimit, {
+      scenario: scenarioId, filterSettings: filters, skipTopOfListPosts: true,
+      rotationRate: 0.5, rotationTime: 24 * 30, ...(filter && { filter }),
+    }, context);
+    freshItems = recommended.filter(item => item.post && eligible(item.post)).map(item => ({
+      post: item.post,
       postMetaInfo: {
-        sources: [scenario as FeedItemSourceType],
-        displayStatus: 'expanded',
-        recommInfo: recommInfo,
-        highlight: post._id ? !viewedPostIds.has(post._id) : true,
+        sources: [(item.scenario || scenarioId) as FeedItemSourceType], displayStatus: 'expanded', highlight: false,
+        recommInfo: item.recommId && item.generatedAt ? {
+          recommId: item.recommId, scenario: item.scenario || scenarioId, generatedAt: item.generatedAt,
+        } : undefined,
       },
-    };
-  }).filter((p) => !!p);
-
-  if (adjustedLimit < limit && unviewedRecombeePostIds.length > 0) {
-    const postsToReuse = limit - displayPosts.length;
-    const reusedPostIds = unviewedRecombeePostIds.slice(0, postsToReuse);
-    const reusedPosts = await context.loaders.Posts.loadMany(reusedPostIds);
-    
-    const reusedDisplayPosts = reusedPosts
-      .filter((post): post is DbPost => !(post instanceof Error))
-      .map((post): FeedFullPost => ({
-        post,
-        postMetaInfo: {
-          sources: [scenarioId as FeedItemSourceType],
-          displayStatus: 'expanded',
-          highlight: !viewedPostIds.has(post._id),
-        },
-      }));
-    
-    return [...reusedDisplayPosts, ...displayPosts].slice(0, limit);
+    }));
   }
 
-  return displayPosts;
+  // Every path, including a cache-only response, gets current read highlighting.
+  const items = [...new Map([...cachedItems, ...freshItems].map(item => [item.post._id, item])).values()].slice(0, limit);
+  const viewed = userIdOrClientId
+    ? await repos.ultraFeedEvents.getViewedPostIds(userIdOrClientId, items.map(item => item.post._id!))
+    : new Set<string>();
+  return items.map(item => ({ ...item, postMetaInfo: {
+    ...item.postMetaInfo, highlight: !viewed.has(item.post._id!), isRead: viewed.has(item.post._id!),
+  } }));
 }
 
 /**

--- a/packages/lesswrong/server/ultraFeed/ultraFeedRanking.ts
+++ b/packages/lesswrong/server/ultraFeed/ultraFeedRanking.ts
@@ -1,3 +1,4 @@
+import type { UltraFeedDiversityContext } from "@/lib/ultraFeedDiversity";
 import { FeedFullPost, FeedItemSourceType, ThreadEngagementStats } from '@/components/ultraFeed/ultraFeedTypes';
 import { generateThreadHash } from './ultraFeedThreadHelpers';
 import moment from 'moment';
@@ -329,32 +330,28 @@ function normalizeSourcesKey(sources?: FeedItemSourceType[]): string {
 function selectWithDiversityConstraints(
   scoredItems: ScoredItem[],
   totalItems: number,
-  constraints: DiversityConstraints
+  constraints: DiversityConstraints,
+  context?: UltraFeedDiversityContext,
 ): Array<{ id: string; appliedConstraints: string[]; position: number }> {
   const selectedWithMetadata: Array<{ id: string; appliedConstraints: string[]; position: number }> = [];
   const selectedSet = new Set<string>();
   const available = [...scoredItems];
   
-  const recentTypes: RankableItemType[] = [];
-  const recentSubscribed: boolean[] = [];
-  const recentSources: string[] = [];
+  const history = [...context?.history ?? []];
+  const recentTypes: RankableItemType[] = history.map(item => item.itemType);
+  const recentSubscribed: boolean[] = history.map(item => item.userSubscribedToAuthor);
+  const recentSources: string[] = history.map(item => normalizeSourcesKey(item.sources));
   
   while (selectedWithMetadata.length < totalItems && available.length > 0) {
-    const currentPosition = selectedWithMetadata.length;
+    const currentPosition = (context?.offset ?? 0) + selectedWithMetadata.length;
     const appliedConstraints: string[] = [];
     const windowStart = Math.floor(currentPosition / constraints.guaranteedSlotsPerWindow.windowSize) * constraints.guaranteedSlotsPerWindow.windowSize;
     const positionInWindow = currentPosition - windowStart;
     
-    const selectedInWindow = selectedWithMetadata.slice(windowStart, currentPosition).map(s => s.id);
-    const bookmarksInWindow = selectedInWindow.filter(id => {
-      const scoredItem = scoredItems.find(si => si.id === id);
-      return scoredItem?.item.sources?.includes('bookmarks' as FeedItemSourceType);
-    }).length;
-    const spotlightsInWindow = selectedInWindow.filter(id => {
-      const scoredItem = scoredItems.find(si => si.id === id);
-      return scoredItem?.item.sources?.includes('spotlights' as FeedItemSourceType);
-    }).length;
-    
+    const selectedInWindow = history.filter(item => item.position >= windowStart && item.position < currentPosition);
+    const bookmarksInWindow = selectedInWindow.filter(item => item.sources.includes('bookmarks')).length;
+    const spotlightsInWindow = selectedInWindow.filter(item => item.sources.includes('spotlights')).length;
+
     // Force bookmark/spotlight near end of window if not already present
     // With windowSize=20: Spotlight at position 17 (18th item), bookmark at position 19 (20th item)
     const needsSpotlight = positionInWindow === (constraints.guaranteedSlotsPerWindow.windowSize - 3) && 
@@ -457,6 +454,8 @@ function selectWithDiversityConstraints(
       : selectedItem.item.itemType === 'commentThread'
         ? selectedItem.item.userSubscribedToAuthor
         : false;
+    history.push({ position: currentPosition, itemType: selectedItem.item.itemType,
+      sources: selectedItem.item.sources, userSubscribedToAuthor: isSubscribed });
     recentSubscribed.push(isSubscribed);
     recentSources.push(normalizeSourcesKey(selectedItem.item.sources));
   }
@@ -534,14 +533,15 @@ export function rankUltraFeedItems(
   items: RankableItem[],
   totalItems: number,
   config: RankingConfig = DEFAULT_RANKING_CONFIG,
-  diversityConstraints: DiversityConstraints = DEFAULT_DIVERSITY_CONSTRAINTS
+  diversityConstraints: DiversityConstraints = DEFAULT_DIVERSITY_CONSTRAINTS,
+  context?: UltraFeedDiversityContext,
 ): Array<{ id: string; metadata?: RankedItemMetadata }> {
   const scoredItems = scoreItems(items, config);
 
 
   scoredItems.sort((a, b) => b.score - a.score);
 
-  const selectedWithConstraints = selectWithDiversityConstraints(scoredItems, totalItems, diversityConstraints);
+  const selectedWithConstraints = selectWithDiversityConstraints(scoredItems, totalItems, diversityConstraints, context);
   
   return selectedWithConstraints.map(({ id, appliedConstraints, position }) => {
     const scoredItem = scoredItems.find(si => si.id === id);

--- a/packages/lesswrong/server/ultraFeed/ultraFeedRanking.ts
+++ b/packages/lesswrong/server/ultraFeed/ultraFeedRanking.ts
@@ -101,6 +101,7 @@ export function toThreadRankable(
   const userSubscribedToAuthor = perComment.some(c => c.userSubscribedToAuthor);
 
   const rankable: ThreadRankableItem = {
+    preselection: thread.preselection,
     id: threadId,
     itemType: 'commentThread',
     threadId,
@@ -502,6 +503,7 @@ function scoredItemToMetadata(
   if (scoredItem.itemType === 'commentThread') {
     return {
       rankedItemType: 'commentThread',
+      preselection: scoredItem.item.preselection,
       scoreBreakdown: scoredItem.breakdown,
       selectionConstraints,
       position,
@@ -555,5 +557,4 @@ export function rankUltraFeedItems(
     };
   });
 }
-
 

--- a/packages/lesswrong/server/ultraFeed/ultraFeedRankingConfig.ts
+++ b/packages/lesswrong/server/ultraFeed/ultraFeedRankingConfig.ts
@@ -13,7 +13,7 @@ export interface RankingConfig {
     // Formula: karmaBonus = min(karma * scale^exponent / (ageHrs + bias)^exponent, maxBonus)
     timeDecayBias: number; // Bias added to age (prevents division by zero, softens early decay)
     timeDecayScale: number; // Scale factor (controls overall decay rate)
-    timeDecayExponent: number; // Fixed at 1 for simple hyperbolic decay
+    timeDecayExponent: number; // Defaults to 0.25
 
     // Timeless karma bonuses
     // Formula: karmaBonus = min(karma^exponent / divisor, maxBonus)
@@ -106,7 +106,8 @@ export function buildRankingConfigFromSettings(unifiedScoring: {
 }): RankingConfig {
   const postSubscribedBonus = unifiedScoring.subscribedBonusSetting * 2;
   const commentSubscribedBonus = unifiedScoring.subscribedBonusSetting * 2;
-  const timeDecayHalfLifeHours = unifiedScoring.timeDecayHalfLifeHours;
+  // Keep the persisted settings key compatible; its value is a scale, not a half-life.
+  const timeDecayScaleHours = unifiedScoring.timeDecayHalfLifeHours;
   
   return {
     startingValue: 1,
@@ -114,7 +115,7 @@ export function buildRankingConfigFromSettings(unifiedScoring: {
       typeMultiplier: unifiedScoring.postsMultiplier,
       subscribedBonus: postSubscribedBonus,
       timeDecayBias: 12,
-      timeDecayScale: timeDecayHalfLifeHours,
+      timeDecayScale: timeDecayScaleHours,
       timeDecayExponent: 0.25,
       karmaSuperlinearExponent: 1.2,
       karmaDivisor: 20,
@@ -124,7 +125,7 @@ export function buildRankingConfigFromSettings(unifiedScoring: {
     threads: {
       typeMultiplier: unifiedScoring.threadsMultiplier,
       timeDecayBias: 12,
-      timeDecayScale: timeDecayHalfLifeHours,
+      timeDecayScale: timeDecayScaleHours,
       timeDecayExponent: 0.25,
       subscribedCommentBonus: commentSubscribedBonus,
       karmaMaxBonus: 20,
@@ -141,4 +142,3 @@ export function buildRankingConfigFromSettings(unifiedScoring: {
     maxScore: 100,
   };
 }
-

--- a/packages/lesswrong/server/ultraFeed/ultraFeedRankingConverters.ts
+++ b/packages/lesswrong/server/ultraFeed/ultraFeedRankingConverters.ts
@@ -77,12 +77,14 @@ export const convertFetchedItemsToRankable = (
     }
   });
 
-  return [
-    ...rankablePosts,
-    ...rankableThreads,
-    ...rankableSpotlights,
-    ...rankableBookmarks,
-  ];
+  // One candidate can arrive through several sources. Keep its content score and
+  // union its sources before selection, so a selected post can satisfy bookmark variety.
+  const byId = new Map<string, RankableItem>();
+  for (const item of [...rankablePosts, ...rankableThreads, ...rankableSpotlights, ...rankableBookmarks]) {
+    const existing = byId.get(item.id);
+    byId.set(item.id, existing ? { ...existing, sources: [...new Set([...existing.sources, ...item.sources])] } : item);
+  }
+  return [...byId.values()];
 };
 
 const attachMetadataToPost = (
@@ -197,7 +199,9 @@ export const mapRankedIdsToSampledItems = (
     if (post) {
       return {
         type: "feedPostWithContents" as const,
-        feedPost: attachMetadataToPost(post, metadata),
+        feedPost: attachMetadataToPost(bookmarkIdToOriginal.has(id) ? {
+          ...post, postMetaInfo: { ...post.postMetaInfo, sources: [...new Set<FeedItemSourceType>([...post.postMetaInfo.sources, 'bookmarks'])] },
+        } : post, metadata),
       };
     }
     
@@ -205,7 +209,11 @@ export const mapRankedIdsToSampledItems = (
     if (thread) {
       return {
         type: "feedCommentThread" as const,
-        feedCommentThread: attachMetadataToThread(thread, metadata),
+        feedCommentThread: attachMetadataToThread(bookmarkIdToOriginal.has(id) ? {
+          ...thread, comments: thread.comments.map(comment => comment.metaInfo ? ({
+            ...comment, metaInfo: { ...comment.metaInfo, sources: [...new Set<FeedItemSourceType>([...comment.metaInfo.sources, 'bookmarks'])] },
+          }) : comment),
+        } : thread, metadata),
       };
     }
     

--- a/packages/lesswrong/server/ultraFeed/ultraFeedRankingTypes.ts
+++ b/packages/lesswrong/server/ultraFeed/ultraFeedRankingTypes.ts
@@ -1,4 +1,4 @@
-import { FeedItemSourceType, PreDisplayFeedComment, ThreadEngagementStats } from '@/components/ultraFeed/ultraFeedTypes';
+import { FeedItemSourceType, PreDisplayFeedComment, ThreadEngagementStats, ThreadPreselectionInfo } from '@/components/ultraFeed/ultraFeedTypes';
 
 export type RankableItemType = 'post' | 'commentThread' | 'spotlight' | 'bookmark' | 'subscriptionSuggestions';
 
@@ -41,6 +41,7 @@ export interface ThreadAggregateStats {
 }
 
 export interface ThreadRankableItem extends RankableItemBase {
+  preselection?: ThreadPreselectionInfo;
   itemType: 'commentThread';
   threadId: string;
   sources: FeedItemSourceType[];
@@ -99,6 +100,7 @@ export type RankedItemMetadata =
     }
   | {
       rankedItemType: 'commentThread';
+      preselection?: ThreadPreselectionInfo;
       scoreBreakdown: ThreadScoreBreakdown;
       selectionConstraints: string[];
       position: number;
@@ -109,7 +111,7 @@ export type RankedItemMetadata =
  * We only rely on comments and optionally primarySource.
  */
 export interface MappablePreparedThread {
+  preselection?: ThreadPreselectionInfo;
   comments: PreDisplayFeedComment[];
   primarySource?: FeedItemSourceType;
 }
-

--- a/packages/lesswrong/server/ultraFeed/ultraFeedReadState.ts
+++ b/packages/lesswrong/server/ultraFeed/ultraFeedReadState.ts
@@ -1,0 +1,12 @@
+/** SQL expressions supplied here must be trusted identifiers/parameters, never user input. */
+export function ultraFeedReadIsCurrentSql(userId: string, documentId: string, timestamp: string): string {
+  return `NOT EXISTS (
+    SELECT 1 FROM "UltraFeedEvents" unread
+    WHERE unread."userId" = ${userId}
+      AND unread."collectionName" = 'Posts'
+      AND unread."documentId" = ${documentId}
+      AND unread."eventType" = 'interacted'
+      AND unread.event->>'action' = 'markUnread'
+      AND unread."createdAt" >= ${timestamp}
+  )`;
+}

--- a/packages/lesswrong/server/ultraFeed/ultraFeedThreadHelpers.ts
+++ b/packages/lesswrong/server/ultraFeed/ultraFeedThreadHelpers.ts
@@ -1,3 +1,4 @@
+import { explainThreadPreselection } from "./ultraFeedThreadPreselection";
 /**
  * Helpers for UltraFeed thread prioritization and preparation.
  * 
@@ -630,58 +631,15 @@ export async function getUltraFeedCommentThreads(
   // --- Select Best Threads --- 
   const finalRankedThreads = selectBestThreads(allScoredThreads); 
 
-  // --- Filter out non-viable threads ---
-  const nonViableReasons = {
-    zeroOrNegativeScore: 0,
-    allCommentsViewed: 0,
-    allCommentsServedInSession: 0,
-  };
-  
-  const viableThreads = finalRankedThreads.filter(rankedThreadInfo => {
-    const thread = rankedThreadInfo.thread;
-    
-    // Exclude threads with zero or negative scores
-    if (rankedThreadInfo.score <= 0) {
-      nonViableReasons.zeroOrNegativeScore++;
-      return false;
-    }
-    
-    // Exclude threads where ALL comments have been viewed or interacted with
-    const hasUnviewedComment = thread.some(comment => 
-      !comment.lastViewed && !comment.lastInteracted
-    );
-    if (!hasUnviewedComment) {
-      nonViableReasons.allCommentsViewed++;
-      return false;
-    }
-    
-    // Exclude threads where ALL comments have already been served in this session
-    if (sessionId && servedCommentIdsInSession.size > 0) {
-      const hasUnservedComment = thread.some(comment => 
-        !servedCommentIdsInSession.has(comment.commentId)
-      );
-      if (!hasUnservedComment) {
-        nonViableReasons.allCommentsServedInSession++;
-        return false;
-      }
-    }
-    
-    return true;
+  const explanations = explainThreadPreselection(finalRankedThreads, limit, servedCommentIdsInSession);
+  const displayThreads = finalRankedThreads.flatMap((rankedThreadInfo, index) => {
+    const preselection = explanations[index];
+    if (!settings.debugMode && !preselection.selected) return [];
+    const prepared = prepareThreadForDisplay(rankedThreadInfo, engagementStatsMap);
+    return prepared ? [{ ...prepared, preselection }] : [];
   });
 
-  const totalThreads = finalRankedThreads.length;
-  const nonViableCount = totalThreads - viableThreads.length;
-  ultraFeedLog(
-    `Comment threads - total: ${totalThreads}, viable: ${viableThreads.length}, ` +
-    `non-viable: ${nonViableCount} (score≤0: ${nonViableReasons.zeroOrNegativeScore}, ` +
-    `viewed: ${nonViableReasons.allCommentsViewed}, served: ${nonViableReasons.allCommentsServedInSession}), ` +
-    `limit: ${limit}`
-  );
-  
-  const displayThreads = viableThreads
-    .slice(0, limit) 
-    .map(rankedThreadInfo => prepareThreadForDisplay(rankedThreadInfo, engagementStatsMap))
-    .filter(rankedThreadInfo => !!rankedThreadInfo);
+  ultraFeedLog(`Comment threads: ${finalRankedThreads.length} candidates, ${explanations.filter(info => info.selected).length} selected, limit ${limit}`);
 
   const returnedCommentIds = displayThreads.flatMap(thread => 
     thread.comments.map(comment => comment.commentId.substring(0, 3))

--- a/packages/lesswrong/server/ultraFeed/ultraFeedThreadHelpers.ts
+++ b/packages/lesswrong/server/ultraFeed/ultraFeedThreadHelpers.ts
@@ -23,6 +23,7 @@ import {
   FeedCommentMetaInfo, 
   FeedCommentFromDb,
   FeedItemSourceType,
+  feedCommentSourceTypesArray,
   FeedItemDisplayStatus,
   ThreadEngagementStats,
 } from '../../components/ultraFeed/ultraFeedTypes';
@@ -577,7 +578,9 @@ export async function getUltraFeedCommentThreads(
     userIdOrClientId, 
     1000, 
     initialCandidateLookbackDays, 
-    commentServedEventRecencyHours
+    commentServedEventRecencyHours,
+    false,
+    feedCommentSourceTypesArray.filter(source => settings.sourceWeights[source] > 0),
   );
   const engagementStatsPromise = commentsRepo.getThreadEngagementStatsForRecentlyActiveThreads(
     userIdOrClientId,

--- a/packages/lesswrong/server/ultraFeed/ultraFeedThreadPreselection.ts
+++ b/packages/lesswrong/server/ultraFeed/ultraFeedThreadPreselection.ts
@@ -1,0 +1,19 @@
+import type { ThreadPreselectionInfo } from '@/components/ultraFeed/ultraFeedTypes';
+
+interface ThreadCandidate {
+  score: number;
+  thread: Array<{ commentId: string; lastViewed: Date | null; lastInteracted: Date | null }>;
+}
+
+/** Describes the exact exclusions used by normal selection as well as the Debug view. */
+export function explainThreadPreselection(candidates: ThreadCandidate[], limit: number, servedIds: Set<string>): ThreadPreselectionInfo[] {
+  let viableRank = 0;
+  return candidates.map((candidate, index) => {
+    const reasons: string[] = [];
+    if (!Number.isFinite(candidate.score) || candidate.score <= 0) reasons.push('non-positive score');
+    if (candidate.thread.every(comment => comment.lastViewed || comment.lastInteracted)) reasons.push('all comments seen');
+    if (candidate.thread.every(comment => servedIds.has(comment.commentId))) reasons.push('already served in this session');
+    if (reasons.length === 0 && ++viableRank > limit) reasons.push('candidate limit');
+    return { score: candidate.score, rank: index + 1, candidateLimit: limit, selected: reasons.length === 0, reasons };
+  });
+}


### PR DESCRIPTION
Opening a post currently makes UltraFeed treat its older comments as seen, even if the reader never scrolls to them. This PR separates post visits from comment observations and fixes several related ways the feed can lose unread content or miscount repetition.

The changes are split into individual commits:

- **Seen and unread state:** track actual visible reading, pause tracking for hidden tabs/feeds and dialogs, preserve tracking across settings changes, respect explicit unread actions, and keep incognito expansion out of reading signals. Large delivery histories no longer erase earlier observations.
- **Repetition:** count a comment card once per exposure across its comments and view milestones. Retire repeatedly viewed spotlights correctly.
- **Content choices:** honor disabled sources on later pages, recheck cached recommendations against current preferences and read state, and preserve bookmark attribution when sources overlap.
- **Pagination and explanations:** carry diversity history across pages without letting suggestions consume reserved slots, show upstream thread-selection decisions in Debug, and correct the misleading half-life setting description without changing saved values.

### Bugs fixed

Ordered by expected user impact, with rarely used incognito behavior ranked lower.

- Opening a post marked its older comments as seen even when the reader never scrolled to them.
- Hidden browser tabs, inactive feed tabs, and open dialogs could continue recording views.
- Marking a post unread failed to override earlier UltraFeed views.
- Cached recommendations could bypass updated content exclusions.
- Large event histories could push earlier observations out of query limits and make seen content appear unseen again.
- Viewing multiple comments or reaching both short and long view milestones counted the same card exposure more than once toward repetition penalties.
- Spotlights with too many views could reappear as unseen candidates.
- Disabling an individual comment source did not reliably exclude its candidates.
- Choosing only followed posts could still admit posts from unrelated authors.
- Pagination could fetch ordinary comments even when every ordinary comment source was disabled.
- Cached recommendations could highlight already-read posts as unread.
- Removed post and spotlight cards could retain observer registrations and pending view timers.
- Diversity counters restarted on each page, preventing bookmark and spotlight guarantees from spanning pages.
- Subscription suggestions and markers could consume reserved diversity positions and cause those slots to be skipped.
- Posts and threads appearing through multiple sources could lose their bookmark attribution.
- Expanding a post in incognito still updated ordinary reading and recommendation signals.
- Changing incognito settings could lose observer registrations for cards that remained mounted.
- Bookmark-only requests unnecessarily fetched ordinary comment candidates.
- The time-decay setting description incorrectly implied that it controlled the relative rate of age decay.
- Debug explanations omitted the upstream thread scores and exclusions that determined which candidates reached final ranking.

### Validation

Locally, 21 synthetic behavior scenarios, 22 focused unit tests, and nine PostgreSQL regressions passed. They cover delivery versus observation, unread transitions, visibility/incognito, reader isolation, source filtering, cached recommendations, repetition, long histories, and pagination. The behavior suite caught two additional bugs fixed here: skipped diversity slots and lost bookmark attribution.

Tests and test infrastructure are intentionally excluded from this PR and retained on the original local branch. Changed-file lint and whitespace checks pass. Full typechecking is blocked by missing generated route types and Hocuspocus dependencies in the PR checkout; actual browser scrolling and post expansion still need verification.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes feed ranking, read/unread inference, and analytics event semantics across SQL repos and the client observer—mistakes could hide content, over-serve repeats, or corrupt read state.
> 
> **Overview**
> UltraFeed no longer treats opening a post as proof that its comments were read. **Comment read state** now comes only from comment-specific `UltraFeedEvents`; post `ReadStatuses` are no longer unioned into comment candidate queries, and large event histories are no longer truncated in a way that drops earlier observations.
> 
> **Exposure and unread semantics** are tightened end-to-end: view tracking moves into `UltraFeedViewTracker`, pauses when the tab is hidden, a dialog is open, or incognito is on, and only counts the active feed tab. Feed items unregister observers on unmount; post expansion skips `recordPostView` in incognito. Marking a post unread writes an `interacted` event, and post read/view queries ignore views invalidated by a later `markUnread` via `ultraFeedReadIsCurrentSql`.
> 
> **Repetition and serving** count one exposure per comment card (`exposureId` on served thread events), merge short/long views for legacy events, and count spotlight views by distinct `feedItemId`. Cached Recombee posts are re-filtered for preferences and current read highlighting; disabled sources stay off on later pages (comment SQL + scoring filter). Overlapping candidates merge sources so bookmark slots can still be satisfied.
> 
> **Pagination** adds optional `getPaginationVariables` on `MixedTypeFeed`; the main feed sends a `diversityContext` built from displayed results so bookmark/spotlight windows continue across pages without suggestions/markers consuming slots. Debug shows thread **preselection** rank, score, and exclusion reasons; settings copy clarifies that `timeDecayHalfLifeHours` is a karma scale, not a half-life.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc695129b8d585238b802423868a29e5bbd2513d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1218254403700496) by [Unito](https://www.unito.io)




