### PR TITLE
Allow white-space: pre-wrap on spans in the HTML sanitizer

### DIFF
--- a/packages/lesswrong/lib/utils/sanitize.ts
+++ b/packages/lesswrong/lib/utils/sanitize.ts
@@ -275,7 +275,11 @@ export const sanitize = function(s: string): string {
       },
       span: {
         // From: https://gist.github.com/olmokramer/82ccce673f86db7cda5e#gistcomment-3119899
-        color: [/([a-z]+|#([\da-f]{3}){1,2}|(rgb|hsl)a\((\d{1,3}%?,\s?){3}(1|0?\.\d+)\)|(rgb|hsl)\(\d{1,3}%?(,\s?\d{1,3}%?){2}\))/]
+        color: [/([a-z]+|#([\da-f]{3}){1,2}|(rgb|hsl)a\((\d{1,3}%?,\s?){3}(1|0?\.\d+)\)|(rgb|hsl)\(\d{1,3}%?(,\s?\d{1,3}%?){2}\))/],
+        // Lexical exports every text node as a span with white-space: pre-wrap,
+        // which is what makes typed double spaces visible in the editor.
+        // Keep it so published HTML renders the same whitespace.
+        'white-space': [/^pre-wrap$/],
       },
     }
   });

--- a/packages/lesswrong/unitTests/sanitize.tests.ts
+++ b/packages/lesswrong/unitTests/sanitize.tests.ts
@@ -189,3 +189,18 @@ describe('sanitize ordered list numbering', () => {
     expect(result).toContain('<li value="4">Item 4</li>');
   });
 });
+
+describe('sanitize text span whitespace', () => {
+  it('preserves white-space: pre-wrap on spans', () => {
+    const input = '<p><span style="white-space: pre-wrap;">Quiz show:  Can it?</span></p>';
+    const result = sanitize(input);
+    expect(result).toContain('white-space:pre-wrap');
+    expect(result).toContain('Quiz show:  Can it?');
+  });
+
+  it('strips other white-space values from spans', () => {
+    const input = '<p><span style="white-space: pre;">a  b</span></p>';
+    const result = sanitize(input);
+    expect(result).not.toContain('white-space');
+  });
+});


### PR DESCRIPTION
## Summary

Lexical exports every text node as `<span style="white-space: pre-wrap">`, which is what makes typed double spaces visible in the editor. The main sanitizer only allowed `color` on spans, so the style was stripped from the stored `html` column and consecutive spaces collapsed to one on the published page. Reopening the editor showed the double spaces again because Lexical rehydrates from its own state.

Reported via Intercom on https://www.lesswrong.com/editPost?postId=hXozGp2rsbZgXnH3o, where the pasted half of the post kept its double spacing (encoded as `&nbsp; ` by the paste source) while every edit typed directly in Lexical lost it. Older CKEditor-authored posts never hit this because CKEditor rewrote runs of spaces to nbsp-plus-space on input.

This only affects revisions saved after deploy, since `html` is computed at save time. Existing posts pick up the fix on their next save.

## Test plan

- [x] `yarn unit packages/lesswrong/unitTests/sanitize.tests.ts` (two new cases: pre-wrap preserved on spans, other `white-space` values still stripped)
- [ ] Type a double space in a Lexical post, save, and confirm the published page renders both spaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018XmE69YywwWguPzByPxfjo
