### PR TITLE
Fix several vertical shifts during front page loading related to the spotlight item

### DIFF
--- a/packages/lesswrong/components/common/LWHome.tsx
+++ b/packages/lesswrong/components/common/LWHome.tsx
@@ -15,7 +15,7 @@ import { registerComponent } from "../../lib/vulcan-lib/components";
 import AnalyticsInViewTracker from "./AnalyticsInViewTracker";
 import FrontpageReviewWidget from "../review/FrontpageReviewWidget";
 import SingleColumnSection from "./SingleColumnSection";
-import DismissibleSpotlightItem from "@/components/spotlights/DismissibleSpotlightItem";
+import { DismissibleSpotlightItemSuspense } from "@/components/spotlights/DismissibleSpotlightItem";
 import QuickTakesSection from "../quickTakes/QuickTakesSection";
 import LWHomePosts from "./LWHomePosts";
 import UltraFeed from "../ultraFeed/UltraFeed";
@@ -84,6 +84,9 @@ const LWHome = () => {
   const mobileSpotlightOverrideId = getMobileSpotlightOverrideId();
 
   return (
+    // Wait for spotlight selection and dismissal before revealing the posts
+    // placeholder. The posts and spotlight content can then load independently.
+    <SuspenseWrapper name="LWHome">
       <AnalyticsContext pageContext="homePage">
         <StructuredData generate={() => getStructuredData(forumType)}/>
         <UpdateLastVisitCookie />
@@ -95,11 +98,11 @@ const LWHome = () => {
           </SingleColumnSection>}
         </>}
         {(!reviewIsActive() || getReviewPhase() === "RESULTS" || !showReviewOnFrontPageIfActive.get(forumType)) && <SingleColumnSection>
-          <DismissibleSpotlightItem
+          <DismissibleSpotlightItemSuspense
             loadingStyle="placeholder"
             className={classes.desktopSpotlight}
           />
-          <DismissibleSpotlightItem
+          <DismissibleSpotlightItemSuspense
             loadingStyle="placeholder"
             className={classes.mobileSpotlight}
             spotlightId={mobileSpotlightOverrideId}
@@ -121,6 +124,7 @@ const LWHome = () => {
           </IsReturningVisitorContextProvider>
         </SuspenseWrapper>
       </AnalyticsContext>
+    </SuspenseWrapper>
   )
 }
 
@@ -155,5 +159,4 @@ const UpdateLastVisitCookie = () => {
 export default registerComponent('LWHome', LWHome, {
   areEqual: "auto",
 });
-
 

--- a/packages/lesswrong/components/spotlights/DismissibleSpotlightItem.tsx
+++ b/packages/lesswrong/components/spotlights/DismissibleSpotlightItem.tsx
@@ -1,4 +1,5 @@
 import moment from 'moment';
+import classNames from 'classnames';
 import React, { useCallback, useMemo } from 'react';
 import { AnalyticsContext, useTracking } from '../../lib/analyticsEvents';
 import { useCookiesWithConsent } from '../hooks/useCookiesWithConsent';
@@ -28,9 +29,12 @@ const DisplaySpotlightByIdQuery = gql(`
   }
 `);
 
-const DismissibleSpotlightItemInner = ({ className, spotlightId }: {
+// Let the parent suspend until we know which spotlight to show and whether it
+// has been dismissed, so it can position content below the spotlight correctly.
+export const DismissibleSpotlightItemSuspense = ({ className, spotlightId, loadingStyle="spinner" }: {
   className?: string,
   spotlightId?: string | null,
+  loadingStyle?: "placeholder"|"spinner",
 }) => {
   const { captureEvent } = useTracking()
 
@@ -67,24 +71,29 @@ const DismissibleSpotlightItemInner = ({ className, spotlightId }: {
   }
 
   return <AnalyticsContext pageElementContext="spotlightItem">
-    <SpotlightItem
-      key={spotlight._id}
-      spotlight={spotlight}
-      hideBanner={hideBanner}
-      className={className}
-    />
+    <SuspenseWrapper
+      name="SpotlightItem"
+      fallback={loadingStyle==="placeholder" ? <SpotlightItemFallback className={className}/> : <Loading/>}
+    >
+      <SpotlightItem
+        key={spotlight._id}
+        spotlight={spotlight}
+        hideBanner={hideBanner}
+        className={className}
+      />
+    </SuspenseWrapper>
   </AnalyticsContext>
 }
 
-const spotlightItemFallbackStyles = defineStyles("SpotlightItemFallback", (theme) => ({
+const spotlightItemFallbackStyles = defineStyles("SpotlightItemFallback", () => ({
   fallback: {
     height: 181,
   },
 }));
 
-export const SpotlightItemFallback = () => {
+export const SpotlightItemFallback = ({className}: {className?: string}) => {
   const classes = useStyles(spotlightItemFallbackStyles);
-  return <div className={classes.fallback}/>
+  return <div className={classNames(classes.fallback, className)}/>
 }
 
 export const DismissibleSpotlightItem = ({loadingStyle="spinner", className, spotlightId}: {
@@ -94,15 +103,15 @@ export const DismissibleSpotlightItem = ({loadingStyle="spinner", className, spo
 }) => {
   return <SuspenseWrapper
     name="DismissibleSpotlightItem"
-    fallback={loadingStyle==="placeholder" ? <SpotlightItemFallback/> : <Loading/>}
+    fallback={loadingStyle==="placeholder" ? <SpotlightItemFallback className={className}/> : <Loading/>}
   >
-    <DismissibleSpotlightItemInner
+    <DismissibleSpotlightItemSuspense
       className={className}
       spotlightId={spotlightId}
+      loadingStyle={loadingStyle}
     />
   </SuspenseWrapper>
 }
 
 export default DismissibleSpotlightItem;
-
 


### PR DESCRIPTION
<details>
<summary>Prompts Used</summary>
During pageload, while suspensefully loading the top of the front page, the latest posts section (which is below the spotlight item) undergoes some extra vertical shifts. If the spotlight item has been dismissed by cookie, it starts with a vertical-space placeholder and then the placeholder is removed, so the latest-posts placeholder starts too low and shifts up. If the spotlight item is _not_ dismissed, there is sometimes a <hr>
During pageload, while suspensefully loading the top of the front page, the latest posts section (which is below the spotlight item) undergoes some extra vertical shifts. If the spotlight item has been dismissed by cookie, it starts with a vertical-space placeholder and then the placeholder is removed, so the latest-posts placeholder starts too low and shifts up. If the spotlight item is _not_ dismissed, there is sometimes a few frames in which the spotlight _and_ the vertical spacing placeholder are present, pushing the latest posts list down.

> Fixed both loading shifts:
>
> - Front-page content waits until spotlight dismissal is known before revealing the posts placeholder.
> - Spotlight fallbacks now respect desktop/mobile visibility, preventing extra spacing.
>
> Four regression tests pass. Typechecking and lint remain blocked by existing Next.js configuration and ESLint dependency issues.
</details>

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1218380976249064) by [Unito](https://www.unito.io)
