### PR TITLE
Autofocus input in login dialogs

### DIFF
--- a/packages/lesswrong/components/users/LoginForm.tsx
+++ b/packages/lesswrong/components/users/LoginForm.tsx
@@ -100,9 +100,11 @@ const currentActionToButtonText: Record<possibleActions, string> = {
   pwReset: "Request Password Reset"
 }
 
-const LoginForm = ({ startingState = "login", returnTo }: {
+const LoginForm = ({ startingState = "login", returnTo, autoFocus = false }: {
   startingState?: possibleActions,
-  returnTo?: string
+  returnTo?: string,
+  /** Only enable when the form is opened by a user interaction. */
+  autoFocus?: boolean,
 }) => {
   const { isAF } = useForumType();
   const classes = useStyles(styles);
@@ -222,6 +224,7 @@ const LoginForm = ({ startingState = "login", returnTo }: {
         <input
           value={username} type="text" name="username"
           autoComplete="username"
+          autoFocus={autoFocus}
           placeholder={currentAction === "signup" ? "username" : "username or email"}
           className={classes.input}
           onChange={event => setUsername(event.target.value)}

--- a/packages/lesswrong/components/users/LoginPopup.tsx
+++ b/packages/lesswrong/components/users/LoginPopup.tsx
@@ -31,7 +31,7 @@ const LoginPopup = ({onClose}: {
       className={classes.dialog}
       paperClassName={classes.paper}
     >
-      <LoginForm />
+      <LoginForm autoFocus />
     </LWDialog>
   );
 }

--- a/packages/lesswrong/components/users/UsersAccountMenu.tsx
+++ b/packages/lesswrong/components/users/UsersAccountMenu.tsx
@@ -51,7 +51,7 @@ export const LWUsersAccountMenu = () => {
       >
         <LWClickAwayListener onClickAway={handleRequestClose}>
           <Paper>
-            {open && <LoginForm />}
+            {open && <LoginForm autoFocus />}
           </Paper>
         </LWClickAwayListener>
       </LWPopper>


### PR DESCRIPTION
<details>
<summary>Prompts Used</summary>
User: Currently when you're logged out, if you tap the Quick Takes comment entry box, it opens a modal login dialog. However it leaves the input focus on the comment box, so keystrokes go to the comment in the background. Make it so that when the login modal appears, it focuses the "username or email" input box. Do the same with the Login button in the top bar. (Watch out for login-form components that might be embedded in the page without user interaction in some out of the way places; these should not take the focus unless interacted with).

GPT-6 Astra:
> Implemented autofocus on “username or email” for both the Quick Takes login modal and top-bar Login dropdown. Embedded login forms retain their existing focus behavior.
>
> Code generation, TypeScript, and targeted ESLint checks passed. Browser behavior wasn’t manually tested.
</details>

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1218419046732868) by [Unito](https://www.unito.io)
