### PR TITLE
Fix supermod Slack cron crashing on the request-scoped forum type

### DIFF
--- a/app/api/cron/supermod-status-to-slack/getSupermodStatus.ts
+++ b/app/api/cron/supermod-status-to-slack/getSupermodStatus.ts
@@ -10,7 +10,7 @@ import { PostsViews } from '@/lib/collections/posts/views';
 import { userGetDisplayName } from '@/lib/collections/users/helpers';
 import { getReviewGroupDisplayName, getReviewGroupFromActions } from '@/lib/collections/users/reviewGroups';
 import { UsersViews } from '@/lib/collections/users/views';
-import { adminAccountSetting } from '@/lib/instanceSettings';
+import { adminAccountSetting, type ForumTypeString } from '@/lib/instanceSettings';
 import { viewTermsToQuery } from '@/lib/utils/viewUtils';
 import { getSiteUrl } from '@/lib/vulcan-lib/utils';
 import { addPacificDays, PACIFIC_TZ, daysLateFromAge, groupDaysLate, type ModeratorCount, type SupermodStatusReport } from './supermodStatusFormat';
@@ -48,6 +48,7 @@ interface UserReviewHistory {
 
 export interface SupermodStatusData {
   windowEnd: Date;
+  forumType: ForumTypeString;
   siteUrl: string;
   adminTeamAccountId: string | null;
   usersById: Record<string, ReportUser>;
@@ -125,7 +126,7 @@ function countModerators(actorIds: Array<string | null>, data: SupermodStatusDat
   const counts = countBy(actorIds.filter(id => id && id !== data.adminTeamAccountId));
   return Object.entries(counts).map(([userId, count]) => ({
     userId,
-    displayName: userGetDisplayName(data.moderatorsById[userId]) || 'Unknown',
+    displayName: userGetDisplayName(data.moderatorsById[userId], data.forumType) || 'Unknown',
     count,
   }));
 }
@@ -172,7 +173,7 @@ export function summarizeSupermodStatus(
         ? 'offboard' : record.reviewGroup;
       return {
         userId: user._id,
-        displayName: userGetDisplayName(user) || 'Unknown',
+        displayName: userGetDisplayName(user, data.forumType) || 'Unknown',
         durationMs: record.durationMs,
         reviewGroupLabel: getReviewGroupDisplayName(group),
       };
@@ -231,11 +232,12 @@ export async function getSupermodStatus(
   const changesByUser = groupBy(userChanges, 'documentId');
   const histories = users.map(user => getUserReviewHistory(user, actionsByUser[user._id] ?? [], changesByUser[user._id] ?? [], windowEnd));
   const postChanges = groupBy(sortBy(recentChanges.filter(change => change.fieldName === 'reviewedByUserId'), 'createdAt'), 'documentId');
-  const adminTeamAccountId = adminAccountSetting.get()?._id ?? null;
+  const adminTeamAccountId = adminAccountSetting.get(context)?._id ?? null;
   const postsById = keyBy(posts, '_id');
   const data: SupermodStatusData = {
     windowEnd,
-    siteUrl: getSiteUrl(),
+    forumType: context.forumType,
+    siteUrl: getSiteUrl(context),
     adminTeamAccountId,
     usersById: keyBy(users, '_id'),
     moderatorsById: keyBy(moderators, '_id'),

--- a/app/api/cron/supermod-status-to-slack/route.ts
+++ b/app/api/cron/supermod-status-to-slack/route.ts
@@ -1,5 +1,6 @@
 import type { NextRequest } from 'next/server';
 import { createAnonymousContext } from '@/server/vulcan-lib/createContexts';
+import { getForumTypeForRequest } from '@/server/utils/requestUtil';
 import { captureException } from '@/lib/sentryWrapper';
 import { postMessage } from '@/server/slack/client';
 import { getSupermodStatus } from './getSupermodStatus';
@@ -24,7 +25,7 @@ export async function GET(request: NextRequest) {
   }
 
   try {
-    const context = createAnonymousContext();
+    const context = createAnonymousContext({ forumType: getForumTypeForRequest(request) });
     const { daily, weekly } = await getSupermodStatus(context, getMostRecentPacificReportTime(now));
     const messages: Array<{ text: string; blocks?: SlackMessageBlock[] }> = [
       { text: formatDailySupermodMessage(daily) },


### PR DESCRIPTION
## Summary

The supermod status cron (`/api/cron/supermod-status-to-slack`) has failed on every run since #12840 merged, logging:

```
Failed to post supermod status to Slack: TypeError: Cannot read properties of undefined (reading 'forumType')
```

#12848 ("Merge the LW and AF Vercel environments") changed `PublicInstanceSetting.get`, `getSiteUrl` and `userGetDisplayName` to take an explicit forum type or resolver context. #12840 was branched before that and merged after it without a rebase. The two PRs touched disjoint files, so the merge was clean, and the PR's CI ran against its own head where the old signatures still existed. The merge commit fails `yarn tsc` with four errors, all in `getSupermodStatus.ts`; the runtime crash is the zero-argument `adminAccountSetting.get()`.

## Changes

- The route derives the forum type from the cron request with `getForumTypeForRequest`, matching the curation cron, and passes it to `createAnonymousContext`.
- `getSupermodStatus` passes the context to `adminAccountSetting.get` and `getSiteUrl`.
- `SupermodStatusData` carries `forumType` so the pure report builders can pass it to `userGetDisplayName`.

## Testing

- `yarn tsc` with a fresh `tsconfig.tsbuildinfo`: the four supermod errors are gone. The only remaining error is a pre-existing one in `next.config.ts` that also appears on `master` locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RebRpu75j2EvtAY2mH3X3c

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1218377728478921) by [Unito](https://www.unito.io)
