### PR TITLE
Animate all the things

### DIFF
--- a/packages/lesswrong/components/comments/CommentsItem/CommentsItem.tsx
+++ b/packages/lesswrong/components/comments/CommentsItem/CommentsItem.tsx
@@ -23,6 +23,7 @@ import CommentExcerpt from "../../common/excerpts/CommentExcerpt";
 import CommentBody from "./CommentBody";
 import CommentsNewForm from "../CommentsNewForm";
 import ParentCommentSingle from "../ParentCommentSingle";
+import AnimatedExpansion from "../../common/AnimatedExpansion";
 import ForumIcon from "../../common/ForumIcon";
 import CommentDiscussionIcon from "./CommentDiscussionIcon";
 import LWTooltip from "../../common/LWTooltip";
@@ -340,18 +341,20 @@ export const CommentsItem = ({
         treeOptions.isSideComment && classes.sideComment,
         comment.tagCommentType === "SUBFORUM" && !comment.topLevelCommentId && classes.subforumTop,
       )}>
-        { comment.parentCommentId && showParentState && (
+        { comment.parentCommentId && (
           <div className={classes.firstParentComment}>
-            <ParentCommentSingle
-              post={post} tag={tag}
-              documentId={comment.parentCommentId}
-              nestingLevel={nestingLevel - 1}
-              truncated={showParentDefault}
-              key={comment.parentCommentId}
-              treeOptions={{
-                hideParentCommentToggleForTopLevel,
-              }}
-            />
+            <AnimatedExpansion expanded={showParentState}>
+              {showParentState && <ParentCommentSingle
+                post={post} tag={tag}
+                documentId={comment.parentCommentId}
+                nestingLevel={nestingLevel - 1}
+                truncated={showParentDefault}
+                key={comment.parentCommentId}
+                treeOptions={{
+                  hideParentCommentToggleForTopLevel,
+                }}
+              />}
+            </AnimatedExpansion>
           </div> 
         )}
         
@@ -464,5 +467,4 @@ function hasPostField(comment: CommentsList | CommentsListWithParentMetadata): c
 function hasTagField(comment: CommentsList | CommentsListWithParentMetadata): comment is CommentsListWithParentMetadata {
   return !!(comment as CommentsListWithParentMetadata).tag
 }
-
 

--- a/packages/lesswrong/components/comments/CommentsItem/CommentsItem.tsx
+++ b/packages/lesswrong/components/comments/CommentsItem/CommentsItem.tsx
@@ -24,6 +24,7 @@ import CommentBody from "./CommentBody";
 import CommentsNewForm from "../CommentsNewForm";
 import ParentCommentSingle from "../ParentCommentSingle";
 import AnimatedExpansion from "../../common/AnimatedExpansion";
+import AnimatedCollapse from "../../common/AnimatedCollapse";
 import ForumIcon from "../../common/ForumIcon";
 import CommentDiscussionIcon from "./CommentDiscussionIcon";
 import LWTooltip from "../../common/LWTooltip";
@@ -278,7 +279,6 @@ export const CommentsItem = ({
       return <CommentBody
         commentBodyRef={commentBodyRef}
         truncated={truncated}
-        collapsed={collapsed}
         comment={comment}
         postPage={postPage}
         voteProps={voteProps}
@@ -389,27 +389,31 @@ export const CommentsItem = ({
             Pinned by {comment.promotedByUser.displayName}
           </div>}
           {comment.rejected && <p><RejectedReasonDisplay reason={comment.rejectedReason ?? null}/></p>}
-          {renderBodyOrEditor(voteProps)}
-          {!comment.deleted && !collapsed && !showEditState && <CommentBottom
-            comment={comment}
-            post={post}
-            treeOptions={treeOptions}
-            votingSystem={votingSystem}
-            voteProps={voteProps}
-            commentBodyRef={commentBodyRef}
-            replyButton={replyButton}
-          />}
+          {comment.deleted ? renderBodyOrEditor(voteProps) : <AnimatedCollapse expanded={!collapsed}>
+            {renderBodyOrEditor(voteProps)}
+            {!showEditState && <CommentBottom
+              comment={comment}
+              post={post}
+              treeOptions={treeOptions}
+              votingSystem={votingSystem}
+              voteProps={voteProps}
+              commentBodyRef={commentBodyRef}
+              replyButton={replyButton}
+            />}
+          </AnimatedCollapse>}
         </div>
-        {displayReviewVoting && !collapsed && <div className={classes.reviewVotingButtons}>
-          <div className={classes.updateVoteMessage}>
-            <LWTooltip title={`If this review changed your mind, update your ${getReviewNameInSitu()} vote for the original post `}>
-              Update your {getReviewNameInSitu()} vote for this post. 
-              <LWHelpIcon/>
-            </LWTooltip>
-          </div>
-          {post && <ReviewVotingWidget post={post} showTitle={false}/>}
-        </div>}
-        { replyFormIsOpen && !collapsed && renderReply() }
+        {(displayReviewVoting || replyFormIsOpen) && <AnimatedCollapse expanded={!collapsed}>
+          {displayReviewVoting && <div className={classes.reviewVotingButtons}>
+            <div className={classes.updateVoteMessage}>
+              <LWTooltip title={`If this review changed your mind, update your ${getReviewNameInSitu()} vote for the original post `}>
+                Update your {getReviewNameInSitu()} vote for this post.
+                <LWHelpIcon/>
+              </LWTooltip>
+            </div>
+            {post && <ReviewVotingWidget post={post} showTitle={false}/>}
+          </div>}
+          {replyFormIsOpen && renderReply()}
+        </AnimatedCollapse>}
       </div>
     </HoveredReactionContextProvider>
     </AnalyticsContext>
@@ -467,4 +471,3 @@ function hasPostField(comment: CommentsList | CommentsListWithParentMetadata): c
 function hasTagField(comment: CommentsList | CommentsListWithParentMetadata): comment is CommentsListWithParentMetadata {
   return !!(comment as CommentsListWithParentMetadata).tag
 }
-

--- a/packages/lesswrong/components/comments/CommentsNode.tsx
+++ b/packages/lesswrong/components/comments/CommentsNode.tsx
@@ -1,5 +1,5 @@
 import { useForumType } from '@/components/hooks/useForumType';
-import React, { useState, useRef, useEffect, useCallback } from 'react';
+import React, { useState, useRef, useEffect, useLayoutEffect, useCallback } from 'react';
 import { registerComponent } from '../../lib/vulcan-lib/components';
 import withErrorBoundary from '../common/withErrorBoundary';
 import { useFilteredCurrentUser } from '../common/withUser';
@@ -16,6 +16,7 @@ import RepliesToCommentList from "../shortform/RepliesToCommentList";
 import AnalyticsTracker from "../common/AnalyticsTracker";
 import { defineStyles } from '@/components/hooks/defineStyles';
 import { useStyles } from '@/components/hooks/useStyles';
+import AnimatedExpansion from '../common/AnimatedExpansion';
 
 const KARMA_COLLAPSE_THRESHOLD = -4;
 
@@ -105,12 +106,14 @@ const CommentsNodeInner = ({treeOptions, comment, startThreadTruncated, truncate
   const currentUserNoSingleLineCommentsSetting = useFilteredCurrentUser(u => u?.noSingleLineComments);
   const { captureEvent } = useTracking()
   const scrollTargetRef = useRef<HTMLDivElement|null>(null);
+  const heightBeforeExpansionRef = useRef<number|null>(null);
 
   const hasInContextLinks = commentPermalinkStyleSetting.get(forumType) === 'in-context';
 
   const { linkedCommentId, scrollToCommentId } = useCommentLinkState();
 
   const { lastCommentId, condensed, postPage, post, highlightDate, scrollOnExpand, forceSingleLine, forceNotSingleLine, expandOnlyCommentIds, noDOMId, onToggleCollapsed } = treeOptions;
+  const animateWholeThread = forceSingleLine && loadChildrenSeparately;
 
   const shouldUncollapseForAutoScroll = useCallback(() => {
     const commentAndChildren = [
@@ -226,6 +229,29 @@ const CommentsNodeInner = ({treeOptions, comment, startThreadTruncated, truncate
 
     return isTruncated && !(expandNewComments && isNewComment);
   })();
+
+  useLayoutEffect(() => {
+    const element = scrollTargetRef.current;
+    const previousHeight = heightBeforeExpansionRef.current;
+    heightBeforeExpansionRef.current = null;
+    if (!element || previousHeight === null || window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+      return;
+    }
+
+    const expandedHeight = element.getBoundingClientRect().height;
+    if (expandedHeight <= previousHeight) {
+      return;
+    }
+
+    // Measure the full content before paint, and release the height once the animation ends.
+    const animation = element.animate([
+      { height: `${previousHeight}px`, overflow: 'clip' },
+      { height: `${expandedHeight}px`, overflow: 'clip' },
+    ], { duration: 200, easing: 'ease-out' });
+
+    return () => animation.cancel();
+  }, [isTruncated, isSingleLine]);
+
   const updatedNestingLevel = nestingLevel + (!!comment.gapIndicator ? 1 : 0)
 
   const passedThroughItemProps = { comment, collapsed, showPinnedOnProfile, enableGuidelines, showParentDefault }
@@ -268,6 +294,7 @@ const CommentsNodeInner = ({treeOptions, comment, startThreadTruncated, truncate
       event?.stopPropagation();
     }
     if (isTruncated || isSingleLine) {
+      heightBeforeExpansionRef.current = animateWholeThread ? null : scrollTargetRef.current?.getBoundingClientRect().height ?? null;
       captureEvent("commentExpanded", { postId: comment.postId, commentId: comment._id, draft: comment.draft });
       setTruncated(false);
       setSingleLine(false);
@@ -277,7 +304,7 @@ const CommentsNodeInner = ({treeOptions, comment, startThreadTruncated, truncate
     if (scroll) {
       scrollIntoView(scrollBehaviour);
     }
-  }, [isTruncated, isSingleLine, comment.postId, comment._id, comment.draft, captureEvent, scrollIntoView]);
+  }, [isTruncated, isSingleLine, animateWholeThread, comment.postId, comment._id, comment.draft, captureEvent, scrollIntoView]);
 
   const onClickFrame = useCallback((event: React.MouseEvent) => {
     handleExpand({ event, scroll: scrollOnExpand });
@@ -349,12 +376,16 @@ const CommentsNodeInner = ({treeOptions, comment, startThreadTruncated, truncate
     </CommentFrame>
   );
   
+  const animatedResult = animateWholeThread
+    ? <AnimatedExpansion expanded={!isSingleLine}>{result}</AnimatedExpansion>
+    : result;
+
   if (comment.gapIndicator) {
     return <div className={classes.gapIndicator}>
-      {result}
+      {animatedResult}
     </div>
   } else {
-    return result;
+    return animatedResult;
   }
 }
 

--- a/packages/lesswrong/components/comments/CommentsNode.tsx
+++ b/packages/lesswrong/components/comments/CommentsNode.tsx
@@ -17,6 +17,7 @@ import AnalyticsTracker from "../common/AnalyticsTracker";
 import { defineStyles } from '@/components/hooks/defineStyles';
 import { useStyles } from '@/components/hooks/useStyles';
 import AnimatedExpansion from '../common/AnimatedExpansion';
+import AnimatedCollapse from '../common/AnimatedCollapse';
 
 const KARMA_COLLAPSE_THRESHOLD = -4;
 
@@ -257,7 +258,7 @@ const CommentsNodeInner = ({treeOptions, comment, startThreadTruncated, truncate
   const passedThroughItemProps = { comment, collapsed, showPinnedOnProfile, enableGuidelines, showParentDefault }
 
   
-  const childrenSection = !collapsed && childComments && childComments.length > 0 && <div className={classes.children}>
+  const childrenSection = childComments && childComments.length > 0 && <div className={classes.children}>
     <div className={classes.parentScroll} onClick={() => scrollIntoView("smooth")} />
     {showExtraChildrenButton}
     {childComments.map(child => <CommentsNode
@@ -361,18 +362,20 @@ const CommentsNodeInner = ({treeOptions, comment, startThreadTruncated, truncate
         }
       </div>}
 
-      {childrenSection}
+      <AnimatedCollapse expanded={!collapsed}>
+        {childrenSection}
 
-      {!isSingleLine && loadChildrenSeparately &&
-        <div className="comments-children">
-          <div className={classes.parentScroll} onClick={() => scrollIntoView("smooth")}/>
-          <RepliesToCommentList
-            parentCommentId={comment._id}
-            post={post as PostsBase}
-            directReplies={loadDirectReplies}
-          />
-        </div>
-      }
+        {!isSingleLine && loadChildrenSeparately &&
+          <div className="comments-children">
+            <div className={classes.parentScroll} onClick={() => scrollIntoView("smooth")}/>
+            <RepliesToCommentList
+              parentCommentId={comment._id}
+              post={post as PostsBase}
+              directReplies={loadDirectReplies}
+            />
+          </div>
+        }
+      </AnimatedCollapse>
     </CommentFrame>
   );
   

--- a/packages/lesswrong/components/comments/ShowParentComment.tsx
+++ b/packages/lesswrong/components/comments/ShowParentComment.tsx
@@ -19,7 +19,11 @@ const styles = defineStyles('ShowParentComment', (theme: ThemeType) => ({
   },
   icon: {
     fontSize: 12,
-    transform: "rotate(90deg)"
+    transform: "rotate(90deg)",
+    transition: "transform 200ms ease-out",
+    "@media (prefers-reduced-motion: reduce)": {
+      transition: "none",
+    },
   },
   parentComment: { // UNUSED
     background: theme.palette.panelBackground.default,
@@ -61,6 +65,5 @@ const ShowParentComment = ({comment, active, onClick}: {
 };
 
 export default ShowParentComment;
-
 
 

--- a/packages/lesswrong/components/common/AnimatedCollapse.tsx
+++ b/packages/lesswrong/components/common/AnimatedCollapse.tsx
@@ -17,6 +17,8 @@ const styles = defineStyles('AnimatedCollapse', () => ({
   },
   content: {
     display: 'flow-root',
+    // Let single-line comments shrink below their intrinsic text width after clipping is released.
+    minWidth: 0,
     minHeight: 0,
     overflow: 'hidden',
   },

--- a/packages/lesswrong/components/common/AnimatedCollapse.tsx
+++ b/packages/lesswrong/components/common/AnimatedCollapse.tsx
@@ -1,0 +1,58 @@
+import React, { useRef } from 'react';
+import classNames from 'classnames';
+import Transition from 'react-transition-group/Transition';
+import { defineStyles, useStyles } from '../hooks/useStyles';
+
+const styles = defineStyles('AnimatedCollapse', () => ({
+  root: {
+    display: 'grid',
+    gridTemplateRows: '0fr',
+    transition: 'grid-template-rows 200ms ease-in-out',
+    '@media (prefers-reduced-motion: reduce)': {
+      transition: 'none',
+    },
+  },
+  expanded: {
+    gridTemplateRows: '1fr',
+  },
+  content: {
+    display: 'flow-root',
+    minHeight: 0,
+    overflow: 'hidden',
+  },
+  entered: {
+    overflow: 'visible',
+  },
+}));
+
+/** Keep content mounted during collapse, and release clipping once expanded. */
+const AnimatedCollapse = ({ expanded, children }: {
+  expanded: boolean,
+  children: React.ReactNode,
+}) => {
+  const classes = useStyles(styles);
+  const rootRef = useRef<HTMLDivElement>(null);
+
+  return <Transition
+    nodeRef={rootRef}
+    in={expanded}
+    timeout={200}
+    mountOnEnter
+    unmountOnExit
+    onEnter={() => { rootRef.current?.getBoundingClientRect(); }}
+  >
+    {state => <div
+      ref={rootRef}
+      className={classNames(classes.root, {
+        [classes.expanded]: state === 'entering' || state === 'entered',
+      })}
+      inert={!expanded}
+    >
+      <div className={classNames(classes.content, { [classes.entered]: state === 'entered' })}>
+        {children}
+      </div>
+    </div>}
+  </Transition>;
+};
+
+export default AnimatedCollapse;

--- a/packages/lesswrong/components/common/AnimatedExpansion.tsx
+++ b/packages/lesswrong/components/common/AnimatedExpansion.tsx
@@ -1,0 +1,68 @@
+import React, { useLayoutEffect, useRef } from 'react';
+import { defineStyles } from '@/components/hooks/defineStyles';
+import { useStyles } from '@/components/hooks/useStyles';
+
+const styles = defineStyles('AnimatedExpansion', () => ({
+  root: {
+    display: 'flow-root',
+  },
+  content: {
+    // Keep child margins inside the measured height.
+    display: 'flow-root',
+  },
+}));
+
+/** Animate expansion, including content that arrives asynchronously after opening. */
+const AnimatedExpansion = ({ expanded, children }: {
+  expanded: boolean,
+  children: React.ReactNode,
+}) => {
+  const classes = useStyles(styles);
+  const rootRef = useRef<HTMLDivElement>(null);
+  const contentRef = useRef<HTMLDivElement>(null);
+  const previousHeightRef = useRef<number|null>(null);
+  const animationRef = useRef<Animation|null>(null);
+
+  useLayoutEffect(() => {
+    const root = rootRef.current;
+    const content = contentRef.current;
+    if (!root || !content) return;
+
+    const reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)');
+    const updateHeight = () => {
+      const height = content.getBoundingClientRect().height;
+      const previousHeight = previousHeightRef.current;
+      if (height === previousHeight) return;
+
+      const fromHeight = animationRef.current?.playState === 'running'
+        ? root.getBoundingClientRect().height
+        : previousHeight;
+      animationRef.current?.cancel();
+      animationRef.current = null;
+      previousHeightRef.current = height;
+
+      if (expanded && previousHeight !== null && height > previousHeight && fromHeight !== null && !reducedMotion.matches) {
+        animationRef.current = root.animate([
+          { height: `${fromHeight}px`, overflow: 'clip' },
+          { height: `${height}px`, overflow: 'clip' },
+        ], { duration: 200, easing: 'ease-out' });
+      }
+    };
+
+    updateHeight();
+    // Observe the natural content height, so the animation itself cannot trigger a resize loop.
+    const observer = new ResizeObserver(updateHeight);
+    observer.observe(content);
+    return () => {
+      observer.disconnect();
+      animationRef.current?.cancel();
+      animationRef.current = null;
+    };
+  }, [expanded]);
+
+  return <div ref={rootRef} className={classes.root}>
+    <div ref={contentRef} className={classes.content}>{children}</div>
+  </div>;
+};
+
+export default AnimatedExpansion;

--- a/packages/lesswrong/components/common/AnimatedExpansion.tsx
+++ b/packages/lesswrong/components/common/AnimatedExpansion.tsx
@@ -13,8 +13,9 @@ const styles = defineStyles('AnimatedExpansion', () => ({
 }));
 
 /** Animate expansion, including content that arrives asynchronously after opening. */
-const AnimatedExpansion = ({ expanded, children }: {
+const AnimatedExpansion = ({ expanded, duration=100, children }: {
   expanded: boolean,
+  duration?: number,
   children: React.ReactNode,
 }) => {
   const classes = useStyles(styles);

--- a/packages/lesswrong/components/common/ExpandableSection.tsx
+++ b/packages/lesswrong/components/common/ExpandableSection.tsx
@@ -1,4 +1,5 @@
-import React, { ComponentType } from "react";
+import React, { ComponentType, useRef } from "react";
+import Transition from "react-transition-group/Transition";
 import SectionTitle, { SectionTitleProps } from "./SectionTitle";
 import { AnalyticsContext } from "../../lib/analyticsEvents";
 import { Link } from "../../lib/reactRouterWrapper";
@@ -36,12 +37,30 @@ const styles = defineStyles("ExpandableSection", (theme: ThemeType) => ({
     fontSize: 16,
     cursor: "pointer",
     transition: "transform 0.2s ease-in-out",
+    "@media (prefers-reduced-motion: reduce)": {
+      transition: "none",
+    },
     "&:hover": {
       color: theme.palette.grey[800],
     }
   },
   chevronExpanded: {
     transform: "rotate(90deg)",
+  },
+  content: {
+    display: "grid",
+    gridTemplateRows: "0fr",
+    transition: "grid-template-rows 200ms ease-in-out",
+    "@media (prefers-reduced-motion: reduce)": {
+      transition: "none",
+    },
+  },
+  contentExpanded: {
+    gridTemplateRows: "1fr",
+  },
+  contentInner: {
+    minHeight: 0,
+    overflow: "hidden",
   },
 }));
 
@@ -67,6 +86,7 @@ const ExpandableSection = ({
   ...sectionTitleProps
 }: ExpandableSectionProps) => {
   const classes = useStyles(styles);
+  const contentRef = useRef<HTMLDivElement>(null);
 
   return (
     <AnalyticsContext pageSectionContext={pageSectionContext}>
@@ -104,7 +124,27 @@ const ExpandableSection = ({
             </div>
           }
         </SectionTitle>
-        {expanded && <>{children}</>}
+        <Transition
+          nodeRef={contentRef}
+          in={expanded}
+          timeout={200}
+          mountOnEnter
+          unmountOnExit
+          onEnter={() => {
+            // Establish the collapsed layout before transitioning newly mounted content.
+            contentRef.current?.getBoundingClientRect();
+          }}
+        >
+          {state => <div
+            ref={contentRef}
+            className={classNames(classes.content, {
+              [classes.contentExpanded]: state === 'entering' || state === 'entered',
+            })}
+            inert={!expanded}
+          >
+            <div className={classes.contentInner}>{children}</div>
+          </div>}
+        </Transition>
       </SingleColumnSection>
     </AnalyticsContext>
   );

--- a/packages/lesswrong/components/common/LWHomePosts.tsx
+++ b/packages/lesswrong/components/common/LWHomePosts.tsx
@@ -52,6 +52,16 @@ import UltraFeedErrorFallback from '../ultraFeed/UltraFeedErrorFallback';
 // Key is the algorithm/tab name
 type RecombeeCookieSettings = [string, RecombeeConfiguration][];
 
+const expandedTagFilterSettingsStyles = {
+  gridTemplateRows: "1fr",
+  transitionDelay: "0ms",
+  '& $tagFilterSettingsContent': {
+    opacity: 1,
+    visibility: "visible",
+    transitionDelay: "180ms, 0ms",
+  },
+};
+
 const styles = defineStyles("LWHomePost", (theme: ThemeType) => ({
   hideOnMobile: {
     [theme.breakpoints.down('sm')]: {
@@ -72,6 +82,30 @@ const styles = defineStyles("LWHomePost", (theme: ThemeType) => ({
   tabPicker: {
     minWidth: 0,
     marginRight: 10,
+  },
+  tagFilterSettings: {
+    display: "grid",
+    gridTemplateRows: "0fr",
+    // Expand before fading in; fade out before collapsing.
+    transition: "grid-template-rows 180ms ease 120ms",
+    '@media (prefers-reduced-motion: reduce)': {
+      '&, & $tagFilterSettingsContent': {
+        transition: "none",
+      },
+    },
+  },
+  tagFilterSettingsContent: {
+    minHeight: 0,
+    overflow: "hidden",
+    opacity: 0,
+    visibility: "hidden",
+    transition: "opacity 120ms ease, visibility 0ms linear 120ms",
+  },
+  tagFilterSettingsExpandedDesktop: {
+    [theme.breakpoints.up('md')]: expandedTagFilterSettingsStyles,
+  },
+  tagFilterSettingsExpandedMobile: {
+    [theme.breakpoints.down('sm')]: expandedTagFilterSettingsStyles,
   },
   tagFilterSettingsButtonContainerDesktop: {
     [theme.breakpoints.up('md')]: {
@@ -495,20 +529,24 @@ const LWHomePosts = ({ children, }: {
 
   const filterSettingsElement = (
     <AnalyticsContext pageSectionContext="tagFilterSettings">
-      {settingsPotentiallyVisible && <div className={settingsVisibleClassName}>
-        <TagFilterSettings
-          filterSettings={filterSettings} 
-          suggestedTagsQueryRef={suggestedTagsQueryRef}
-          setPersonalBlogFilter={setPersonalBlogFilter} 
-          setTagFilter={setTagFilter} 
-          removeTagFilter={removeTagFilter} 
-          flexWrapEndGrow={false}
-        />
-        {selectedTab === 'recombee-hybrid' && hasSetAnyFilters && <div className={classes.enrichedTagFilterNotice}>
-          In the Enriched tab, filters apply only to "Recent" posts, not "Recommended" posts.
-        </div>}
-  
-      </div>}
+      <div className={classNames(classes.tagFilterSettings, {
+        [classes.tagFilterSettingsExpandedDesktop]: desktopSettingsVisible,
+        [classes.tagFilterSettingsExpandedMobile]: mobileSettingsVisible,
+      })}>
+        <div className={classes.tagFilterSettingsContent}>
+          <TagFilterSettings
+            filterSettings={filterSettings}
+            suggestedTagsQueryRef={suggestedTagsQueryRef}
+            setPersonalBlogFilter={setPersonalBlogFilter}
+            setTagFilter={setTagFilter}
+            removeTagFilter={removeTagFilter}
+            flexWrapEndGrow={false}
+          />
+          {selectedTab === 'recombee-hybrid' && hasSetAnyFilters && <div className={classes.enrichedTagFilterNotice}>
+            In the Enriched tab, filters apply only to "Recent" posts, not "Recommended" posts.
+          </div>}
+        </div>
+      </div>
     </AnalyticsContext>
   );
 
@@ -711,5 +749,3 @@ function ContinueReadingTab() {
 export default registerComponent("LWHomePosts", LWHomePosts, {
   areEqual: "auto",
 });
-
-

--- a/packages/lesswrong/components/common/LWHomePosts.tsx
+++ b/packages/lesswrong/components/common/LWHomePosts.tsx
@@ -641,6 +641,7 @@ const LWHomePosts = ({ children, }: {
                     <PostsList2
                       terms={recentPostsTerms}
                       alwaysShowLoadMore
+                      animateLoadMore
                       hideHiddenFrontPagePosts
                       repeatedPostsPrecedence={3}
                     >
@@ -723,6 +724,7 @@ const LWHomePosts = ({ children, }: {
                 <PostsList2 
                   terms={{...recentPostsTerms, view: "new"}} 
                   alwaysShowLoadMore 
+                  animateLoadMore
                   hideHiddenFrontPagePosts
                 >
                   <Link to={"/allPosts"}>{advancedSortingText}</Link>

--- a/packages/lesswrong/components/common/LWPopper.tsx
+++ b/packages/lesswrong/components/common/LWPopper.tsx
@@ -98,6 +98,9 @@ const LWPopper = ({
           // levels, this causes ugly resampling. (This has no effect on whether
           // GPU acceleration is used or on performance.)
           gpuAcceleration: false,
+          // Bottom/right offsets drift when the containing block changes size,
+          // such as while a settings panel expands. Keep coordinates relative to top/left.
+          adaptive: false,
         },
       },
       ...(distance>0 ? [{
@@ -170,4 +173,3 @@ export const PopperPortalProvider = ({children}: {
 }
 
 export default LWPopper;
-

--- a/packages/lesswrong/components/hooks/useLoadMoreExpansion.ts
+++ b/packages/lesswrong/components/hooks/useLoadMoreExpansion.ts
@@ -1,0 +1,38 @@
+import { useLayoutEffect, useRef } from 'react';
+
+/** Animate newly loaded rows without animating initial loads or filter changes. */
+export const useLoadMoreExpansion = ({ loading, itemCount, enabled = true }: {
+  loading: boolean,
+  itemCount: number,
+  enabled?: boolean,
+}) => {
+  const listRef = useRef<HTMLDivElement>(null);
+  const heightBeforeLoadMoreRef = useRef<number|null>(null);
+
+  useLayoutEffect(() => {
+    if (loading) return;
+
+    const element = listRef.current;
+    const previousHeight = heightBeforeLoadMoreRef.current;
+    heightBeforeLoadMoreRef.current = null;
+    if (!enabled || !element || previousHeight === null || window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
+
+    const expandedHeight = element.getBoundingClientRect().height;
+    if (expandedHeight <= previousHeight) return;
+
+    const animation = element.animate([
+      { height: `${previousHeight}px`, overflow: 'clip' },
+      { height: `${expandedHeight}px`, overflow: 'clip' },
+    ], { duration: 200, easing: 'ease-out' });
+
+    return () => animation.cancel();
+  }, [loading, itemCount, enabled]);
+
+  const prepareForLoadMore = () => {
+    if (enabled) {
+      heightBeforeLoadMoreRef.current = listRef.current?.getBoundingClientRect().height ?? null;
+    }
+  };
+
+  return { listRef, prepareForLoadMore };
+};

--- a/packages/lesswrong/components/posts/AllPostsPage.tsx
+++ b/packages/lesswrong/components/posts/AllPostsPage.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { Ref, useCallback, useState } from 'react';
+import classNames from 'classnames';
 import { useUpdateCurrentUser } from '../hooks/useUpdateCurrentUser';
 import { useLocation } from '../../lib/routeUtil';
 import { useCurrentUser } from '../common/withUser';
@@ -27,6 +28,33 @@ const styles = defineStyles("AllPostsPage", (theme: ThemeType) => ({
   divider: {
     border: "none",
     borderTop: `1px solid ${theme.palette.grey[300]}`,
+  },
+  settings: {
+    display: "grid",
+    gridTemplateRows: "0fr",
+    // Fade out before collapsing; expand before fading in.
+    transition: "grid-template-rows 180ms ease 120ms",
+    "@media (prefers-reduced-motion: reduce)": {
+      "&, & $settingsContent": {
+        transition: "none",
+      },
+    },
+  },
+  settingsContent: {
+    minHeight: 0,
+    overflow: "hidden",
+    opacity: 0,
+    visibility: "hidden",
+    transition: "opacity 120ms ease, visibility 0ms linear 120ms",
+  },
+  settingsExpanded: {
+    gridTemplateRows: "1fr",
+    transitionDelay: "0ms",
+    "& $settingsContent": {
+      opacity: 1,
+      visibility: "visible",
+      transitionDelay: "180ms, 0ms",
+    },
   },
 }));
 
@@ -83,16 +111,23 @@ const AllPostsPage = ({defaultHideSettings}: {defaultHideSettings?: boolean}) =>
             </div>}
           </TooltipRef>
           {isFriendlyUI() && !showSettings && <hr className={classes.divider} />}
-          <PostsListSettings
-            hidden={!showSettings}
-            currentTimeframe={currentTimeframe}
-            currentSorting={currentSorting}
-            currentFilter={currentFilter}
-            currentShowLowKarma={currentShowLowKarma}
-            currentIncludeEvents={currentIncludeEvents}
-            persistentSettings
-            showTimeframe
-          />
+          <div
+            className={classNames(classes.settings, { [classes.settingsExpanded]: showSettings })}
+            inert={!showSettings}
+          >
+            <div className={classes.settingsContent}>
+              <PostsListSettings
+                hidden={false}
+                currentTimeframe={currentTimeframe}
+                currentSorting={currentSorting}
+                currentFilter={currentFilter}
+                currentShowLowKarma={currentShowLowKarma}
+                currentIncludeEvents={currentIncludeEvents}
+                persistentSettings
+                showTimeframe
+              />
+            </div>
+          </div>
           <AllPostsList
             {...{
               currentTimeframe,
@@ -111,6 +146,5 @@ const AllPostsPage = ({defaultHideSettings}: {defaultHideSettings?: boolean}) =>
 }
 
 export default AllPostsPage;
-
 
 

--- a/packages/lesswrong/components/posts/LWPostsItem.tsx
+++ b/packages/lesswrong/components/posts/LWPostsItem.tsx
@@ -40,6 +40,7 @@ import { ResponseIcon } from "./PostsPage/RSVPs";
 import { maybeDate } from '@/lib/utils/dateUtils';
 import { isIfAnyoneBuildsItFrontPage } from '../seasonal/styles';
 import { defineStyles, useStyles } from '../hooks/useStyles';
+import AnimatedExpansion from '../common/AnimatedExpansion';
 
 export const KARMA_WIDTH = 32;
 
@@ -95,6 +96,10 @@ export const styles = defineStyles("LWPostsItem", (theme: ThemeType) => ({
     width: "100%",
     background: theme.palette.panelBackground.translucent,
     backdropFilter: "blur(1px)"
+  },
+  metadataRow: {
+    // Anchor the trailing buttons to the post row, excluding expanded comments.
+    position: "relative",
   },
   postsItem: {
     display: "flex",
@@ -508,7 +513,7 @@ const LWPostsItem = (props: PostsItemConfig) => {
             [classes.isRead]: isRead && !showReadCheckbox  // readCheckbox and post-title read-status don't aesthetically match
           })}
         >
-          <div {...eventHandlers}>
+          <div className={classes.metadataRow} {...eventHandlers}>
             <PostsItemTooltipWrapper
               post={post}
               placement={tooltipPlacement}
@@ -654,31 +659,32 @@ const LWPostsItem = (props: PostsItemConfig) => {
                 </div>
               }
             </PostsItemTooltipWrapper>
-          </div>
-
-          <PostsItemTrailingButtons
-            {...{
-              post,
-              showTrailingButtons,
-              showMostValuableCheckbox,
-              showDismissButton,
-              showArchiveButton,
-              resumeReading,
-              onDismiss,
-              onArchive,
-            }}
-          />
-
-          {renderComments && <div className={classes.newCommentsSection}>
-            <PostsItemNewCommentsWrapper
-              terms={commentTerms}
-              post={post}
-              treeOptions={{
-                highlightDate: maybeDate(post.lastVisitedAt ?? undefined),
-                condensed: condensedAndHiddenComments,
+            <PostsItemTrailingButtons
+              {...{
+                post,
+                showTrailingButtons,
+                showMostValuableCheckbox,
+                showDismissButton,
+                showArchiveButton,
+                resumeReading,
+                onDismiss,
+                onArchive,
               }}
             />
-          </div>}
+          </div>
+
+          <AnimatedExpansion expanded={renderComments && !condensedAndHiddenComments}>
+            {renderComments && <div className={classes.newCommentsSection}>
+              <PostsItemNewCommentsWrapper
+                terms={commentTerms}
+                post={post}
+                treeOptions={{
+                  highlightDate: maybeDate(post.lastVisitedAt ?? undefined),
+                  condensed: condensedAndHiddenComments,
+                }}
+              />
+            </div>}
+          </AnimatedExpansion>
 
           {renderDialogueMessages && <div className={classes.newCommentsSection}>
             <PostsItemNewDialogueResponses postId={post._id} unreadCount={post.unreadDebateResponseCount} />

--- a/packages/lesswrong/components/posts/PostsList2.tsx
+++ b/packages/lesswrong/components/posts/PostsList2.tsx
@@ -13,6 +13,7 @@ import PostsItem from "./PostsItem";
 import PostsLoading from "./PostsLoading";
 import { SuspenseWrapper } from '../common/SuspenseWrapper';
 import { HideIfRepeated } from './HideRepeatedPostsContext';
+import { useLoadMoreExpansion } from '../hooks/useLoadMoreExpansion';
 
 const Error = ({error}: any) => <div>
   <FormattedMessage id={error.id} values={{value: error.value}}/>{error.message}
@@ -40,7 +41,9 @@ const styles = defineStyles("PostsList2", (theme: ThemeType) => ({
   },
 }));
 
-type PostsList2Props = PostsListConfig;
+interface PostsList2Props extends PostsListConfig {
+  animateLoadMore?: boolean,
+}
 
 const PostsList2 = (props: PostsList2Props & {noSuspenseBoundary?: boolean}) => {
   if (props.noSuspenseBoundary) {
@@ -87,6 +90,15 @@ const PostsListLoaded = ({...props}: PostsList2Props) => {
     repeatedPostsPrecedence,
   } = usePostsList(props);
   const classes = useStyles(styles);
+  const { listRef, prepareForLoadMore } = useLoadMoreExpansion({
+    loading,
+    itemCount: orderedResults?.length ?? 0,
+    enabled: props.animateLoadMore ?? false,
+  });
+  const handleLoadMore = () => {
+    prepareForLoadMore();
+    loadMore();
+  };
 
   if (!orderedResults && loading) {
     return (
@@ -118,7 +130,7 @@ const PostsListLoaded = ({...props}: PostsList2Props) => {
         {orderedResults && !orderedResults.length && <PostsNoResults/>}
 
         <AnalyticsContext viewType={viewType}>
-          <div className={classNames(
+          <div ref={listRef} className={classNames(
             boxShadow && classes.postsBoxShadow,
             showPlacement && classes.postsGrid,
           )}>
@@ -137,7 +149,7 @@ const PostsListLoaded = ({...props}: PostsList2Props) => {
           <LoadMore
             {...loadMoreProps}
             loading={loading}
-            loadMore={loadMore}
+            loadMore={handleLoadMore}
             hideLoading={dimWhenLoading || !showLoading}
             // It's important to use hidden here rather than not rendering the component,
             // because LoadMore has an "isFirstRender" check that prevents it from showing loading dots
@@ -157,5 +169,3 @@ export default registerComponent('PostsList2', PostsList2, {
     terms: "deep",
   },
 });
-
-

--- a/packages/lesswrong/components/posts/RecombeePostsList.tsx
+++ b/packages/lesswrong/components/posts/RecombeePostsList.tsx
@@ -19,6 +19,7 @@ import { stickiedPostTerms } from '@/lib/collections/posts/constants';
 import { SuspenseWrapper } from '../common/SuspenseWrapper';
 import { registerComponent } from '@/lib/vulcan-lib/components';
 import uniqBy from 'lodash/uniqBy';
+import { useLoadMoreExpansion } from '../hooks/useLoadMoreExpansion';
 
 type LoadMoreSettings = {
   loadMore: (RecombeeConfiguration | HybridRecombeeConfiguration)['loadMore'];
@@ -150,6 +151,10 @@ const RecombeePostsListInner = ({ algorithm, settings, limit = 15 }: {
   
   //exclude posts with hiddenPostIds
   const filteredResults = uniqueResults?.filter(({ post }) => !hiddenPostIds.includes(post._id));
+  const { listRef, prepareForLoadMore } = useLoadMoreExpansion({
+    loading: loading || networkStatus === NetworkStatus.fetchMore,
+    itemCount: filteredResults?.length ?? 0,
+  });
 
   const postIds = filteredResults?.map(({post}) => post._id) ?? [];
   const postIdsWithScenario = filteredResults?.map(({ post, scenario, curated, stickied, generatedAt }, idx) => {
@@ -192,7 +197,7 @@ const RecombeePostsListInner = ({ algorithm, settings, limit = 15 }: {
   }
 
   return <div>
-    <div>
+    <div ref={listRef}>
       {filteredResults.map(({ post, recommId, curated, stickied }) => <IsRecommendationContext.Provider key={post._id} value={!!recommId}>
         <PostsItem 
           post={post} 
@@ -207,6 +212,7 @@ const RecombeePostsListInner = ({ algorithm, settings, limit = 15 }: {
       <LoadMore
         loading={loading || networkStatus === NetworkStatus.fetchMore}
         loadMore={() => {
+          prepareForLoadMore();
           const loadMoreSettings = getLoadMoreSettings(resolverName, filteredResults, loadMoreCount);
           void fetchMore({
             variables: {
@@ -252,4 +258,3 @@ export const RecombeePostsList = registerComponent("RecombeePostsList", Recombee
     settings: "deep",
   },
 });
-

--- a/packages/lesswrong/components/quickTakes/QuickTakesListItem.tsx
+++ b/packages/lesswrong/components/quickTakes/QuickTakesListItem.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from "react";
+import React, { useCallback, useLayoutEffect, useRef, useState } from "react";
 import { useTracking } from "../../lib/analyticsEvents";
 import { isFriendlyUI } from "../../themes/forumTheme";
 import classNames from "classnames";
@@ -10,6 +10,10 @@ import { defineStyles } from '@/components/hooks/defineStyles';
 import { useStyles } from '@/components/hooks/useStyles';
 
 const styles = defineStyles("QuickTakesListItem", (theme: ThemeType) => ({
+  root: {
+    // Include the expanded comment's margins in the animated height.
+    display: "flow-root",
+  },
   expandedRoot: {
     position: "relative",
     "& .comments-node-root": {
@@ -32,10 +36,37 @@ const QuickTakesListItem = ({quickTake, linesToDisplay=2}: {
   const classes = useStyles(styles);
   const {captureEvent} = useTracking();
   const [expanded, setExpanded] = useState(false);
+  const rootRef = useRef<HTMLDivElement>(null);
+  const heightBeforeExpansionRef = useRef<number|null>(null);
+
+  useLayoutEffect(() => {
+    const element = rootRef.current;
+    const previousHeight = heightBeforeExpansionRef.current;
+    heightBeforeExpansionRef.current = null;
+    if (!expanded || !element || previousHeight === null || window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+      return;
+    }
+
+    const expandedHeight = element.getBoundingClientRect().height;
+    if (expandedHeight <= previousHeight) {
+      return;
+    }
+
+    const animation = element.animate([
+      { height: `${previousHeight}px`, overflow: 'clip' },
+      { height: `${expandedHeight}px`, overflow: 'clip' },
+    ], { duration: 200, easing: 'ease-out' });
+
+    return () => animation.cancel();
+  }, [expanded]);
+
   const wrappedSetExpanded = useCallback((value: boolean) => {
+    if (value && !expanded) {
+      heightBeforeExpansionRef.current = rootRef.current?.getBoundingClientRect().height ?? null;
+    }
     setExpanded(value);
     captureEvent(value ? "shortformItemExpanded" : "shortformItemCollapsed");
-  }, [captureEvent, setExpanded]);
+  }, [captureEvent, expanded]);
   const CollapsedListItem = isFriendlyUI() ? QuickTakesCollapsedListItem : LWQuickTakesCollapsedListItem;
 
   // We're doing both a NoSSR + conditional `display: 'none'` to toggle between the collapsed & expanded quick take
@@ -65,10 +96,10 @@ const QuickTakesListItem = ({quickTake, linesToDisplay=2}: {
     </div>
   );
 
-  return <>
+  return <div ref={rootRef} className={classes.root}>
     {expandedComment}
     {collapsedComment}
-  </>;
+  </div>;
 }
 
 export default QuickTakesListItem;

--- a/packages/lesswrong/components/quickTakes/QuickTakesSection.tsx
+++ b/packages/lesswrong/components/quickTakes/QuickTakesSection.tsx
@@ -1,5 +1,5 @@
 import { useForumType } from '@/components/hooks/useForumType';
-import React from "react";
+import React, { useLayoutEffect, useRef } from "react";
 import { registerComponent } from "../../lib/vulcan-lib/components";
 import { useCurrentUser } from "../common/withUser";
 import { useExpandedFrontpageSection } from "../hooks/useExpandedFrontpageSection";
@@ -43,6 +43,10 @@ const styles = defineStyles("QuickTakesSection", (theme: ThemeType) => ({
     fontFamily: theme.palette.fonts.sansSerifStack,
     fontSize: '1.16rem',
   },
+  loading: {
+    // Include the dots' overflow and preserve the space normally occupied by the footer.
+    padding: '16px 0 24px',
+  },
 }));
 
 const QuickTakesSectionLoaded = ({showCommunity}: {
@@ -62,19 +66,49 @@ const QuickTakesSectionLoaded = ({showCommunity}: {
   });
 
   const results = data?.comments?.results;
+  const listRef = useRef<HTMLDivElement>(null);
+  const heightBeforeLoadMoreRef = useRef<number|null>(null);
+
+  useLayoutEffect(() => {
+    const element = listRef.current;
+    const previousHeight = heightBeforeLoadMoreRef.current;
+    if (!element || previousHeight === null) return;
+
+    if (loading) {
+      // Measure with the centered spinner in place while waiting for the new items.
+      heightBeforeLoadMoreRef.current = element.getBoundingClientRect().height;
+      return;
+    }
+
+    heightBeforeLoadMoreRef.current = null;
+    const expandedHeight = element.getBoundingClientRect().height;
+    if (expandedHeight <= previousHeight || window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
+
+    const animation = element.animate([
+      { height: `${previousHeight}px`, overflow: 'clip' },
+      { height: `${expandedHeight}px`, overflow: 'clip' },
+    ], { duration: 200, easing: 'ease-out' });
+
+    return () => animation.cancel();
+  }, [loading, results]);
+
+  const handleLoadMore = () => {
+    heightBeforeLoadMoreRef.current = listRef.current?.getBoundingClientRect().height ?? null;
+    return loadMoreProps.loadMore();
+  };
 
   const showLoadMore = !loadMoreProps.hidden;
 
   return <>
     {(userCanQuickTake(currentUser) || !currentUser) && <QuickTakesEntry currentUser={currentUser} successCallback={refetch} />}
-    <div className={classes.list}>
+    <div ref={listRef} className={classes.list}>
       {results?.map((result: FrontpageShortformComments) => (
         <QuickTakesListItem key={result._id} quickTake={result} />
       ))}
-      {loading && <Loading />}
-      {showLoadMore && (
+      {loading && <div className={classes.loading}><Loading /></div>}
+      {showLoadMore && !loading && (
         <SectionFooter>
-          <LoadMore {...loadMoreProps} sectionFooterStyles />
+          <LoadMore {...loadMoreProps} loadMore={handleLoadMore} sectionFooterStyles />
         </SectionFooter>
       )}
     </div>
@@ -132,5 +166,3 @@ const QuickTakesSection = () => {
 export default registerComponent("QuickTakesSection", QuickTakesSection, {
   areEqual: "auto"
 });
-
-

--- a/packages/lesswrong/components/spotlights/DismissibleSpotlightItem.tsx
+++ b/packages/lesswrong/components/spotlights/DismissibleSpotlightItem.tsx
@@ -1,6 +1,7 @@
 import moment from 'moment';
 import classNames from 'classnames';
-import React, { useCallback, useMemo } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef } from 'react';
+import Transition from 'react-transition-group/Transition';
 import { AnalyticsContext, useTracking } from '../../lib/analyticsEvents';
 import { useCookiesWithConsent } from '../hooks/useCookiesWithConsent';
 import { HIDE_SPOTLIGHT_ITEM_PREFIX } from '../../lib/cookies/cookies';
@@ -55,6 +56,41 @@ export const DismissibleSpotlightItemSuspense = ({ className, spotlightId, loadi
   const [cookies, setCookie] = useCookiesWithConsent([cookieName]);
 
   const isHidden = useMemo(() => !!cookies[cookieName], [cookies, cookieName]);
+  const spotlightRef = useRef<HTMLDivElement>(null);
+  const dismissAnimationRef = useRef<Animation|null>(null);
+
+  const cancelDismissAnimation = useCallback(() => {
+    dismissAnimationRef.current?.cancel();
+    dismissAnimationRef.current = null;
+  }, []);
+
+  useEffect(() => cancelDismissAnimation, [cancelDismissAnimation, spotlight?._id]);
+
+  const animateDismissal = useCallback(() => {
+    cancelDismissAnimation();
+    const element = spotlightRef.current;
+    if (!element || window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
+
+    const height = element.getBoundingClientRect().height;
+    if (!height) return;
+
+    const marginBottom = window.getComputedStyle(element).marginBottom;
+    // Keep overflowing artwork visible during the fade; collapse only once it is transparent.
+    dismissAnimationRef.current = element.animate([
+      { opacity: 1, height: `${height}px`, marginBottom, offset: 0, easing: 'ease-out' },
+      { opacity: 0, height: `${height}px`, marginBottom, offset: 0.375, easing: 'ease-in-out' },
+      { opacity: 0, height: '0px', marginBottom: '0px', offset: 1 },
+    ], { duration: 320, fill: 'forwards' });
+  }, [cancelDismissAnimation]);
+
+  const finishDismissal = useCallback((done: () => void) => {
+    const animation = dismissAnimationRef.current;
+    if (!animation || animation.playState === 'finished') {
+      done();
+    } else {
+      animation.onfinish = done;
+    }
+  }, []);
 
   const hideBanner = useCallback(() => {
     setCookie(
@@ -66,7 +102,7 @@ export const DismissibleSpotlightItemSuspense = ({ className, spotlightId, loadi
     captureEvent("spotlightItemHideItemClicked", { document: spotlightDocument })
   }, [setCookie, cookieName, spotlightDocument, captureEvent]);
 
-  if (!spotlight || isHidden) {
+  if (!spotlight) {
     return null;
   }
 
@@ -75,12 +111,24 @@ export const DismissibleSpotlightItemSuspense = ({ className, spotlightId, loadi
       name="SpotlightItem"
       fallback={loadingStyle==="placeholder" ? <SpotlightItemFallback className={className}/> : <Loading/>}
     >
-      <SpotlightItem
+      <Transition
         key={spotlight._id}
-        spotlight={spotlight}
-        hideBanner={hideBanner}
-        className={className}
-      />
+        nodeRef={spotlightRef}
+        in={!isHidden}
+        mountOnEnter
+        unmountOnExit
+        onEnter={cancelDismissAnimation}
+        onExit={animateDismissal}
+        addEndListener={finishDismissal}
+      >
+        <SpotlightItem
+          ref={spotlightRef}
+          inert={isHidden}
+          spotlight={spotlight}
+          hideBanner={hideBanner}
+          className={className}
+        />
+      </Transition>
     </SuspenseWrapper>
   </AnalyticsContext>
 }
@@ -114,4 +162,3 @@ export const DismissibleSpotlightItem = ({loadingStyle="spinner", className, spo
 }
 
 export default DismissibleSpotlightItem;
-

--- a/packages/lesswrong/components/spotlights/SpotlightItem.tsx
+++ b/packages/lesswrong/components/spotlights/SpotlightItem.tsx
@@ -399,6 +399,8 @@ export const SpotlightItem = ({
   isDraftProcessing,
   className,
   children,
+  ref,
+  inert,
 }: {
   spotlight: SpotlightDisplay,
   showAdminInfo?: boolean,
@@ -409,6 +411,8 @@ export const SpotlightItem = ({
   isDraftProcessing?: boolean,
   className?: string,
   children?: React.ReactNode,
+  ref?: React.Ref<HTMLDivElement>,
+  inert?: boolean,
 }) => {
   const classes = useStyles(styles);
   const currentUser = useCurrentUser()
@@ -503,6 +507,8 @@ export const SpotlightItem = ({
       <AnalyticsTracker eventType="spotlightItem" captureOnMount captureOnClick={false}>
         <div
           id={spotlight._id}
+          ref={ref}
+          inert={inert}
           style={style}
           className={classNames(classes.root, className)}
       >
@@ -658,4 +664,3 @@ const SpotlightReviewComment = ({id}: {
     />
   </div>
 }
-

--- a/packages/lesswrong/components/tagging/SingleLineTagUpdates.tsx
+++ b/packages/lesswrong/components/tagging/SingleLineTagUpdates.tsx
@@ -17,6 +17,7 @@ import { SuspenseWrapper } from '../common/SuspenseWrapper';
 import Loading from '../vulcan-core/Loading';
 import { defineStyles } from '@/components/hooks/defineStyles';
 import { useStyles } from '@/components/hooks/useStyles';
+import AnimatedExpansion from '../common/AnimatedExpansion';
 
 export const POSTED_AT_WIDTH = 38
 
@@ -112,7 +113,7 @@ const SingleLineTagUpdates = ({tag, revisionIds, commentCount, commentIds, users
   const [expanded,setExpanded] = useState(false);
   documentDeletions ??= [];
 
-  return <div className={classes.root} >
+  const content = <div className={classes.root} >
     <div className={classes.metadata} onClick={_ev => setExpanded(!expanded)}>
 
       <div className={classes.title} >
@@ -201,9 +202,9 @@ const SingleLineTagUpdates = ({tag, revisionIds, commentCount, commentIds, users
         )}
       </SuspenseWrapper>}
     </div>}
-  </div>
+  </div>;
+
+  return <AnimatedExpansion expanded={expanded}>{content}</AnimatedExpansion>;
 }
 
 export default SingleLineTagUpdates
-
-

--- a/packages/lesswrong/components/ultraFeed/UltraFeed.tsx
+++ b/packages/lesswrong/components/ultraFeed/UltraFeed.tsx
@@ -1,5 +1,7 @@
 import { useForumType } from '@/components/hooks/useForumType';
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useLayoutEffect, useRef, useState } from 'react';
+import classNames from 'classnames';
+import Transition from 'react-transition-group/Transition';
 import { useCurrentUser } from '../common/withUser';
 import type { ObservableQuery } from '@apollo/client';
 import { randomId } from '../../lib/random';
@@ -132,6 +134,32 @@ const styles = defineStyles("UltraFeed", (theme: ThemeType) => ({
     marginTop: 16,
     marginBottom: 32,
   },
+  settingsReveal: {
+    display: 'grid',
+    gridTemplateRows: '0fr',
+    transition: 'grid-template-rows 180ms ease 120ms',
+    '@media (prefers-reduced-motion: reduce)': {
+      '&, & $settingsRevealContent': {
+        transition: 'none',
+      },
+    },
+  },
+  settingsRevealContent: {
+    minHeight: 0,
+    overflow: 'hidden',
+    opacity: 0,
+    visibility: 'hidden',
+    transition: 'opacity 120ms ease, visibility 0ms linear 120ms',
+  },
+  settingsRevealExpanded: {
+    gridTemplateRows: '1fr',
+    transitionDelay: '0ms',
+    '& $settingsRevealContent': {
+      opacity: 1,
+      visibility: 'visible',
+      transitionDelay: '180ms, 0ms',
+    },
+  },
   composerButton: {
     display: 'none',
     [theme.breakpoints.down('sm')]: {
@@ -215,10 +243,17 @@ const UltraFeedContent = ({
   const forYouWrapperRef = useRef<HTMLDivElement | null>(null);
   const followingWrapperRef = useRef<HTMLDivElement | null>(null);
   const debugWrapperRef = useRef<HTMLDivElement | null>(null);
+  const settingsRevealRef = useRef<HTMLDivElement>(null);
+  const [settingsTab, setSettingsTab] = useState(activeTab);
   const [hasRenderedForYou, setHasRenderedForYou] = useState(activeTab === 'ultraFeed');
   const [hasRenderedFollowing, setHasRenderedFollowing] = useState(activeTab === 'following');
   const [hasRenderedDebug, setHasRenderedDebug] = useState(activeTab === 'debug');
   const [isTransitioning, setIsTransitioning] = useState(false);
+
+  useLayoutEffect(() => {
+    // Keep the outgoing settings panel intact when a tab switch closes it.
+    if (settingsVisible) setSettingsTab(activeTab);
+  }, [activeTab, settingsVisible]);
 
   const handleOpenQuickTakeDialog = () => {
     captureEvent("ultraFeedComposerQuickTakeDialogOpened");
@@ -257,24 +292,44 @@ const UltraFeedContent = ({
       <div className={classes.root} ref={feedContainerRef}>
         <UltraFeedObserverProvider incognitoMode={resolverSettings.incognitoMode}>
         <OverflowNavObserverProvider>
-            {settingsVisible && (
-              <div className={useExternalContainer ? classes.settingsContainerExternal : classes.settingsContainer}>
-                {activeTab === 'following' ? (
-                  <UltraFeedFollowingSettings
-                    settings={settings}
-                    updateSettings={updateSettings}
-                    onClose={() => onCloseSettings?.()}
-                  />
-                ) : (
-                  <UltraFeedSettings 
-                    settings={settings}
-                    updateSettings={updateSettings}
-                    onClose={() => onCloseSettings?.()} 
-                    truncationMaps={truncationMaps}
-                  />
-                )}
-              </div>
-            )}
+            <Transition
+              nodeRef={settingsRevealRef}
+              in={!!settingsVisible}
+              timeout={300}
+              mountOnEnter
+              unmountOnExit
+              onEnter={() => {
+                // Establish the collapsed layout before animating newly mounted settings.
+                settingsRevealRef.current?.getBoundingClientRect();
+              }}
+            >
+              {state => <div
+                ref={settingsRevealRef}
+                className={classNames(classes.settingsReveal, {
+                  [classes.settingsRevealExpanded]: state === 'entering' || state === 'entered',
+                })}
+                inert={!settingsVisible}
+              >
+                <div className={classes.settingsRevealContent}>
+                  <div className={useExternalContainer ? classes.settingsContainerExternal : classes.settingsContainer}>
+                    {settingsTab === 'following' ? (
+                      <UltraFeedFollowingSettings
+                        settings={settings}
+                        updateSettings={updateSettings}
+                        onClose={() => onCloseSettings?.()}
+                      />
+                    ) : (
+                      <UltraFeedSettings
+                        settings={settings}
+                        updateSettings={updateSettings}
+                        onClose={() => onCloseSettings?.()}
+                        truncationMaps={truncationMaps}
+                      />
+                    )}
+                  </div>
+                </div>
+              </div>}
+            </Transition>
 
             {infoVisible && activeTab === 'ultraFeed' && (
               <div className={useExternalContainer ? classes.settingsContainerExternal : classes.settingsContainer}>


### PR DESCRIPTION
Animations for:

 * Latest posts list settings gear
 * Expanding truncated comment items
 * Expanding Quick Takes on the front page
 * Expanding/collapsing the Quick Takes section as a whole
 * Settings on the All Posts page.
 * Expanding single-line quick takes on the All Posts page, and wikitag page edits/discussion
 * Show-parent on a comment.
 * Dismissing a spotlight item.
 * Settings on the "Your Feed" section.
 * Load More on the front page Quick Takes section
 * Front page posts list Load More
 * Opening comments on post items
 * Collapsing comments with [-]
 
