### PR TITLE
Fix horizontal layout shift during load if you're an admin with Sunshine Sidebar

### DIFF
--- a/packages/lesswrong/components/layout/RouteRootClient.tsx
+++ b/packages/lesswrong/components/layout/RouteRootClient.tsx
@@ -51,7 +51,13 @@ const styles = defineStyles("RouteRootClient", (theme: ThemeType) => ({
     padding: 0,
   },
   rightSidebar: {
-    gridArea: 'rightSidebar'
+    gridArea: 'rightSidebar',
+    // Reserve the sidebar's column before its deferred content and queries load.
+    width: 210,
+    display: 'none',
+    [theme.breakpoints.up('lg')]: {
+      display: 'block',
+    },
   },
 }))
 

--- a/packages/lesswrong/components/sunshineDashboard/SunshineSidebar.tsx
+++ b/packages/lesswrong/components/sunshineDashboard/SunshineSidebar.tsx
@@ -22,12 +22,7 @@ const styles = defineStyles("SunshineSidebar", (theme: ThemeType) => ({
   root: {
     zIndex: theme.zIndexes.sunshineSidebar,
     position: "relative",
-    display:"none",
     background: theme.palette.panelBackground.default,
-    width: 210,
-    [theme.breakpoints.up('lg')]: {
-      display:"block"
-    }
   },
   background: {
     background: theme.palette.panelBackground.default,


### PR DESCRIPTION
<details>
<summary>Prompts Used</summary>
Currently the Sunshine Sidebat causes a horizontal shift during pageload for moderators for whom it's open by default. Adjust the suspense boundaries &c to prevent that.

> Moved the sidebar’s width and responsive visibility outside the deferred content and Suspense boundary. Its 210px column is now reserved on initial render, preventing the horizontal shift.
>
> `git diff --check` passed. ESLint was blocked by the existing missing `plugin:@next/next/recommended-legacy` config. Browser behavior wasn’t verified.
</details>

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1218380642935732) by [Unito](https://www.unito.io)
