### PR TITLE
Fix extra comment top spacing

### DIFF
--- a/packages/lesswrong/components/comments/CommentsItem/CommentsItem.tsx
+++ b/packages/lesswrong/components/comments/CommentsItem/CommentsItem.tsx
@@ -64,6 +64,11 @@ const styles = defineStyles("CommentsItem", (theme: ThemeType) => ({
     borderStyle: "none",
     padding: 0,
     ...theme.typography.commentStyle,
+    '& > .CommentsItemMeta-root + .AnimatedCollapse-root .CommentBody-root.ContentStyles-commentBody': {
+      // The animation wrapper prevents these margins from collapsing. The metadata
+      // already supplies 8px, so retain only any excess from the body's .5em margin.
+      marginTop: 'max(0px, calc(0.5em - 8px))',
+    },
   },
   sideComment: {
     "& blockquote": {


### PR DESCRIPTION
<details>
<summary>Prompts Used</summary>

User: It looks like in this branch we may have accidentally increased the comment top-padding for normal comments on post pages). Check for changes that may have had that effect, and restore the previous padding.

Astra:

> Fixed the extra spacing introduced by the collapse wrapper. The gap below comment metadata is restored from roughly 15.5 px to 8 px, while preserving the animation.
>
> Verified normal spacing after collapsing and reopening.
</details>

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1218384616816085) by [Unito](https://www.unito.io)
