### PR TITLE
Unify the two notions of single-line comment collapse

### DIFF
--- a/packages/lesswrong/components/comments/CommentsItem/CommentBody.tsx
+++ b/packages/lesswrong/components/comments/CommentsItem/CommentBody.tsx
@@ -44,10 +44,9 @@ const styles = defineStyles('CommentBody', (theme: ThemeType) => ({
   },
 }))
 
-const CommentBody = ({comment, commentBodyRef, collapsed, truncated, postPage, voteProps, className}: {
+const CommentBody = ({comment, commentBodyRef, truncated, postPage, voteProps, className}: {
   comment: CommentsList,
   commentBodyRef?: React.RefObject<ContentItemBodyImperative|null>|null,
-  collapsed?: boolean,
   truncated?: boolean,
   postPage?: boolean,
   voteProps?: VotingProps<VoteableTypeClient>
@@ -68,7 +67,6 @@ const CommentBody = ({comment, commentBodyRef, collapsed, truncated, postPage, v
   );
 
   if (comment.deleted) { return <CommentDeletedMetadata documentId={comment._id}/> }
-  if (collapsed) { return null }
 
   const innerHtml = (truncated && !truncationDisabledByUserConfig) ? commentExcerptFromHTML(comment, postPage) : (html ?? '')
 

--- a/packages/lesswrong/components/comments/CommentsItem/CommentsItem.tsx
+++ b/packages/lesswrong/components/comments/CommentsItem/CommentsItem.tsx
@@ -24,7 +24,6 @@ import CommentBody from "./CommentBody";
 import CommentsNewForm from "../CommentsNewForm";
 import ParentCommentSingle from "../ParentCommentSingle";
 import AnimatedExpansion from "../../common/AnimatedExpansion";
-import AnimatedCollapse from "../../common/AnimatedCollapse";
 import ForumIcon from "../../common/ForumIcon";
 import CommentDiscussionIcon from "./CommentDiscussionIcon";
 import LWTooltip from "../../common/LWTooltip";
@@ -64,11 +63,6 @@ const styles = defineStyles("CommentsItem", (theme: ThemeType) => ({
     borderStyle: "none",
     padding: 0,
     ...theme.typography.commentStyle,
-    '& > .CommentsItemMeta-root + .AnimatedCollapse-root .CommentBody-root.ContentStyles-commentBody': {
-      // The animation wrapper prevents these margins from collapsing. The metadata
-      // already supplies 8px, so retain only any excess from the body's .5em margin.
-      marginTop: 'max(0px, calc(0.5em - 8px))',
-    },
   },
   sideComment: {
     "& blockquote": {
@@ -170,12 +164,10 @@ export const CommentsItem = ({
   comment,
   nestingLevel=1,
   isChild,
-  collapsed,
   isParentComment,
   parentCommentId,
   scrollIntoView,
-  toggleCollapse,
-  setSingleLine,
+  collapseToSingleLine,
   truncated,
   showPinnedOnProfile,
   parentAnswerId,
@@ -189,12 +181,14 @@ export const CommentsItem = ({
   comment: CommentsList|CommentsListWithParentMetadata,
   nestingLevel: number,
   isChild?: boolean,
-  collapsed?: boolean,
   isParentComment?: boolean,
   parentCommentId?: string,
   scrollIntoView?: () => void,
-  toggleCollapse?: () => void,
-  setSingleLine?: (singleLine: boolean) => void,
+  /**
+   * Collapses the comment to a single line, hiding its replies. Used by the
+   * [-] button, and to return a draft to its single-line form after editing.
+   */
+  collapseToSingleLine?: () => void,
   truncated: boolean,
   showPinnedOnProfile?: boolean,
   parentAnswerId?: string,
@@ -242,7 +236,7 @@ export const CommentsItem = ({
   const editCancelCallback = () => {
     setShowEditState(false);
     if (comment.draft) {
-      setSingleLine?.(true);
+      collapseToSingleLine?.();
     }
   }
 
@@ -259,7 +253,7 @@ export const CommentsItem = ({
     }
     setShowEditState(false);
     if (comment.draft) {
-      setSingleLine?.(true);
+      collapseToSingleLine?.();
     }
   }
 
@@ -384,9 +378,7 @@ export const CommentsItem = ({
               toggleShowParent,
               scrollIntoView,
               parentAnswerId,
-              setSingleLine,
-              collapsed,
-              toggleCollapse,
+              collapseToSingleLine,
               setShowEdit,
             }}
           />
@@ -394,31 +386,27 @@ export const CommentsItem = ({
             Pinned by {comment.promotedByUser.displayName}
           </div>}
           {comment.rejected && <p><RejectedReasonDisplay reason={comment.rejectedReason ?? null}/></p>}
-          {comment.deleted ? renderBodyOrEditor(voteProps) : <AnimatedCollapse expanded={!collapsed}>
-            {renderBodyOrEditor(voteProps)}
-            {!showEditState && <CommentBottom
-              comment={comment}
-              post={post}
-              treeOptions={treeOptions}
-              votingSystem={votingSystem}
-              voteProps={voteProps}
-              commentBodyRef={commentBodyRef}
-              replyButton={replyButton}
-            />}
-          </AnimatedCollapse>}
+          {renderBodyOrEditor(voteProps)}
+          {!comment.deleted && !showEditState && <CommentBottom
+            comment={comment}
+            post={post}
+            treeOptions={treeOptions}
+            votingSystem={votingSystem}
+            voteProps={voteProps}
+            commentBodyRef={commentBodyRef}
+            replyButton={replyButton}
+          />}
         </div>
-        {(displayReviewVoting || replyFormIsOpen) && <AnimatedCollapse expanded={!collapsed}>
-          {displayReviewVoting && <div className={classes.reviewVotingButtons}>
-            <div className={classes.updateVoteMessage}>
-              <LWTooltip title={`If this review changed your mind, update your ${getReviewNameInSitu()} vote for the original post `}>
-                Update your {getReviewNameInSitu()} vote for this post.
-                <LWHelpIcon/>
-              </LWTooltip>
-            </div>
-            {post && <ReviewVotingWidget post={post} showTitle={false}/>}
-          </div>}
-          {replyFormIsOpen && renderReply()}
-        </AnimatedCollapse>}
+        {displayReviewVoting && <div className={classes.reviewVotingButtons}>
+          <div className={classes.updateVoteMessage}>
+            <LWTooltip title={`If this review changed your mind, update your ${getReviewNameInSitu()} vote for the original post `}>
+              Update your {getReviewNameInSitu()} vote for this post.
+              <LWHelpIcon/>
+            </LWTooltip>
+          </div>
+          {post && <ReviewVotingWidget post={post} showTitle={false}/>}
+        </div>}
+        {replyFormIsOpen && renderReply()}
       </div>
     </HoveredReactionContextProvider>
     </AnalyticsContext>

--- a/packages/lesswrong/components/comments/CommentsItem/CommentsItemMeta.tsx
+++ b/packages/lesswrong/components/comments/CommentsItem/CommentsItemMeta.tsx
@@ -65,13 +65,6 @@ const styles = defineStyles("CommentsItemMeta", (theme: ThemeType) => ({
       fontFamily: "monospace",
     },
   },
-  collapseChevron: {
-    width: 15,
-    transition: "transform 0.2s",
-  },
-  collapseChevronOpen: {
-    transform: "rotate(90deg)",
-  },
   collapseCharacter: {
     transform: 'translateY(0.75px)',
   },
@@ -145,9 +138,7 @@ export const CommentsItemMeta = ({
   toggleShowParent,
   scrollIntoView,
   parentAnswerId,
-  setSingleLine,
-  collapsed,
-  toggleCollapse,
+  collapseToSingleLine,
   setShowEdit,
   rightSectionElements,
 }: {
@@ -160,9 +151,12 @@ export const CommentsItemMeta = ({
   toggleShowParent: () => void,
   scrollIntoView?: () => void,
   parentAnswerId?: string,
-  setSingleLine?: (singleLine: boolean) => void,
-  collapsed?: boolean,
-  toggleCollapse?: () => void,
+  /**
+   * Collapses the comment to a single line, hiding its replies. Called by the
+   * [-] button, which is only shown if this is provided (and
+   * `treeOptions.showCollapseButtons` is set).
+   */
+  collapseToSingleLine?: () => void,
   setShowEdit: () => void,
   rightSectionElements?: React.ReactNode,
 }) => {
@@ -172,7 +166,7 @@ export const CommentsItemMeta = ({
   const { scrollToCommentId } = useCommentLinkState();
 
   const {
-    postPage, showCollapseButtons, post, tag, singleLineCollapse, isSideComment,
+    postPage, showCollapseButtons, post, tag, isSideComment,
     hideActionsMenu, hideParentCommentToggle, hideParentCommentToggleForTopLevel,
   } = treeOptions;
 
@@ -241,16 +235,11 @@ export const CommentsItemMeta = ({
           onClick={toggleShowParent}
         />
       }
-      {(showCollapseButtons || collapsed) &&
-        <a className={classes.collapse} onClick={toggleCollapse}>
-          <>[<span className={classes.collapseCharacter}>{collapsed ? "+" : "-"}</span>]</>
+      {showCollapseButtons && collapseToSingleLine &&
+        <a className={classes.collapse} onClick={collapseToSingleLine}>
+          <>[<span className={classes.collapseCharacter}>-</span>]</>
         </a>
       }
-      {singleLineCollapse && <a className={classes.collapse} onClick={() =>
-        setSingleLine && setSingleLine(true)
-      }>
-        [<span>{collapsed ? "+" : "-"}</span>]
-      </a>}
       <CommentUserName
         comment={comment}
         className={classes.username}

--- a/packages/lesswrong/components/comments/CommentsNode.tsx
+++ b/packages/lesswrong/components/comments/CommentsNode.tsx
@@ -19,14 +19,17 @@ import { useStyles } from '@/components/hooks/useStyles';
 import AnimatedExpansion from '../common/AnimatedExpansion';
 import AnimatedCollapse from '../common/AnimatedCollapse';
 
+/**
+ * Comments with karma below this threshold start out collapsed to a single
+ * line, with their replies hidden.
+ */
 const KARMA_COLLAPSE_THRESHOLD = -4;
 
 export const COMMENT_DRAFT_TREE_OPTIONS: CommentTreeOptions = {
   condensed: true,
-  singleLineCollapse: true,
   hideSingleLineMeta: true,
   forceSingleLine: true,
-  showCollapseButtons: false,
+  showCollapseButtons: true,
   initialShowEdit: true,
   hideReply: true
 };
@@ -67,6 +70,10 @@ export interface CommentsNodeProps {
    * expanded state to child comments
    */
   forceUnTruncated?: boolean,
+  /**
+   * If set, this comment does not start out collapsed to a single line because
+   * of low karma or being deleted. Not passed to child comments.
+   */
   forceUnCollapsed?: boolean,
   expandNewComments?: boolean,
   isChild?: boolean,
@@ -79,12 +86,6 @@ export interface CommentsNodeProps {
   loadDirectReplies?: boolean,
   showPinnedOnProfile?: boolean,
   enableGuidelines?: boolean,
-  /**
-   * Determines the karma threshold used to decide whether to collapse a comment.
-   * 
-   * Currently only overriden in the comment moderation tab.
-   */
-  karmaCollapseThreshold?: number,
   /**
    * Determines whether to expand this comment's parent comment (if it exists) by default.
    * 
@@ -101,19 +102,24 @@ export interface CommentsNodeProps {
  *
  * Before adding more props to this, consider whether you should instead be adding a field to the CommentTreeOptions interface.
  */
-const CommentsNodeInner = ({treeOptions, comment, startThreadTruncated, truncated, shortform, nestingLevel=1, expandAllThreads, forceUnTruncated, forceUnCollapsed, expandNewComments=true, isChild, parentAnswerId, parentCommentId, showExtraChildrenButton, hoverPreview, childComments, loadChildrenSeparately, loadDirectReplies=false, showPinnedOnProfile=false, enableGuidelines=true, karmaCollapseThreshold=KARMA_COLLAPSE_THRESHOLD, showParentDefault=false, noAutoScroll=false, displayTagIcon=false, className}: CommentsNodeProps) => {
+const CommentsNodeInner = ({treeOptions, comment, startThreadTruncated, truncated, shortform, nestingLevel=1, expandAllThreads, forceUnTruncated, forceUnCollapsed, expandNewComments=true, isChild, parentAnswerId, parentCommentId, showExtraChildrenButton, hoverPreview, childComments, loadChildrenSeparately, loadDirectReplies=false, showPinnedOnProfile=false, enableGuidelines=true, showParentDefault=false, noAutoScroll=false, displayTagIcon=false, className}: CommentsNodeProps) => {
   const { forumType } = useForumType();
   const classes = useStyles(styles);
   const currentUserNoSingleLineCommentsSetting = useFilteredCurrentUser(u => u?.noSingleLineComments);
   const { captureEvent } = useTracking()
   const scrollTargetRef = useRef<HTMLDivElement|null>(null);
-  const heightBeforeExpansionRef = useRef<number|null>(null);
+  // Height of the comment before it was expanded or collapsed, so the change can be animated
+  const heightBeforeResizeRef = useRef<number|null>(null);
+  // Whether the comment was collapsed with its [-] button (as opposed to
+  // starting out collapsed), in which case the single line appears under the
+  // mouse cursor and shouldn't immediately show its hover preview.
+  const collapsedWithButtonRef = useRef(false);
 
   const hasInContextLinks = commentPermalinkStyleSetting.get(forumType) === 'in-context';
 
   const { linkedCommentId, scrollToCommentId } = useCommentLinkState();
 
-  const { lastCommentId, condensed, postPage, post, highlightDate, scrollOnExpand, forceSingleLine, forceNotSingleLine, expandOnlyCommentIds, noDOMId, onToggleCollapsed } = treeOptions;
+  const { lastCommentId, condensed, postPage, post, highlightDate, scrollOnExpand, forceSingleLine, forceNotSingleLine, expandOnlyCommentIds, noDOMId, onCollapse } = treeOptions;
   const animateWholeThread = forceSingleLine && loadChildrenSeparately;
 
   const shouldUncollapseForAutoScroll = useCallback(() => {
@@ -126,9 +132,9 @@ const CommentsNodeInner = ({treeOptions, comment, startThreadTruncated, truncate
 
   const shouldExpandAndScrollTo = !noDOMId && !noAutoScroll && comment && scrollToCommentId === comment._id
 
-  const beginCollapsed = useCallback(() => {
-    return !shouldUncollapseForAutoScroll() && !forceUnCollapsed && (comment.deleted || (comment.baseScore ?? 0) < karmaCollapseThreshold)
-  }, [comment.baseScore, comment.deleted, forceUnCollapsed, karmaCollapseThreshold, shouldUncollapseForAutoScroll])
+  const beginCollapsedToSingleLine = useCallback(() => {
+    return !shouldUncollapseForAutoScroll() && !forceUnCollapsed && (comment.deleted || (comment.baseScore ?? 0) < KARMA_COLLAPSE_THRESHOLD)
+  }, [comment.baseScore, comment.deleted, forceUnCollapsed, shouldUncollapseForAutoScroll])
 
   const beginSingleLine = useCallback((): boolean => {
     // TODO: Before hookification, this got nestingLevel without the default value applied, which may have changed its behavior?
@@ -160,8 +166,12 @@ const CommentsNodeInner = ({treeOptions, comment, startThreadTruncated, truncate
     return !shouldExpandAndScrollTo && !!startThreadTruncated
   }, [shouldExpandAndScrollTo, startThreadTruncated])
 
-  // Whether the comment is completely hidden (with the toggle arrow closed)
-  const [collapsed, setCollapsed] = useState<boolean>(beginCollapsed);
+  // Whether the comment has been collapsed to a single line with its replies
+  // hidden behind a comment-count icon, either with the [-] button or because
+  // it started out that way (deleted, or karma below the threshold). This
+  // overrides the ordinary single-line logic below, which only applies to
+  // truncated threads and leaves replies visible.
+  const [collapsedToSingleLine, setCollapsedToSingleLine] = useState<boolean>(beginCollapsedToSingleLine);
   
   const [singleLine, setSingleLine] = useState(beginSingleLine());
   const [truncatedState, setTruncated] = useState(beginTruncated);
@@ -196,8 +206,8 @@ const CommentsNodeInner = ({treeOptions, comment, startThreadTruncated, truncate
 
   useEffect(() => {
     // The comment hash isn't sent to the server, so `shouldUncollapseForAutoScroll` may be different from the first render pass
-    if (collapsed && shouldUncollapseForAutoScroll()) {
-      setCollapsed(false);
+    if (collapsedToSingleLine && shouldUncollapseForAutoScroll()) {
+      setCollapsedToSingleLine(false);
     }
 
     if (shouldExpandAndScrollTo) {
@@ -206,13 +216,12 @@ const CommentsNodeInner = ({treeOptions, comment, startThreadTruncated, truncate
     //eslint-disable-next-line react-hooks/exhaustive-deps
   }, [scrollToCommentId]);
 
-  const toggleCollapse = useCallback(
-    () => {
-      onToggleCollapsed?.();
-      setCollapsed(!collapsed)
-    },
-    [collapsed, onToggleCollapsed]
-  );
+  const collapseToSingleLine = useCallback(() => {
+    onCollapse?.();
+    heightBeforeResizeRef.current = animateWholeThread ? null : scrollTargetRef.current?.getBoundingClientRect().height ?? null;
+    collapsedWithButtonRef.current = true;
+    setCollapsedToSingleLine(true);
+  }, [onCollapse, animateWholeThread]);
 
   const isTruncated = ((): boolean => {
     if (expandAllThreads) return false;
@@ -224,6 +233,7 @@ const CommentsNodeInner = ({treeOptions, comment, startThreadTruncated, truncate
   const isNewComment = !!(highlightDate && (new Date(comment.postedAt).getTime() > new Date(highlightDate).getTime()))
 
   const isSingleLine = ((): boolean => {
+    if (collapsedToSingleLine) return true;
     if (!singleLine || currentUserNoSingleLineCommentsSetting) return false;
     if (forceSingleLine) return true;
     if (forceNotSingleLine) return false
@@ -233,21 +243,21 @@ const CommentsNodeInner = ({treeOptions, comment, startThreadTruncated, truncate
 
   useLayoutEffect(() => {
     const element = scrollTargetRef.current;
-    const previousHeight = heightBeforeExpansionRef.current;
-    heightBeforeExpansionRef.current = null;
+    const previousHeight = heightBeforeResizeRef.current;
+    heightBeforeResizeRef.current = null;
     if (!element || previousHeight === null || window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
       return;
     }
 
-    const expandedHeight = element.getBoundingClientRect().height;
-    if (expandedHeight <= previousHeight) {
+    const newHeight = element.getBoundingClientRect().height;
+    if (newHeight === previousHeight) {
       return;
     }
 
     // Measure the full content before paint, and release the height once the animation ends.
     const animation = element.animate([
       { height: `${previousHeight}px`, overflow: 'clip' },
-      { height: `${expandedHeight}px`, overflow: 'clip' },
+      { height: `${newHeight}px`, overflow: 'clip' },
     ], { duration: 200, easing: 'ease-out' });
 
     return () => animation.cancel();
@@ -255,7 +265,7 @@ const CommentsNodeInner = ({treeOptions, comment, startThreadTruncated, truncate
 
   const updatedNestingLevel = nestingLevel + (!!comment.gapIndicator ? 1 : 0)
 
-  const passedThroughItemProps = { comment, collapsed, showPinnedOnProfile, enableGuidelines, showParentDefault }
+  const passedThroughItemProps = { comment, showPinnedOnProfile, enableGuidelines, showParentDefault }
 
   
   const childrenSection = childComments && childComments.length > 0 && <div className={classes.children}>
@@ -295,10 +305,11 @@ const CommentsNodeInner = ({treeOptions, comment, startThreadTruncated, truncate
       event?.stopPropagation();
     }
     if (isTruncated || isSingleLine) {
-      heightBeforeExpansionRef.current = animateWholeThread ? null : scrollTargetRef.current?.getBoundingClientRect().height ?? null;
+      heightBeforeResizeRef.current = animateWholeThread ? null : scrollTargetRef.current?.getBoundingClientRect().height ?? null;
       captureEvent("commentExpanded", { postId: comment.postId, commentId: comment._id, draft: comment.draft });
       setTruncated(false);
       setSingleLine(false);
+      setCollapsedToSingleLine(false);
       setTruncatedStateSet(true);
     }
 
@@ -339,8 +350,9 @@ const CommentsNodeInner = ({treeOptions, comment, startThreadTruncated, truncate
                   nestingLevel={updatedNestingLevel}
                   parentCommentId={parentCommentId}
                   hideKarma={post?.hideCommentKarma}
-                  showDescendentCount={loadChildrenSeparately}
+                  showDescendentCount={loadChildrenSeparately || collapsedToSingleLine}
                   displayTagIcon={displayTagIcon}
+                  startsHovered={collapsedWithButtonRef.current}
                 />
               </AnalyticsTracker>
             </AnalyticsContext>
@@ -351,10 +363,9 @@ const CommentsNodeInner = ({treeOptions, comment, startThreadTruncated, truncate
                 nestingLevel={updatedNestingLevel}
                 parentCommentId={parentCommentId}
                 parentAnswerId={parentAnswerId || (comment.answer && comment._id) || undefined}
-                toggleCollapse={toggleCollapse}
+                collapseToSingleLine={collapseToSingleLine}
                 key={comment._id}
                 scrollIntoView={scrollIntoView}
-                setSingleLine={setSingleLine}
                 displayTagIcon={displayTagIcon}
                 { ...passedThroughItemProps}
               />
@@ -362,7 +373,7 @@ const CommentsNodeInner = ({treeOptions, comment, startThreadTruncated, truncate
         }
       </div>}
 
-      <AnimatedCollapse expanded={!collapsed}>
+      <AnimatedCollapse expanded={!collapsedToSingleLine}>
         {childrenSection}
 
         {!isSingleLine && loadChildrenSeparately &&

--- a/packages/lesswrong/components/comments/SingleLineComment.tsx
+++ b/packages/lesswrong/components/comments/SingleLineComment.tsx
@@ -1,6 +1,6 @@
 import { useForumType } from '@/components/hooks/useForumType';
 import { registerComponent } from '../../lib/vulcan-lib/components';
-import React from 'react';
+import React, { useRef } from 'react';
 import { useHover } from '../common/withHover';
 import classNames from 'classnames';
 import withErrorBoundary from '../common/withErrorBoundary';
@@ -134,6 +134,10 @@ const styles = defineStyles("SingleLineComment", (theme: ThemeType) => ({
     ...metaNoticeStyles(theme),
     marginRight: 20
   },
+  descendentCount: {
+    // Keep the count at the right edge even when there's no text preview to fill the row
+    marginLeft: "auto",
+  },
   preview: {
     width: 400,
   },
@@ -142,7 +146,7 @@ const styles = defineStyles("SingleLineComment", (theme: ThemeType) => ({
   }
 }))
 
-const SingleLineComment = ({treeOptions, comment, nestingLevel, parentCommentId, hideKarma, showDescendentCount, displayTagIcon=false }: {
+const SingleLineComment = ({treeOptions, comment, nestingLevel, parentCommentId, hideKarma, showDescendentCount, displayTagIcon=false, startsHovered=false }: {
   treeOptions: CommentTreeOptions,
   comment: CommentsList,
   nestingLevel: number,
@@ -150,12 +154,26 @@ const SingleLineComment = ({treeOptions, comment, nestingLevel, parentCommentId,
   hideKarma?: boolean,
   showDescendentCount?: boolean,
   displayTagIcon?: boolean,
+  /**
+   * If set, the single line appeared under the mouse cursor (eg because the
+   * comment was just collapsed with its [-] button), so the hover preview is
+   * not shown until the mouse leaves and re-enters.
+   */
+  startsHovered?: boolean,
 }) => {
   const { forumType } = useForumType();
   const classes = useStyles(styles);
-  const {anchorEl, hover, eventHandlers} = useHover();
+  const hoverPreviewSuppressedRef = useRef(startsHovered);
+  const {anchorEl, hover, eventHandlers} = useHover({
+    getIsEnabled: () => !hoverPreviewSuppressedRef.current,
+  });
   
   if (!comment) return null
+
+  const onMouseLeave = (event: React.MouseEvent) => {
+    hoverPreviewSuppressedRef.current = false;
+    eventHandlers.onMouseLeave(event);
+  };
   
   const { enableHoverPreview=true, hideSingleLineMeta, post, singleLinePostTitle, hideParentCommentToggle, deemphasizeCommentsExcludingUserIds } = treeOptions;
 
@@ -171,7 +189,7 @@ const SingleLineComment = ({treeOptions, comment, nestingLevel, parentCommentId,
   const deempphasizeComment = !!deemphasizeCommentsExcludingUserIds && !deemphasizeCommentsExcludingUserIds.has(comment.userId ?? '')
 
   return (
-    <div className={classes.root} {...eventHandlers}>
+    <div className={classes.root} onMouseOver={eventHandlers.onMouseOver} onMouseLeave={onMouseLeave}>
       <ContentStyles
         contentType={comment.answer ? "post" : "comment"}
         className={classNames(
@@ -212,12 +230,14 @@ const SingleLineComment = ({treeOptions, comment, nestingLevel, parentCommentId,
           { comment.promoted && !hideSingleLineMeta && <span className={classes.metaNotice}>Pinned</span>}
           {contentToRender}
         </ContentStyles>}
-        {showDescendentCount && comment.descendentCount>0 && <PostsItemComments
-          small={true}
-          commentCount={comment.descendentCount}
-          unreadComments={false}
-          newPromotedComments={false}
-        />}
+        {showDescendentCount && comment.descendentCount>0 && <span className={classes.descendentCount}>
+          <PostsItemComments
+            small={true}
+            commentCount={comment.descendentCount}
+            unreadComments={false}
+            newPromotedComments={false}
+          />
+        </span>}
       </ContentStyles>
       <LWPopper
         open={displayHoverOver}
@@ -241,6 +261,7 @@ const SingleLineComment = ({treeOptions, comment, nestingLevel, parentCommentId,
                 showEditInContext: false
               }}
               hoverPreview
+              forceUnCollapsed
               noAutoScroll
             />
           </div>

--- a/packages/lesswrong/components/comments/commentTree.ts
+++ b/packages/lesswrong/components/comments/commentTree.ts
@@ -23,16 +23,16 @@ export interface CommentTreeOptions {
   postPage?: boolean,
   
   /**
-   * Whether to show a [-] button in the top-left of each comment. (Note
-   * the distinction between this collapsing mechanism, and single-line
-   * comments; these are separate.)
+   * Whether to show a [-] button in the top-left of each comment, which
+   * collapses the comment to a single line and hides its replies behind a
+   * comment-count icon. (Clicking the single line expands it again.)
    */
   showCollapseButtons?: boolean,
 
   /**
-   * Called when a comment is collapsed or expanded (by clicking the little icon by the author's name)
+   * Called when a comment is collapsed by clicking its [-] button.
    */
-  onToggleCollapsed?: () => void,
+  onCollapse?: () => void,
 
   /**
    * In certain special contexts, the ID of the most recent comment in
@@ -77,12 +77,6 @@ export interface CommentTreeOptions {
    * mode. (Default true).
    */
   enableHoverPreview?: boolean,
-  
-  /**
-   * If passed, a [-] button will be added which shrinks the comment to
-   * single line. Mutually exclusive with showCollapseButtons.
-   */
-  singleLineCollapse?: boolean,
   
   /**
    * If passed, the Reply link will be hidden from the bottom of

--- a/packages/lesswrong/components/quickTakes/LWQuickTakesCollapsedListItem.tsx
+++ b/packages/lesswrong/components/quickTakes/LWQuickTakesCollapsedListItem.tsx
@@ -204,14 +204,11 @@ const LWQuickTakesCollapsedListItem = ({quickTake, setExpanded, linesToDisplay=2
             post: quickTake.post ?? undefined,
             hideParentCommentToggle: true,
             showCollapseButtons: false,
-            onToggleCollapsed: () => setExpanded(true),
           },
           comment: quickTake,
           showCommentTitle: false,
           showParentState,
           toggleShowParent,
-          collapsed: false,
-          toggleCollapse: () => setExpanded(true),
           setShowEdit,
           rightSectionElements: <div className={classes.commenterInfo}>
             {commentersElement}

--- a/packages/lesswrong/components/quickTakes/QuickTakesListItem.tsx
+++ b/packages/lesswrong/components/quickTakes/QuickTakesListItem.tsx
@@ -80,7 +80,7 @@ const QuickTakesListItem = ({quickTake, linesToDisplay=2}: {
           treeOptions={{
             post: quickTake.post ?? undefined,
             showCollapseButtons: isFriendlyUI(),
-            onToggleCollapsed: () => wrappedSetExpanded(!expanded),
+            onCollapse: () => wrappedSetExpanded(false),
           }}
           comment={quickTake}
           loadChildrenSeparately

--- a/packages/lesswrong/components/review/ReviewPostComments.tsx
+++ b/packages/lesswrong/components/review/ReviewPostComments.tsx
@@ -46,14 +46,14 @@ const styles = defineStyles('ReviewPostComments', (theme: ThemeType) => ({
   }
 }))
 
-const ReviewPostComments = ({terms, title, post, singleLine, placeholderCount, hideReviewVoteButtons, singleLineCollapse}: {
+const ReviewPostComments = ({terms, title, post, singleLine, placeholderCount, hideReviewVoteButtons, showCollapseButtons}: {
   terms: CommentsViewTerms,
   title?: string,
   post: PostsList,
   singleLine?: boolean,
   placeholderCount?: number,
   hideReviewVoteButtons?: boolean
-  singleLineCollapse?: boolean
+  showCollapseButtons?: boolean
 }) => {
   const classes = useStyles(styles);
   const { view, limit, ...selectorTerms } = terms;
@@ -99,7 +99,7 @@ const ReviewPostComments = ({terms, title, post, singleLine, placeholderCount, h
             highlightDate: maybeDate(post.lastVisitedAt ?? undefined),
             hideSingleLineMeta: true,
             hideReviewVoteButtons: hideReviewVoteButtons,
-            singleLineCollapse: singleLineCollapse,
+            showCollapseButtons,
             enableHoverPreview: false,
             post: post,
             forceSingleLine: true

--- a/packages/lesswrong/components/review/ReviewVoteTableRow.tsx
+++ b/packages/lesswrong/components/review/ReviewVoteTableRow.tsx
@@ -314,7 +314,7 @@ const ReviewVoteTableRow = ({post, index, dispatch, costTotal, expandedPostId, h
           <ReviewPostComments
             singleLine
             hideReviewVoteButtons
-            singleLineCollapse
+            showCollapseButtons
             placeholderCount={post.reviewCount}
             terms={{
               view: "reviews",

--- a/packages/lesswrong/components/review/SingleLineReviewsList.tsx
+++ b/packages/lesswrong/components/review/SingleLineReviewsList.tsx
@@ -32,7 +32,7 @@ const SingleLineReviewsList = () => {
           <CommentsNode
             treeOptions={{
               condensed: true,
-              singleLineCollapse: true,
+              showCollapseButtons: true,
               hideSingleLineMeta: true,
               singleLinePostTitle: true,
               showPostTitle: true,

--- a/packages/lesswrong/components/shortform/ShortformListItem.tsx
+++ b/packages/lesswrong/components/shortform/ShortformListItem.tsx
@@ -109,7 +109,7 @@ const ShortformListItem = ({comment, hideTag}: {
   const treeOptions = {
     post: comment.post || undefined,
     showCollapseButtons: true,
-    onToggleCollapsed: () => wrappedSetExpanded(!expanded),
+    onCollapse: () => wrappedSetExpanded(false),
   };
   if (expanded) {
     return (

--- a/packages/lesswrong/components/spotlights/SpotlightItem.tsx
+++ b/packages/lesswrong/components/spotlights/SpotlightItem.tsx
@@ -655,7 +655,7 @@ const SpotlightReviewComment = ({id}: {
     <CommentByIdSuspense
       commentId={id}
       treeOptions={{
-        singleLineCollapse: true,
+        showCollapseButtons: true,
         forceSingleLine: true,
         hideSingleLineMeta: true,
       }}


### PR DESCRIPTION
On comments in some contexts (ie post pages), we have a collapse button "[-]" which puts a comment (and its children) into a collapsed state. We also had a related but separate concept, "single-line comments". These looked and worked differently, for basically historical reasons. Merge these two states into one, keeping only the single-line-comment concept and not the collapsed concept.

(One unintuitive consequence to sanity check: comments that are pre-collapsed due to low karma now have a visible indication if they have child comments, which they didn't before.)

<details>
<summary>Prompts Used</summary>
User: On comments in some contexts (ie post pages), we have a collapse button "[-]" which puts a comment (and its children) into a collapsed state. We also have a related but separate concept, "single-line comments". Collapsing hides the comment and its children, and is triggered by this button or by low karma. There are several variants of single-line comments; in some contexts we reduce a comment to single-line, hide its children, and show a child-comment-count icon in that line, while in other contexts those comments are shown (likely also as single-line).

Let's unify these two concepts. We'll eliminate the redundant concept of "collapsed", and the [-] will make it single-line, in the variant where descendent-comments are hidden and shown with a comment-count icon.

Fable 5.1:
> Done. The separate "collapsed" state is gone, and `[-]` now collapses a comment to a single line with its replies hidden behind a reply-count badge. Verified in the browser on a local post page, plus a clean `yarn tsc` and eslint on the changed files. Nothing is committed.
>
> **What changed**
>
> - `CommentsNode` now has a `collapsedToSingleLine` state instead of `collapsed`. It forces single-line rendering regardless of the truncation rules or the user's "no single-line comments" setting, and hides the children section. Clicking the single line clears it, along with the ordinary single-line and truncation state.
> - Deleted comments and comments below the −4 karma threshold start in that state, so they render as a single line (karma, author, date, no excerpt) rather than as a header with hidden body.
> - The reply-count badge in `SingleLineComment` now shows whenever a comment is collapsed this way, not only in the load-children-separately contexts.
> - `CommentsItemMeta` renders one `[-]` button, gated on `showCollapseButtons`, calling a `collapseToSingleLine` callback. The `collapsed`, `toggleCollapse`, and `setSingleLine` props are gone from `CommentsItem`, `CommentsItemMeta`, and `CommentBody`. The draft edit-cancel and edit-success flows use the same callback to return a draft to single-line.
> - `CommentsItem` no longer wraps the body and reply form in `AnimatedCollapse`, and the margin workaround that wrapper needed is removed.
> - The height animation in `CommentsNode` now runs on collapse as well as expand, so `[-]` still animates.
> - In `CommentTreeOptions`, `singleLineCollapse` is removed in favor of `showCollapseButtons`, and `onToggleCollapsed` is renamed to `onCollapse` since it only fires on collapse now. Call sites in the review, spotlight, shortform, and quick-takes components are updated. The unused `karmaCollapseThreshold` prop was removed too.
> - The hover preview inside `SingleLineComment` passes `forceUnCollapsed`, so previewing a deleted or low-karma comment shows the full item rather than another single line.
>
> **Behavior notes worth knowing**
>
> - Users with the "no single-line comments" preference will now see low-karma and manually collapsed comments as single lines. Before, they saw a header with hidden body.
> - Deleted comments no longer show their deletion metadata until expanded.
> - `forceUnCollapsed` keeps its name and meaning: it stops a node from starting collapsed due to karma or deletion.

<hr>

User: Thanks. A few nits:
If a comment is pre-collapsed due to low karma, its text preview is hidden (makes sense), but as a side effect the comment bubble for child comment count isn't right-aligned like it normally would be. The same may also happen for very-short comments. When you collaps a comment, the hover-preview tooltip of the comment appears immediately (since it's already hovered). Let's make it not appear until the mouse leaves and reenteres.

Fable 5.1:
> Both nits are fixed and verified in the browser. Type check and eslint are clean.
>
> **Count badge alignment.** The badge in `SingleLineComment` is now wrapped in a span with `margin-left: auto`, so it sits at the right edge whether or not a text preview fills the row. Checked on a one-sentence comment with two replies: the "2" badge sits flush right.
>
> **Hover preview after collapsing.** `CommentsNode` records when a collapse came from the `[-]` button and passes a `startsHovered` prop to `SingleLineComment`. That component seeds a ref from it and passes a `getIsEnabled` check to `useHover`, so mouseover events are ignored until the next mouseleave clears the ref. Comments that start collapsed from low karma are unaffected. Checked with real mouse movement: after clicking `[-]` and nudging the cursor within the line, no preview appeared. After moving out and back in, the preview appeared as usual.
>
> Nothing is committed.
</details>

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1218419112004524) by [Unito](https://www.unito.io)
