### PR TITLE
Scrub the agent session from saved environments under the real home dir

### DIFF
--- a/packages/lesswrong/server/research/sandbox/saveEnvironment.ts
+++ b/packages/lesswrong/server/research/sandbox/saveEnvironment.ts
@@ -1,5 +1,6 @@
 import { Sandbox, Snapshot } from "@vercel/sandbox";
 import { signSupervisorToken } from "./supervisor/auth";
+import { CLAUDE_DIR, SANDBOX_HOME_DIR } from "./sandboxLayout";
 import {
   getRunningSandbox,
   sandboxNameForConversation,
@@ -89,18 +90,28 @@ function deriveLabel(repoDir: string | null, conversationTitle: string | null): 
 }
 
 async function scrubAgentSession(clone: Sandbox): Promise<void> {
-  // `~/.claude/projects` is the session transcript; `~/.claude/history.jsonl` is
-  // the global cross-conversation prompt log (outside projects/); `~/.claude.json`
-  // may hold MRU prompt state. This removes only the agent session — it is NOT a
+  // `.claude/projects` is the session transcript (and Claude Code's auto-memory
+  // under it); `.claude/history.jsonl` is the global cross-conversation prompt
+  // log (outside projects/); `.claude.json` may hold MRU prompt state. Paths are
+  // spelled out under SANDBOX_HOME_DIR and removed as root: `runCommand` runs as
+  // the unprivileged `vercel-sandbox` user, whose `~` is /home/vercel-sandbox,
+  // not the agent's home. This removes only the agent session — it is NOT a
   // secrets scrub (the env keeps the user's functional setup, e.g. `.env`).
-  await clone.runCommand({
-    cmd: "sh",
+  const result = await clone.runCommand({
+    cmd: "rm",
     args: [
-      "-c",
-      "rm -rf ~/.claude/projects ~/.claude/history.jsonl; " +
-        "[ -f ~/.claude.json ] && rm -f ~/.claude.json; true",
+      "-rf",
+      `${CLAUDE_DIR}/projects`,
+      `${CLAUDE_DIR}/history.jsonl`,
+      `${SANDBOX_HOME_DIR}/.claude.json`,
     ],
+    sudo: true,
   });
+  if (result.exitCode !== 0) {
+    throw new Error(
+      `Failed to scrub the agent session from the environment clone (exit ${result.exitCode}): ${(await result.stderr()).slice(0, 500)}`,
+    );
+  }
 }
 
 async function createCloneFromSnapshot(snapshotId: string): Promise<Sandbox> {


### PR DESCRIPTION
## Bug

`scrubAgentSession` in `saveEnvironment.ts` ran `rm -rf ~/.claude/projects ~/.claude/history.jsonl` and `rm -f ~/.claude.json` via `sh -c`. Sandbox `runCommand` executes as the unprivileged `vercel-sandbox` user, whose `~` is `/home/vercel-sandbox`, while the supervisor pins the agent's `HOME` to `/root` (`SANDBOX_HOME_DIR`). The scrub therefore never touched the agent's real session files, and "without conversation" environments silently kept:

- every source conversation's transcript under `/root/.claude/projects/-vercel-sandbox/` (readable by the agent in any fork), and
- Claude Code's auto-memory (`.../memory/MEMORY.md` and friends), which is loaded by working directory rather than session id, so every fork started with the source conversation's memories in context.

Verified on the prod "Lightcone Commons Dev" environment snapshot: seven transcripts (~25 MB) plus six memory files were present.

## Fix

- Spell the paths out under `SANDBOX_HOME_DIR` / `CLAUDE_DIR` and run the `rm` with `sudo: true`.
- Throw if the scrub exits non-zero, so a failed scrub fails the save instead of leaking the session.

Existing "without conversation" environments saved before this change still contain their sessions; re-save them to clean them up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FCB4Q8BxnxYoGzzdW76yT1

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1218343262760953) by [Unito](https://www.unito.io)
