### PR TITLE
Fix an issue that would cause Load More to fail on the spotlights list on /recommendations

### DIFF
--- a/packages/lesswrong/components/hooks/useQueryWithLoadMore.ts
+++ b/packages/lesswrong/components/hooks/useQueryWithLoadMore.ts
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { type OperationVariables } from "@apollo/client";
 import { useQuery } from "@/lib/crud/useQuery";
 import type { TypedDocumentNode } from "@graphql-typed-document-node/core";
@@ -67,61 +67,76 @@ export function useQueryWithLoadMore<
     ...remainingOptions
   } = options;
 
-  const { limit, selector, ...remainingVariables } = variables ?? {};
+  const { limit, selector } = variables;
   const initialLimit = (selector && 'limit' in selector && typeof selector.limit === 'number')
     ? selector.limit
     : (limit ?? 10);
+
+  // Keep the last successful limit separately so a failed request can be retried.
+  const [paginationState, setPaginationState] = useState({
+    selector, limit: initialLimit, loadedLimit: initialLimit,
+  });
+  const enableTotal = variables.enableTotal;
+
+  let pagination = paginationState;
+  const selectorChanged = !isEqual(selector, pagination.selector);
+  if (selectorChanged) {
+    pagination = { selector, limit: initialLimit, loadedLimit: initialLimit };
+    setPaginationState(pagination);
+  }
 
   const queryOutput = useQuery(query, {
     ...remainingOptions,
     ssr,
     notifyOnNetworkStatusChange,
-    variables: {
-      ...({ selector, ...remainingVariables }) as TVariables,
-      limit: initialLimit,
-    }
+    variables: { ...variables, limit: pagination.limit },
   });
-  const { data, loading, fetchMore } = queryOutput;
+  const { loading, refetch } = queryOutput;
+  const previousData = useRef(queryOutput.data);
+  if (queryOutput.data || selectorChanged) {
+    previousData.current = queryOutput.data;
+  }
+  // Keep the existing list visible while refetch changes the limit, including
+  // when that list came from SSR injection rather than an Apollo query result.
+  const data = queryOutput.data ?? (
+    pagination.limit !== pagination.loadedLimit
+      ? previousData.current
+      : undefined
+  );
 
   const queryName = query.definitions.find(d => d.kind === Kind.OPERATION_DEFINITION)?.selectionSet?.selections?.find(s => s.kind === Kind.FIELD)?.name?.value;
-  const queryResult = data?.[queryName as keyof typeof data];
-
-  const [limitState, setLimitState] = useState(initialLimit);
-  const resetTrigger = variables.selector;
-  const [lastResetTrigger, setLastResetTrigger] = useState(resetTrigger);
-  const enableTotal = variables.enableTotal;
-
-  let effectiveLimit = limitState;
-  if (!isEqual(resetTrigger, lastResetTrigger)) {
-    setLastResetTrigger(resetTrigger);
-    setLimitState(initialLimit);
-    effectiveLimit = initialLimit;
-  }
+  const queryResult = queryName ? data?.[queryName] : undefined;
 
   const count = queryResult?.results?.length ?? 0;
   const totalCount = queryResult?.totalCount ?? undefined;
 
-  const showLoadMore = alwaysShowLoadMore || (enableTotal ? (count < (totalCount ?? 0)) : (count >= effectiveLimit));
+  const showLoadMore = alwaysShowLoadMore || (enableTotal ? (count < (totalCount ?? 0)) : (count >= pagination.loadedLimit));
 
   const loadMore = useStabilizedCallbackAsync<void>(async () => {
-    const newLimit: number = effectiveLimit + itemsPerPage;
+    const newLimit: number = pagination.loadedLimit + itemsPerPage;
+    const nextPagination = { ...pagination, limit: newLimit };
+    setPaginationState(nextPagination);
     
-    const result = await fetchMore({
-      variables: { limit: newLimit } as AnyBecauseHard,
-      updateQuery: (prev, {fetchMoreResult}) => fetchMoreResult ?? prev,
-    });
-    setLimitState(newLimit);
+    // We fetch the whole expanded list, so advance the watched query's variables.
+    // fetchMore would write the expanded list under the original limit, where a
+    // late initial response (including one started during hydration) can replace it.
+    await refetch({ ...variables, limit: newLimit });
+    // A response for an old selector must not advance the current selector's limit.
+    setPaginationState(current => current === nextPagination
+      ? { ...current, loadedLimit: newLimit }
+      : current);
   });
 
   return {
     ...queryOutput,
+    data,
     loadMoreProps: {
       loadMore,
       count,
       totalCount,
       loading,
       hidden: !showLoadMore,
-      limit: effectiveLimit,
+      limit: pagination.loadedLimit,
       showLoadMore,
     },
   };


### PR DESCRIPTION
<details>
<summary>Prompts Used</summary>
User: On /recommendations, there's a Spotlight Items list with a Load More. Sometimes, clicking on the Load More fails to expand the list: The Load More button disappears, a streamGraphql request is made and gets back a list with +50 spotlights, but the UI doesn't update to show them. No error messages appear in any of the obvious places.

GPT-6 Astra:
> Fixed a reproducible race in [useQueryWithLoadMore.ts](/Users/jbabcock/repositories/Lesserwrong/LessWrong2/packages/lesswrong/components/hooks/useQueryWithLoadMore.ts): a late one-item response could overwrite the 51-item list after the pagination limit advanced, hiding Load More.
>
> Pagination now advances the watched query’s limit, preserves visible items during loading, and supports retries.
>
> Six regression tests, typechecking, and targeted lint pass. Code generation completed.
</details>

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201302964208280/1218419289393907) by [Unito](https://www.unito.io)
