### PR TITLE
Suppress iOS zooming

### DIFF
--- a/packages/lesswrong/components/layout/ClientAppGenerator.tsx
+++ b/packages/lesswrong/components/layout/ClientAppGenerator.tsx
@@ -23,6 +23,7 @@ import { initClientOnce } from '@/client/initClient';
 import { TimeProvider } from '@/lib/utils/TimeProvider';
 import { ForumTypeProvider } from '@/components/hooks/useForumType';
 import type { ForumTypeString } from '@/lib/instanceSettings';
+import PhoneZoomControl from './PhoneZoomControl';
 
 if (isClient) {
   // This has a downstream call to `googleTagManagerIdSetting.get()`.
@@ -151,6 +152,7 @@ const ClientAppGenerator = ({ abTestGroupsUsed, requestId, forumType, children }
           <CookiesProvider>
             <UserContextProvider>
               <ThemeContextProvider>
+                <PhoneZoomControl/>
                 <ABTestGroupsUsedContext.Provider value={abTestGroupsUsed}>
                   <HelmetProvider>
                     <LocationContextProvider>

--- a/packages/lesswrong/components/layout/PhoneZoomControl.tsx
+++ b/packages/lesswrong/components/layout/PhoneZoomControl.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import { useLayoutEffect } from 'react';
+import { defineStyles, useStyles } from '../hooks/useStyles';
+import { useTheme } from '../themes/useTheme';
+
+const styles = defineStyles('PhoneZoomControl', (theme: ThemeType) => ({
+  '@global': {
+    html: {
+      [theme.breakpoints.down('xs')]: {
+        // Allow scrolling in both directions, but not pinch/double-tap page zoom.
+        touchAction: 'pan-x pan-y',
+      },
+    },
+  },
+}));
+
+interface ViewportOverride {
+  element: HTMLMetaElement,
+  originalContent: string,
+  appliedContent: string,
+}
+
+interface PhoneViewportState {
+  mediaQuery: MediaQueryList,
+  override: ViewportOverride | null,
+}
+
+function restoreViewport(state: PhoneViewportState) {
+  const override = state.override;
+  // Don't overwrite a newer viewport supplied by Next's metadata handling.
+  if (override && override.element.content === override.appliedContent) {
+    override.element.content = override.originalContent;
+  }
+  state.override = null;
+}
+
+function keepViewportDirective(directive: string) {
+  return !/^\s*(maximum-scale|user-scalable)\s*=/i.test(directive);
+}
+
+function updateViewport(state: PhoneViewportState) {
+  const viewport = document.querySelector<HTMLMetaElement>('meta[name="viewport"]');
+  if (!state.mediaQuery.matches || state.override?.element !== viewport) {
+    restoreViewport(state);
+  }
+  if (!state.mediaQuery.matches || !viewport) return;
+  if (state.override?.appliedContent === viewport.content) return;
+
+  const originalContent = viewport.content;
+  const appliedContent = `${originalContent.split(',').filter(keepViewportDirective).join(',')}, maximum-scale=1, user-scalable=no`;
+  state.override = { element: viewport, originalContent, appliedContent };
+  // touch-action controls gestures; the viewport limit separately prevents
+  // iOS from zooming to focus small inputs and contenteditable editors.
+  viewport.content = appliedContent;
+}
+
+export default function PhoneZoomControl() {
+  useStyles(styles);
+  const theme = useTheme();
+  const mediaQuery = theme.breakpoints.down('xs').replace('@media ', '');
+
+  useLayoutEffect(() => {
+    const state: PhoneViewportState = {
+      mediaQuery: window.matchMedia(mediaQuery),
+      override: null,
+    };
+    const update = () => updateViewport(state);
+    update();
+    state.mediaQuery.addEventListener('change', update);
+
+    // Next can replace or update its viewport metadata during navigation.
+    // Reapply the phone restriction without creating a second viewport tag.
+    const observer = new MutationObserver(update);
+    observer.observe(document.head, {
+      childList: true,
+      subtree: true,
+      attributes: true,
+      attributeFilter: ['content', 'name'],
+    });
+    return () => {
+      observer.disconnect();
+      state.mediaQuery.removeEventListener('change', update);
+      restoreViewport(state);
+    };
+  }, [mediaQuery]);
+
+  return null;
+}

--- a/packages/lesswrong/components/spuriousChange.ts
+++ b/packages/lesswrong/components/spuriousChange.ts
@@ -2,5 +2,5 @@
 // This file gets rewritten by scripts/benchmarkIncrementalStart.sh as a way
 // of realistically triggering a server restart, as though a source file had
 // been edited.
-const someVar = 26246
+const someVar = 26247
 


### PR DESCRIPTION
(Not adequately tested yet)

<details>
<summary>Prompts Used</summary>
User: On iOS, interacting with the login dialog causes the page to zoom in very slightly (mostly just removing page left and right padding). The same happens with comment input boxes, and probably other input elements as well. It's not clear that we want the mobile page to be zoomable at all; in theory we're handling everything that could create a need for horizontal scroll directly.

Can we disable this page-zoom in general, at phone screen widths? (Preferrably not disabling it for tablet or desktop widths, since on larger sizes there's inactive stuff in the margins which the user might want to get rid of by zooming.) Or barring that, can we prevent the input-box-triggered zoom in particular?

GPT-6 Astra:
> Implemented below the existing **600px breakpoint**:
>
> - Viewport scale limits to prevent iOS’s [input-focus zoom](https://bugs.webkit.org/show_bug.cgi?id=157771).
> - Touch rules to disable pinch/double-tap page zoom while allowing scrolling.
> - Automatic restoration of normal zoom at wider widths, including after rotation.
>
> This applies across inputs and editors. Five regression tests, TypeScript, code generation, and targeted lint pass. Actual iOS focus/pinch behavior still needs device testing; browser zoom overrides may remain available.
</details>

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1218418879683073) by [Unito](https://www.unito.io)
