### PR TITLE
Fix vertical alignment of post page bottom vote buttons

### DIFF
--- a/packages/lesswrong/components/votes/PostsVoteDefault.tsx
+++ b/packages/lesswrong/components/votes/PostsVoteDefault.tsx
@@ -21,6 +21,23 @@ const styles = defineStyles("PostsVoteDefault", (theme: ThemeType) => ({
     justifyContent: 'flex-end',
     alignItems: 'center',
   },
+  voteBlockFooter: {
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    gap: 2,
+    // Inline line boxes differ between browsers; size these rows to the arrows.
+    '& $upvote, & $downvote': {
+      display: 'flex',
+      margin: 0,
+    },
+    '& $downvote': {
+      marginTop: -3,
+    },
+    '& $voteScores': {
+      margin: 0,
+    },
+  },
   upvote: {
     marginBottom: -21
   },
@@ -104,6 +121,7 @@ const PostsVoteDefault = ({
     <div className={classNames({
       [classes.voteBlock]: !useHorizontalLayout,
       [classes.voteBlockHorizontal]: useHorizontalLayout,
+      [classes.voteBlockFooter]: isFooter && !useHorizontalLayout,
     })}>
       <TooltipRef
         title={whyYouCantVote ?? "Click-and-hold for strong vote (click twice on mobile)"}
@@ -182,5 +200,3 @@ const PostsVoteDefault = ({
 }
 
 export default PostsVoteDefault;
-
-


### PR DESCRIPTION
They were highly misaligned in Firefox and slightly misaligned in Chrome.

<details>
<summary>Prompts Used</summary>
The voting buttons on the bottom of post pages have a vertical misalignment/spacing issue, which appears in Firefox but not in Chrome.

> Fixed the footer voting layout using flex spacing, removing its dependence on browser-specific line heights and negative margins.
>
> Verified matching alignment in isolated Firefox and Chromium checks. ESLint and diff checks pass.
<hr>
Thanks, it is now consistent between browsers. Let's also bring the down button 4px closer.

> Moved the footer’s downvote button 4px closer to the score.
</details>

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1218380774644724) by [Unito](https://www.unito.io)
