### PR TITLE
Extend Inkhaven frontpage through Sept 10 early-bird deadline

### DIFF
--- a/packages/lesswrong/components/seasonal/Inkhaven2026Banner.tsx
+++ b/packages/lesswrong/components/seasonal/Inkhaven2026Banner.tsx
@@ -3,10 +3,12 @@ import { AnalyticsContext } from "../../lib/analyticsEvents";
 import { defineStyles, useStyles } from '../hooks/useStyles';
 import CloudinaryImage2 from "../common/CloudinaryImage2";
 
-// Frontpage campaign: 10 days from 2026-08-28.
+// Frontpage campaign: originally 10 days from 2026-08-28; extended through EOD 2026-09-10 PT.
 export const INKHAVEN_RESIDENCY_3_SPOTLIGHT_ID = 'SbqCm443KuNuxoZKt';
 export const INKHAVEN_RESIDENCY_3_START = new Date('2026-08-28T00:00:00-07:00');
-export const INKHAVEN_RESIDENCY_3_END = new Date('2026-09-07T00:00:00-07:00');
+export const INKHAVEN_RESIDENCY_3_END = new Date('2026-09-11T00:00:00-07:00');
+export const INKHAVEN_RESIDENCY_3_EARLY_BIRD_LINE = 'Early-Bird Deadline is Tonight (Sept 10)';
+export const INKHAVEN_RESIDENCY_3_EARLY_BIRD_DESCRIPTION_HTML = '<p>Want to become a great blogger? Join a cohort of ~40 promising writers for an intense month focused on the art and craft of writing, where everyone will publish a blogpost every single day. With 1-1 support from people including Scott Alexander, Max Harms, Scott Sumner, and more. Nov 10–Dec 11, at Lighthaven, CA. Early-Bird Deadline is Tonight (Sept 10).</p>';
 const INKHAVEN_RESIDENCY_3_BANNER_PUBLIC_ID = 'ChatGPT_Image_Aug_29_2026_09_46_57_AM_uynuti';
 
 const styles = defineStyles("Inkhaven2026Banner", (theme: ThemeType) => ({
@@ -31,7 +33,7 @@ const styles = defineStyles("Inkhaven2026Banner", (theme: ThemeType) => ({
     display: 'block',
     // Wider/shorter asset than the previous plume; keep origin top-right and
     // scale up so the typewriter scene stays a similar size in the gutter.
-    transform: 'translate(calc(-38px + (0.6 * clamp(2.5rem, 3vw, 4rem) * 1.2)), calc(-2vh - 10px - (1.4 * clamp(2.5rem, 3vw, 4rem) * 1.2)))',
+    transform: 'translate(calc(-110px + (0.6 * clamp(2.5rem, 3vw, 4rem) * 1.2)), calc(-2vh - 10px - (1.4 * clamp(2.5rem, 3vw, 4rem) * 1.2)))',
     transformOrigin: 'top right',
   },
   imageColumn: {
@@ -72,6 +74,12 @@ const styles = defineStyles("Inkhaven2026Banner", (theme: ThemeType) => ({
         textDecoration: 'none',
       }
     },
+    '& h3': {
+      fontSize: 'clamp(1.5rem, 1.5vw, 2.2rem)',
+      margin: 0,
+      lineHeight: '1.2',
+      marginBottom: 8,
+    },
     '& button': {
       ...theme.typography.commentStyle,
       backgroundColor: theme.palette.primary.main,
@@ -111,6 +119,18 @@ const styles = defineStyles("Inkhaven2026Banner", (theme: ThemeType) => ({
   noWidow: {
     whiteSpace: 'nowrap',
   },
+  earlyBirdWide: {
+    display: 'block',
+    [theme.breakpoints.down(1600)]: {
+      display: 'none',
+    },
+  },
+  earlyBirdMid: {
+    display: 'none',
+    [theme.breakpoints.down(1600)]: {
+      display: 'block',
+    },
+  },
 }));
 
 export const Inkhaven2026Banner = () => {
@@ -129,6 +149,16 @@ export const Inkhaven2026Banner = () => {
         </div>
         <div className={classes.inkhavenBannerText}>
           <h2><a href="https://www.inkhaven.blog">Inkhaven<br /><span className={classes.noWidow}>Residency #3</span></a></h2>
+          <h3>
+            <span className={classes.earlyBirdWide}>
+              Early-Bird Deadline<br />
+              is Tonight <span className={classes.noWidow}>(Sept 10)</span>
+            </span>
+            <span className={classes.earlyBirdMid}>
+              Early-Bird Application Deadline<br />
+              is Tonight <span className={classes.noWidow}>(Sept 10)</span>
+            </span>
+          </h3>
           <div className={classes.inkhavenBannerDateAndLocation}>
             A month-long writing residency. Publish a blogpost every day for 30 days. Nov 10–Dec 11, 2026 in Berkeley, CA. <span className={classes.noWidow}>Scholarships available.</span>
           </div>

--- a/packages/lesswrong/components/spotlights/SpotlightItem.tsx
+++ b/packages/lesswrong/components/spotlights/SpotlightItem.tsx
@@ -33,7 +33,7 @@ import range from 'lodash/range';
 import { CommentByIdSuspense } from '../comments/CommentById';
 import { SingleLineCommentPlaceholder } from '../comments/SingleLineComment';
 import { descriptionStyles } from './SpotlightDescriptionStyles';
-import { INKHAVEN_RESIDENCY_3_SPOTLIGHT_ID } from '../seasonal/Inkhaven2026Banner';
+import { INKHAVEN_RESIDENCY_3_EARLY_BIRD_DESCRIPTION_HTML, INKHAVEN_RESIDENCY_3_EARLY_BIRD_LINE, INKHAVEN_RESIDENCY_3_SPOTLIGHT_ID } from '../seasonal/Inkhaven2026Banner';
 
 import dynamic from 'next/dynamic';
 const SpotlightForm = dynamic(() => import('./SpotlightForm').then(mod => ({ default: mod.SpotlightForm })), { ssr: false });
@@ -489,7 +489,12 @@ export const SpotlightItem = ({
   const style = {
     "--spotlight-fade": spotlight.imageFadeColor,
   } as CSSProperties;
-  const subtitleComponent = spotlight.subtitleUrl ? <Link to={spotlight.subtitleUrl}>{spotlight.customSubtitle}</Link> : spotlight.customSubtitle
+  const isInkhavenEarlyBird = spotlight._id === INKHAVEN_RESIDENCY_3_SPOTLIGHT_ID;
+  const displaySubtitle = isInkhavenEarlyBird ? INKHAVEN_RESIDENCY_3_EARLY_BIRD_LINE : spotlight.customSubtitle;
+  const descriptionHtml = isInkhavenEarlyBird
+    ? INKHAVEN_RESIDENCY_3_EARLY_BIRD_DESCRIPTION_HTML
+    : (spotlight.description?.html ?? '');
+  const subtitleComponent = spotlight.subtitleUrl ? <Link to={spotlight.subtitleUrl}>{displaySubtitle}</Link> : displaySubtitle
 
   const spotlightDocument = spotlight.post ?? spotlight.sequence ?? spotlight.tag;
   const spotlightReviews = getSpotlightDisplayReviews(spotlight);
@@ -516,7 +521,7 @@ export const SpotlightItem = ({
                   </LWTooltip>}
                 </span>
               </div>
-              {spotlight.customSubtitle && showSubtitle && <div className={classes.subtitle}>
+              {displaySubtitle && showSubtitle && <div className={classes.subtitle}>
                 {subtitleComponent}
               </div>}
               <div className={classes.description}>
@@ -530,7 +535,7 @@ export const SpotlightItem = ({
                   </div>
                   :
                   <ContentItemBody
-                    dangerouslySetInnerHTML={{__html: spotlight.description?.html ?? ''}}
+                    dangerouslySetInnerHTML={{__html: descriptionHtml}}
                     description={`${spotlight.documentType} ${spotlightDocument?._id}`}
                   />
                 }

--- a/packages/lesswrong/scripts/overcomingBiasLinks/rewrite.ts
+++ b/packages/lesswrong/scripts/overcomingBiasLinks/rewrite.ts
@@ -6,6 +6,7 @@ import { getSqlClientOrThrow } from "@/server/sql/sqlClient";
 import { getNextVersionAfterSemver, htmlToChangeMetrics } from "@/server/editor/utils";
 import { randomId } from "@/lib/random";
 import { htmlToPingbacks } from "@/server/pingbacks";
+import { forumTypeSetting } from "@/lib/forumTypeUtils";
 import { inventorySchema, lookupResultSchema, type LinkDocument, type StoredRevision, normalizeObUrl, parseLwUrl, transformContents } from "./content";
 
 interface RevisionEdit {
@@ -117,7 +118,7 @@ async function repairDocument(
         SELECT * FROM jsonb_populate_record(NULL::"Revisions", $(revision)::jsonb)
       `, { revision: JSON.stringify(edit.revision) });
       if (edit.updatePointer) {
-        const pingbacks = await htmlToPingbacks(edit.revision.html ?? "", [{ collectionName, documentId }]);
+        const pingbacks = await htmlToPingbacks(edit.revision.html ?? "", [{ collectionName, documentId }], forumTypeSetting.get());
         await tx.none(`
           UPDATE $(collectionName:name) SET contents_latest = $(revisionId), pingbacks = $(pingbacks)::jsonb
           ${collectionName === "Comments" ? `, contents = COALESCE(contents, '{}'::jsonb) || $(contents)::jsonb` : ""}


### PR DESCRIPTION
## Summary
- Turns the Inkhaven Residency #3 frontpage campaign back on through EOD Sept 10 PT (exclusive midnight Sept 11).
- Adds early-bird copy on the desktop sidebar (two-line on wide screens; "Application" on mid-width) and overrides the pinned mobile/tablet spotlight subtitle and body (~40 writers).
- Nudges the sidebar art left so more of the typewriter scene sits in the gutter.

## Test plan
- [ ] After deploy, desktop homepage (≥1600px) shows the Inkhaven sidebar with "Early-Bird Deadline" / "is Tonight (Sept 10)" and Apply Now.
- [ ] Between 1200px and 1600px, the line reads "Early-Bird Application Deadline" / "is Tonight (Sept 10)" and does not overflow the post list.
- [ ] Below 1200px, the pinned Inkhaven spotlight shows "Early-Bird Deadline is Tonight (Sept 10)" and ~40 writers; phone still zooms the typewriter splash.
- [ ] After Sept 10 11:59pm PT, both the banner and the mobile pin disappear.


Made with [Cursor](https://cursor.com)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1218346671582622) by [Unito](https://www.unito.io)
